### PR TITLE
LUC-431: gitignore .claude/ (Claude Code workspace)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,6 @@ cython_debug/
 .pypirc
 
 CLAUDE.md
+.claude/*
 
 otel_test/*


### PR DESCRIPTION
Adds `.claude/*` to `.gitignore` so per-developer Claude Code workspaces (skills, settings, transcripts) don't get committed to this public repo.

CLAUDE.md is already in `.gitignore` and stays out for now — it's currently an internal-facing doc. A user-facing CLAUDE.md aimed at end users of the SDK can ship later if useful.