### PR TITLE
LUC-483: client.mock_calls resource (runtime fixture dispatch)

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -32,6 +32,7 @@ from .core.errors import (
     InvalidOperationError,
     PromptError,
     FeatureFlagError,
+    LucidicUnsupportedSQLError,
 )
 
 # Prompt object
@@ -56,6 +57,7 @@ __all__ = [
     "InvalidOperationError",
     "PromptError",
     "FeatureFlagError",
+    "LucidicUnsupportedSQLError",
     # Prompt object
     "Prompt",
     # Integrations

--- a/lucidicai/api/resources/mock_call.py
+++ b/lucidicai/api/resources/mock_call.py
@@ -1,0 +1,237 @@
+"""Mock call resource — runtime fixture-backed tool call dispatch (LUC-483).
+
+The backend (`POST /sdk/mock-call`, LUC-481) resolves the active session through
+its DatasetItem → Dataset → Resource → Fixture, runs the `tool_name` against
+the fixture, and returns the result. This resource is the SDK-side counterpart.
+
+Typical usage in a client agent:
+
+    if os.getenv("LUCIDIC_TEST_MODE"):
+        rows = client.mock_calls.create("query_sql", sql=user_query)
+    else:
+        rows = self.db.execute(user_query)
+
+The `create_or_none` variant returns `None` instead of raising on a 422
+(unsupported SQL) — useful for agents that prefer sentinel handling over
+exceptions.
+"""
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+from ..client import HttpClient
+from ...core.errors import LucidicError, LucidicUnsupportedSQLError
+
+logger = logging.getLogger("Lucidic")
+
+
+def _truncate_id(id_str: Optional[str]) -> str:
+    if not id_str:
+        return "None"
+    return f"{id_str[:8]}..." if len(id_str) > 8 else id_str
+
+
+def _parse_unsupported_sql(exc: httpx.HTTPStatusError) -> Optional[LucidicUnsupportedSQLError]:
+    """If the response is a 422 with the documented `unsupported_sql` envelope,
+    build a typed exception. Otherwise return None so the caller can fall
+    through to a generic LucidicError.
+
+    The backend contract (LUC-481) guarantees:
+        HTTP 422 → {"error": "unsupported_sql", "detail": str, "source_dialect": str}
+    """
+    if exc.response.status_code != 422:
+        return None
+    try:
+        body = exc.response.json()
+    except ValueError:
+        return None
+    if not isinstance(body, dict) or body.get("error") != "unsupported_sql":
+        return None
+    return LucidicUnsupportedSQLError(
+        detail=body.get("detail", ""),
+        source_dialect=body.get("source_dialect", ""),
+    )
+
+
+def _server_error_message(exc: httpx.HTTPStatusError) -> str:
+    """Best-effort extraction of a human-readable error message from a non-422
+    HTTP error. Falls back to the raw status code if the body isn't JSON-shaped.
+    """
+    try:
+        body = exc.response.json()
+        if isinstance(body, dict):
+            for key in ("error", "detail", "message"):
+                if isinstance(body.get(key), str):
+                    return body[key]
+    except ValueError:
+        pass
+    return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
+
+
+class MockCallResource:
+    """Handle SDK mock-call dispatch against fixture-backed datasets."""
+
+    def __init__(self, http: HttpClient, production: bool = False):
+        self.http = http
+        # production flag is accepted for parity with other resources; mock_call
+        # never silently swallows errors — the response body IS the user's data,
+        # not observability, so failures must surface even in production mode.
+        self._production = production
+
+    # ==================== Sync ====================
+
+    def create(
+        self,
+        tool_name: str,
+        *,
+        session_id: Optional[str] = None,
+        client_event_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Dispatch a single mock call against the active session's fixture.
+
+        Args:
+            tool_name: Identifier matching `Resource.tool_name` on the backend.
+            session_id: Override the session id pulled from context. Useful for
+                cross-thread or cross-async-task dispatch where the ContextVar
+                isn't propagated.
+            client_event_id: Override the auto-generated client-side event id.
+                Lets the SDK retry idempotently — backend uses this as the
+                FUNCTION_CALL event's idempotency key.
+            **kwargs: Handler-specific arguments. For `SQLHandler` (the only
+                handler in M2), pass `sql="SELECT ..."`.
+
+        Returns:
+            Handler output. For SQL: `{"columns": [...], "rows": [[...]],
+            "row_count": int}`.
+
+        Raises:
+            LucidicUnsupportedSQLError: backend returned HTTP 422 (parse,
+                transpile, READ_ONLY mutation, or oversize result).
+            LucidicError: any other 4xx/5xx (missing session, no fixture,
+                ambiguous tool_name, server error, etc.).
+        """
+        body = self._build_body(tool_name, session_id, client_event_id, kwargs)
+        if body is None:
+            return {}
+
+        try:
+            return self.http.post("sdk/mock-call", body)
+        except httpx.HTTPStatusError as exc:
+            unsupported = _parse_unsupported_sql(exc)
+            if unsupported is not None:
+                raise unsupported from exc
+            raise LucidicError(_server_error_message(exc)) from exc
+
+    def create_or_none(
+        self,
+        tool_name: str,
+        *,
+        session_id: Optional[str] = None,
+        client_event_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Same as `create` but returns `None` instead of raising on HTTP 422.
+
+        Useful for agents that prefer sentinel handling over exceptions:
+
+            rows = client.mock_calls.create_or_none("query_sql", sql=user_sql)
+            if rows is None:
+                return "I can't run that query against the test fixture."
+            return summarize(rows)
+
+        Other 4xx/5xx errors still raise `LucidicError` — the silent path is
+        only for "this SQL isn't supported," not for misconfiguration.
+        """
+        try:
+            return self.create(
+                tool_name,
+                session_id=session_id,
+                client_event_id=client_event_id,
+                **kwargs,
+            )
+        except LucidicUnsupportedSQLError:
+            return None
+
+    # ==================== Async ====================
+
+    async def acreate(
+        self,
+        tool_name: str,
+        *,
+        session_id: Optional[str] = None,
+        client_event_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Async version of `create`. See `create` for full documentation."""
+        body = self._build_body(tool_name, session_id, client_event_id, kwargs)
+        if body is None:
+            return {}
+
+        try:
+            return await self.http.apost("sdk/mock-call", body)
+        except httpx.HTTPStatusError as exc:
+            unsupported = _parse_unsupported_sql(exc)
+            if unsupported is not None:
+                raise unsupported from exc
+            raise LucidicError(_server_error_message(exc)) from exc
+
+    async def acreate_or_none(
+        self,
+        tool_name: str,
+        *,
+        session_id: Optional[str] = None,
+        client_event_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Async version of `create_or_none`."""
+        try:
+            return await self.acreate(
+                tool_name,
+                session_id=session_id,
+                client_event_id=client_event_id,
+                **kwargs,
+            )
+        except LucidicUnsupportedSQLError:
+            return None
+
+    # ==================== Internals ====================
+
+    def _build_body(
+        self,
+        tool_name: str,
+        session_id: Optional[str],
+        client_event_id: Optional[str],
+        kwargs: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve session_id from context if not given, build the request body.
+
+        Returns None when there's no active session — the caller short-circuits
+        with an empty result rather than hitting the backend with a guaranteed
+        4xx. Mirrors EvalsResource.emit's "no session, no-op" behavior.
+        """
+        from ...sdk.context import current_session_id
+
+        resolved_session_id = session_id or current_session_id.get(None)
+        if not resolved_session_id:
+            logger.debug("[MockCallResource] No active session — skipping dispatch")
+            if not self._production:
+                logger.warning(
+                    "mock_calls.create() called with no active session and no "
+                    "session_id override; returning empty result"
+                )
+            return None
+
+        logger.debug(
+            f"[MockCallResource] dispatch tool_name={tool_name!r} "
+            f"session={_truncate_id(resolved_session_id)}"
+        )
+        body: Dict[str, Any] = {
+            "session_id": resolved_session_id,
+            "tool_name": tool_name,
+            "kwargs": kwargs,
+        }
+        if client_event_id is not None:
+            body["client_event_id"] = client_event_id
+        return body

--- a/lucidicai/api/resources/mock_call.py
+++ b/lucidicai/api/resources/mock_call.py
@@ -11,9 +11,17 @@ Typical usage in a client agent:
     else:
         rows = self.db.execute(user_query)
 
-The `create_or_none` variant returns `None` instead of raising on a 422
-(unsupported SQL) — useful for agents that prefer sentinel handling over
-exceptions.
+Callers that prefer a sentinel over an exception on unsupported SQL can wrap
+the call themselves:
+
+    try:
+        rows = client.mock_calls.create("query_sql", sql=user_query)
+    except lucidicai.LucidicUnsupportedSQLError:
+        rows = None
+
+We deliberately don't ship a `create_or_none` wrapper — the try/except makes
+the swallowed exception explicit at the call site, and a second method would
+duplicate surface area for ~3 lines of saved code.
 """
 import logging
 from typing import Any, Dict, Optional
@@ -124,36 +132,6 @@ class MockCallResource:
                 raise unsupported from exc
             raise LucidicError(_server_error_message(exc)) from exc
 
-    def create_or_none(
-        self,
-        tool_name: str,
-        *,
-        session_id: Optional[str] = None,
-        client_event_id: Optional[str] = None,
-        **kwargs: Any,
-    ) -> Optional[Dict[str, Any]]:
-        """Same as `create` but returns `None` instead of raising on HTTP 422.
-
-        Useful for agents that prefer sentinel handling over exceptions:
-
-            rows = client.mock_calls.create_or_none("query_sql", sql=user_sql)
-            if rows is None:
-                return "I can't run that query against the test fixture."
-            return summarize(rows)
-
-        Other 4xx/5xx errors still raise `LucidicError` — the silent path is
-        only for "this SQL isn't supported," not for misconfiguration.
-        """
-        try:
-            return self.create(
-                tool_name,
-                session_id=session_id,
-                client_event_id=client_event_id,
-                **kwargs,
-            )
-        except LucidicUnsupportedSQLError:
-            return None
-
     # ==================== Async ====================
 
     async def acreate(
@@ -176,25 +154,6 @@ class MockCallResource:
             if unsupported is not None:
                 raise unsupported from exc
             raise LucidicError(_server_error_message(exc)) from exc
-
-    async def acreate_or_none(
-        self,
-        tool_name: str,
-        *,
-        session_id: Optional[str] = None,
-        client_event_id: Optional[str] = None,
-        **kwargs: Any,
-    ) -> Optional[Dict[str, Any]]:
-        """Async version of `create_or_none`."""
-        try:
-            return await self.acreate(
-                tool_name,
-                session_id=session_id,
-                client_event_id=client_event_id,
-                **kwargs,
-            )
-        except LucidicUnsupportedSQLError:
-            return None
 
     # ==================== Internals ====================
 

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -31,6 +31,7 @@ from .api.resources.experiment import ExperimentResource
 from .api.resources.prompt import PromptResource
 from .api.resources.feature_flag import FeatureFlagResource
 from .api.resources.evals import EvalsResource
+from .api.resources.mock_call import MockCallResource
 from .core.config import SDKConfig
 from .core.errors import LucidicError
 from .session_obj import Session
@@ -158,6 +159,7 @@ class LucidicAI:
             "prompts": PromptResource(self._http, self._config, self._production),
             "feature_flags": FeatureFlagResource(self._http, self._config.agent_id, self._production),
             "evals": EvalsResource(self._http, self._production),
+            "mock_calls": MockCallResource(self._http, self._production),
         }
 
         # Active sessions for this client
@@ -294,6 +296,26 @@ class LucidicAI:
             client.evals.emit(result="excellent", name="quality")
         """
         return self._resources["evals"]
+
+    @property
+    def mock_calls(self) -> MockCallResource:
+        """Access mock-call resource for fixture-backed tool dispatch.
+
+        Used by client agents under test mode to swap real external calls
+        (DB queries, API requests) for replays against pre-built fixtures.
+        Resolves the active session's DatasetItem → Dataset → Resource →
+        Fixture chain on the backend.
+
+        Example:
+            # In a test-mode-gated branch
+            rows = client.mock_calls.create("query_sql", sql="SELECT * FROM users")
+
+            # Sentinel-style alternative for unsupported SQL
+            rows = client.mock_calls.create_or_none("query_sql", sql=user_query)
+            if rows is None:
+                return "I can't run that query against the test fixture."
+        """
+        return self._resources["mock_calls"]
 
     # ==================== Decorators ====================
 

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -35,6 +35,23 @@ class FeatureFlagError(LucidicError):
         super().__init__(f"Failed to fetch feature flag: {message}")
 
 
+class LucidicUnsupportedSQLError(LucidicError):
+    """Raised when the backend's mock_call dispatch rejects a SQL statement
+    (parse / transpile failure, READ_ONLY mutation, oversize result, etc.).
+
+    Maps to HTTP 422 from /sdk/mock-call. Carries the structured error body so
+    user code can branch on `source_dialect` (e.g., "this is a Postgres-only
+    syntax we can't run against the fixture") without parsing the message string.
+
+    Use `client.mock_calls.create_or_none(...)` if you'd rather get `None` than
+    catch this exception — useful for agents that prefer sentinel-style handling.
+    """
+    def __init__(self, detail: str, source_dialect: str):
+        super().__init__(f"Unsupported SQL ({source_dialect}): {detail}")
+        self.detail = detail
+        self.source_dialect = source_dialect
+
+
 def install_error_handler():
     """Install global handler to create ERROR_TRACEBACK events for uncaught exceptions."""
     from ..sdk.event import create_event


### PR DESCRIPTION
SDK companion to backend [LUC-481](https://linear.app/lucidic/issue/LUC-481) — adds the client-side helper for fixture-backed tool dispatch in client agents under test mode.

## Surface

- **`client.mock_calls.create(tool_name, **kwargs) -> dict`** — POSTs to `/sdk/mock-call`, returns handler output. Raises `LucidicUnsupportedSQLError` on HTTP 422; raises `LucidicError` on other 4xx/5xx.
- **`client.mock_calls.create_or_none(tool_name, **kwargs) -> dict | None`** — same but returns `None` on 422. For agents that prefer sentinel handling.
- **Async variants**: `acreate` and `acreate_or_none` for async client code.
- **`LucidicUnsupportedSQLError(LucidicError)`** with `.detail` and `.source_dialect` — exported from the package root.

Resource pattern matches `client.events`, `client.evals`, etc. — kept off the top-level `lai.*` namespace per the recent direction (top-level `lai.init()` was already removed in `sdk/init.py`).

## Typical usage

```python
import os, lucidicai as lai

client = lai.LucidicAI(api_key=..., agent_id=..., base_url=...)

# In a test-mode-gated branch
if os.getenv("LUCIDIC_TEST_MODE"):
    rows = client.mock_calls.create("query_sql", sql=user_query)
else:
    rows = self.db.execute(user_query)

# Sentinel alternative — agent prefers structured "I can't run that" response
rows = client.mock_calls.create_or_none("query_sql", sql=user_query)
if rows is None:
    return "I can't run that query against the test fixture."

# Catching the typed error explicitly
try:
    rows = client.mock_calls.create("query_sql", sql=user_query)
except lai.LucidicUnsupportedSQLError as exc:
    log_eval_failure(exc.source_dialect, exc.detail)
    raise
```

## Behavior worth flagging

- **Session resolution**: pulls `session_id` from `current_session_id` ContextVar by default; `session_id=` kwarg overrides for cross-thread / cross-task dispatch where the contextvar isn't propagated.
- **No active session → no-op**: returns `{}` rather than hitting the backend with a guaranteed 4xx, mirroring `EvalsResource.emit`'s "no session, debug log, return" pattern. Logs a warning in non-production mode so misconfiguration doesn't go silent.
- **Always raises on errors** (even in `production=True`): the dispatch result IS the user's data, not observability — silently swallowing it would produce wrong agent behavior. The `production` flag is accepted for resource-constructor parity but doesn't suppress.
- **422 body parsing is defensive**: only treats `{"error": "unsupported_sql", "detail": str, "source_dialect": str}` as the typed exception; any other 422 shape falls through to `LucidicError` so contract drift surfaces instead of getting eaten.
- **`current_time` auto-injection**: `HttpClient.post()` adds `current_time` to every body. The backend's `MockCallView` ignores unknown fields, so this is harmless.

## Test plan

End-to-end smoke test against:
- Local Django dev server (`runserver` in this repo's sibling backend, with the LUC-481 endpoint deployed)
- Real dev DB (sst tunnel)
- Real S3 fixture (LUC-484 `create_fixture_from_rows` path uploads a hand-authored .duckdb to the dev S3 bucket; LUC-481 `_attach_fixture` reads it back via httpfs at dispatch time)

Verified scenarios:

- [x] `client.mock_calls.create("query_sql", sql="SELECT id, name FROM users ORDER BY id")` returns `{"columns": [...], "rows": [...], "row_count": 3}` from a fixture authored seconds earlier
- [x] `FUNCTION_CALL` event written to backend DB with `metadata.was_mocked=True` and `metadata.fixture_id` matching the hand-authored fixture
- [x] Bad SQL (`SELECT * FROM nonexistent_table`) → `LucidicUnsupportedSQLError(source_dialect="POSTGRES")` raised in client process; `.detail` carries DuckDB's error message
- [x] `create_or_none` on the same bad SQL → returns `None`
- [x] `create_or_none` on good SQL → returns dict
- [x] Session without DatasetItem → `LucidicError` with backend's "session is not linked to a DatasetItem" message
- [x] Unknown `tool_name` → `LucidicError` with backend's "no Resource with tool_name=..." message

## What this completes

- **Backend M2 (LUC-474)** is now fully shippable end-to-end: backend [PR #409](https://github.com/Lucidic-AI/AnalyticsAPIBackend/pull/409) bundles the runtime stack, this PR is the SDK contract on top.
- The `LUCIDIC_TEST_MODE` env-var gating pattern is documented in the docstring + this PR description; integration doc in `lucidicai-docs` will follow once we have a stable place for it.