### PR TITLE
WIP Anthropic handler

### DIFF
--- a/lucidicai/providers/anthropic_handler.py
+++ b/lucidicai/providers/anthropic_handler.py
@@ -29,10 +29,10 @@ class AnthropicHandler(BaseProvider):
                 for piece in content:
                     if piece.get("type") == "text":
                         descriptions.append(piece.get("text", ""))
-                    elif piece.get("type") == "image_url":
-                        url = piece.get("image_url", {}).get("url")
-                        if url:
-                            screenshots.append(url)
+                    elif piece.get("type") == "image":
+                        img = piece.get("image", {}).get("data")
+                        if img:
+                            screenshots.append(img)
             elif isinstance(content, str):
                 descriptions.append(content)
 


### PR DESCRIPTION
Anthropic's messages API is instance based, so the current method of patching an instance's create function does not work since the user's instance of the client will always use the original version.

To solve this, we probably have to reroute every new instance by the user. There are definitely ways to do this, but I haven't fully explored them yet.