### PR TITLE
LUC-608: [SDK 3/3] client.tools namespace + session-init wiring + first-session sync

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -49,6 +49,9 @@ from .core.errors import (
 # Prompt object
 from .api.resources.prompt import Prompt
 
+# Tool dispatch (v2 tool-backed)
+from .sdk.tools import mockable
+
 # Integrations
 from .integrations.livekit import setup_livekit
 
@@ -82,6 +85,8 @@ __all__ = [
     "LucidicUnsupportedSQLError",
     # Prompt object
     "Prompt",
+    # Tool dispatch (v2 tool-backed)
+    "mockable",
     # Integrations
     "setup_livekit",
     # Version

--- a/lucidicai/api/resources/agent_tools_sync.py
+++ b/lucidicai/api/resources/agent_tools_sync.py
@@ -1,0 +1,101 @@
+"""Agent-tools-sync resource — ``POST /sdk/agent-tools/sync``.
+
+Sister of ``MockCallResource``. Consumed by ``ToolsResource.sync()``
+(LUC-608) to push the captured tool registry to the backend so the
+dashboard's Tools tab (LUC-586) and the ``mock_call`` dispatch
+(LUC-584) have the latest source_hash + signature + docstring per tool.
+
+Backend contract (``api/views/sdk_agent_tools.py``, frozen):
+
+- Request body: ``{agent_id, tools: [{name, signature{params, return_type},
+  docstring, return_shape, source_hash}, ...]}``
+- 200: ``{synced: true, stats: {...}}``
+- 422: ``{errors: {...}}`` when Tool.clean rejects a payload (non-identifier
+  name, malformed source_hash, signature shape mismatch, etc.). The
+  service rolls back the whole batch — partial syncs aren't a thing.
+- 503: ``{error: str}`` when the per-agent sync lock can't be acquired
+  within the backend's timeout. SDK should back off + retry.
+"""
+import logging
+from typing import Any, Dict, List
+
+import httpx
+
+from ..client import HttpClient
+from ...core.errors import LucidicError
+
+logger = logging.getLogger("Lucidic")
+
+
+class SyncAgentToolsResource:
+    """Thin wrapper over ``POST /sdk/agent-tools/sync``.
+
+    Constructed once per ``LucidicAI`` (held by ``ToolsResource``).
+    Doesn't know about ``ToolSurface`` — caller (``ToolsResource.sync``)
+    converts the registry into the wire shape before calling here. Keeps
+    this module HTTP-only.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def sync(
+        self,
+        *,
+        agent_id: str,
+        tools: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """POST the tool catalog and return the backend's stats.
+
+        Returns the parsed body on 200 — typically
+        ``{"synced": True, "stats": {"created": int, "updated": int,
+        "drift_count": int, ...}}`` (exact shape is informational; the
+        SDK only checks synced=True).
+
+        Raises ``LucidicError`` on any non-2xx. The validation-failure
+        path (422) carries a structured error body in
+        ``exc.response.json()["errors"]`` — surfaced inline in the
+        exception message so callers see the bad payload field without
+        manual parsing.
+        """
+        body = {"agent_id": agent_id, "tools": tools}
+        logger.debug(
+            "[SyncAgentToolsResource] syncing %d tool(s) for agent %s",
+            len(tools), agent_id[:8] + "...",
+        )
+        try:
+            return self.http.post("sdk/agent-tools/sync", body)
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_sync_error(exc)) from exc
+
+    async def async_sync(
+        self,
+        *,
+        agent_id: str,
+        tools: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Async sibling of ``sync``."""
+        body = {"agent_id": agent_id, "tools": tools}
+        try:
+            return await self.http.apost("sdk/agent-tools/sync", body)
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_sync_error(exc)) from exc
+
+
+def _format_sync_error(exc: httpx.HTTPStatusError) -> str:
+    """Best-effort human-readable error from a non-2xx /sdk/agent-tools/sync.
+
+    422 carries ``{"errors": {<field>: [...messages]}}`` from
+    Tool.clean; 503 carries ``{"error": <str>}``; other shapes fall
+    back to status + raw body.
+    """
+    try:
+        body = exc.response.json()
+    except ValueError:
+        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
+    if isinstance(body, dict):
+        if "errors" in body:
+            return f"HTTP {exc.response.status_code} validation: {body['errors']}"
+        if "error" in body:
+            return f"HTTP {exc.response.status_code}: {body['error']}"
+    return f"HTTP {exc.response.status_code}: {body!r}"

--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -158,6 +158,15 @@ class SessionResource:
             )
             shutdown_manager.register_session(real_session_id, state)
 
+        # LUC-608: when the user passes datasetitem_id they intend tool-backed
+        # dispatch. Init per-session fixture state + bind MockContext so
+        # subsequent @mockable calls in this session route through the backend.
+        # ToolsResource._init_session NEVER raises — session creation must not
+        # be blocked by tool-init failures, and the session works as normal
+        # observability without it.
+        if datasetitem_id and self._client._has_tools_resource():
+            self._client.tools._init_session(real_session_id)
+
         logger.debug(f"[SessionResource] Created session {real_session_id[:8]}...")
         return session
 
@@ -244,6 +253,10 @@ class SessionResource:
                 auto_end=auto_end,
             )
             shutdown_manager.register_session(real_session_id, state)
+
+        # LUC-608: see create() for full rationale. Async sibling.
+        if datasetitem_id and self._client._has_tools_resource():
+            await self._client.tools._ainit_session(real_session_id)
 
         logger.debug(f"[SessionResource] Created async session {real_session_id[:8]}...")
         return session

--- a/lucidicai/api/resources/session_init_fixtures.py
+++ b/lucidicai/api/resources/session_init_fixtures.py
@@ -1,0 +1,80 @@
+"""Session-init-fixtures resource — ``POST /sdk/session-init-fixtures``.
+
+Backend prerequisite for any subsequent ``mock_call`` against a
+tool-backed session: materializes the per-session DuckDB file (LUC-574)
+and writes ``Session.tool_version_snapshot`` (LUC-585). Without this
+the mock_call view returns 400 ``session_not_initialized``.
+
+The backend is gracefully tolerant of non-tool-backed sessions:
+returns ``{"initialized": False, "reason": "..."}`` when the session
+has no DatasetItem. The SDK reads ``initialized`` to decide whether to
+establish a ``MockContext`` for the session — see
+``sdk/tools/resource.py::ToolsResource._init_session``.
+
+Backend contract (``api/views/sdk_session_fixtures.py``):
+
+- Request body: ``{session_id}``
+- 200: ``{initialized: bool, reason?: str, fixture_ids: [...],
+  tools_snapshotted: [...], already_initialized: bool}``
+- 400: ``{error: <str>}`` for malformed input or session lookup failure
+- 404: ``{error: "Specified session not found"}``
+- 503: ``{error: <str>}`` couldn't acquire init lock — retry with backoff
+"""
+import logging
+from typing import Any, Dict
+
+import httpx
+
+from ..client import HttpClient
+from ...core.errors import LucidicError
+
+logger = logging.getLogger("Lucidic")
+
+
+class SessionInitFixturesResource:
+    """Thin wrapper over ``POST /sdk/session-init-fixtures``."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def init(self, session_id: str) -> Dict[str, Any]:
+        """Initialize per-session fixture state + tool version snapshot.
+
+        Returns the parsed body. Caller inspects ``initialized``:
+        True → session is tool-backed and ready for mock_call; False →
+        no-op (session has no DatasetItem or no Resources/tools).
+
+        Raises ``LucidicError`` on 4xx/5xx with the backend's error
+        string. The session_not_found path (404) is a real bug — the
+        session_id was wrong or already finished — but we surface it
+        as a plain ``LucidicError`` since the caller in
+        ``SessionResource.create()`` already swallows + warns.
+        """
+        body = {"session_id": session_id}
+        logger.debug(
+            "[SessionInitFixturesResource] init session %s",
+            session_id[:8] + "..." if len(session_id) > 8 else session_id,
+        )
+        try:
+            return self.http.post("sdk/session-init-fixtures", body)
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_init_error(exc)) from exc
+
+    async def ainit(self, session_id: str) -> Dict[str, Any]:
+        """Async sibling of ``init``."""
+        body = {"session_id": session_id}
+        try:
+            return await self.http.apost("sdk/session-init-fixtures", body)
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_init_error(exc)) from exc
+
+
+def _format_init_error(exc: httpx.HTTPStatusError) -> str:
+    """Best-effort human-readable error from a non-2xx response."""
+    try:
+        body = exc.response.json()
+    except ValueError:
+        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
+    if isinstance(body, dict) and "error" in body:
+        return f"HTTP {exc.response.status_code}: {body['error']}"
+    return f"HTTP {exc.response.status_code}: {body!r}"

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -32,6 +32,7 @@ from .api.resources.prompt import PromptResource
 from .api.resources.feature_flag import FeatureFlagResource
 from .api.resources.evals import EvalsResource
 from .api.resources.mock_call import MockCallResource
+from .sdk.tools.resource import ToolsResource
 from .core.config import SDKConfig
 from .core.errors import LucidicError
 from .session_obj import Session
@@ -162,6 +163,23 @@ class LucidicAI:
             "mock_calls": MockCallResource(self._http, self._production),
         }
 
+        # LUC-608: client.tools — namespace for @mockable + adapter
+        # registration. ToolsResource is constructed BEFORE the buffer
+        # is drained so the client.tools property resolves correctly.
+        self._resources["tools"] = ToolsResource(client=self)
+
+        # Drain any @mockable decorations that ran before this client
+        # existed (the typical "decorate at module import, instantiate
+        # client in main()" pattern). Multi-client edge case: whichever
+        # client constructs first claims the buffer.
+        from .sdk.tools.registry import drain_buffer_into
+        drained = drain_buffer_into(self)
+        if drained:
+            logger.debug(
+                f"[LucidicAI] drained {drained} pre-init @mockable decoration(s) "
+                f"into client.tools registry"
+            )
+
         # Active sessions for this client
         self._sessions: Dict[str, Session] = {}
         self._session_lock = threading.Lock()
@@ -216,6 +234,25 @@ class LucidicAI:
     def is_valid(self) -> bool:
         """Check if the client is properly configured."""
         return self._valid
+
+    @property
+    def tools(self) -> ToolsResource:
+        """Access the client's tool registry + mock dispatch surface (LUC-608).
+
+        ``@client.tools.mockable`` decorates a function; ``client.tools.sync()``
+        flushes the registry to the backend. See ``ToolsResource`` for the
+        full API.
+        """
+        return self._resources["tools"]
+
+    def _has_tools_resource(self) -> bool:
+        """True when ``self.tools`` is wired up.
+
+        ``SessionResource`` uses this to gate the auto-call to
+        ``ToolsResource._init_session`` — production-mode clients that
+        fail validation skip ``_resources`` setup entirely.
+        """
+        return "tools" in self._resources
 
     @property
     def experiments(self) -> ExperimentResource:

--- a/lucidicai/sdk/tools/__init__.py
+++ b/lucidicai/sdk/tools/__init__.py
@@ -1,23 +1,34 @@
 """SDK tool registry + ``@mockable`` decorator for v2 tool-backed dispatch.
 
-Public surface exported here:
+Public surface (consumed by user code and adapter modules):
 
-- ``ToolSurface`` — dataclass capturing one tool's signature/docstring/hash.
-- ``register_tool`` — push a captured ``ToolSurface`` into the active client's
-  registry (or buffer it when no client is alive yet).
-- ``snapshot_registry`` — read the current set of registered ``ToolSurface``s,
-  used by ``client.tools.sync()`` (LUC-577c) to build the request body for
-  ``POST /sdk/agent-tools/sync``.
-- ``mockable`` — decorator that captures a function's surface at decoration
-  time and (in this ticket) returns a fast-path wrapper that runs the
-  function unchanged. The dispatch-intercept layer is wired in LUC-577c.
-- ``drain_buffer_into`` — internal hook used by ``LucidicAI.__init__``
-  (LUC-577c) to flush decorators that ran before the client was constructed.
+- ``ToolSurface`` — captured surface metadata (LUC-577a).
+- ``register_tool`` — push a captured surface into the active client's
+  registry, or buffer when no client is alive yet (LUC-577a).
+- ``snapshot_registry`` — read all currently-registered surfaces.
+- ``mockable`` — decorator capturing + routing dispatch (LUC-577a + 608).
+- ``drain_buffer_into`` — internal hook for ``LucidicAI.__init__``.
+- ``ToolsResource`` — the ``client.tools`` namespace (LUC-608).
+- ``MockContext`` — bound state telling ``@mockable`` to route through
+  the backend; set by ``ToolsResource._init_session`` on tool-backed
+  session start (LUC-608).
+- ``bind_mock_context`` / ``clear_mock_context`` — lifecycle hooks for
+  session start/end (LUC-608).
+- ``emit_call_through_backend`` / ``aemit_call_through_backend`` —
+  transport layer used by ``@mockable`` wrappers and framework
+  adapters (LUC-607).
 
-Adapter modules (LUC-578/579/580) consume helpers from ``registry`` for
-their JSON-schema / Pydantic / callable paths; they're exported there
-rather than re-exported here to keep this module the user-facing surface.
+Adapter modules (LUC-578/579/580) consume the registry's shared
+helpers (``_params_from_json_schema``, ``_params_from_callable``,
+``_compute_source_hash``) directly from ``registry.py`` — not re-exported
+here to keep this module the *user-facing* surface.
 """
+from .context import (
+    MockContext,
+    bind_mock_context,
+    clear_mock_context,
+    current_mock_context,
+)
 from .mockable import mockable
 from .registry import (
     ToolSurface,
@@ -25,12 +36,24 @@ from .registry import (
     register_tool,
     snapshot_registry,
 )
+from .resource import ToolsResource
+from .transport import aemit_call_through_backend, emit_call_through_backend
 
 
 __all__ = [
+    # Surface capture + registry (LUC-577a)
     "ToolSurface",
     "drain_buffer_into",
     "mockable",
     "register_tool",
     "snapshot_registry",
+    # Transport (LUC-607)
+    "aemit_call_through_backend",
+    "emit_call_through_backend",
+    # Client namespace + mock context (LUC-608)
+    "MockContext",
+    "ToolsResource",
+    "bind_mock_context",
+    "clear_mock_context",
+    "current_mock_context",
 ]

--- a/lucidicai/sdk/tools/context.py
+++ b/lucidicai/sdk/tools/context.py
@@ -1,0 +1,85 @@
+"""Mock-context binding — the contextvar that says "this call should be mocked".
+
+``MockContext`` carries the two things a ``@mockable`` wrapper needs to
+route a call through the backend: the bound ``LucidicAI`` client (the
+``mock_calls`` resource lives there) and the session id (mock_call
+dispatches per session, with drift-checked against the session's
+``tool_version_snapshot``).
+
+Set by ``ToolsResource._init_session`` (LUC-608) when a tool-backed
+session is created and ``/sdk/session-init-fixtures`` reports
+``initialized=True``. Cleared on session end. ``@mockable`` wrappers
+read via ``_current_mock_context()`` on every call — a single
+contextvar lookup, no allocation.
+
+Concurrency notes:
+
+- Async tasks each see their own copy (``ContextVar`` semantics).
+  Setting in task A doesn't affect task B. Matches how the existing
+  ``current_session_id`` is bound — see ``lucidicai/sdk/context.py``.
+- Nested sessions clobber: ``bind_mock_context(ctx_inner)`` while one
+  is already set replaces the outer. Same pattern as
+  ``set_active_session``. ``Token``-based reset is supported for
+  callers that need it (the session lifecycle uses this).
+"""
+import contextvars
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ...client import LucidicAI
+
+
+@dataclass(frozen=True)
+class MockContext:
+    """Bound state telling ``@mockable`` to route through the backend.
+
+    ``client`` is the parent ``LucidicAI`` — transport pulls
+    ``client._resources["mock_calls"]`` to issue the dispatch.
+    ``session_id`` is the resolved id from ``client.sessions.create()``;
+    backend uses it to look up the per-session ``tool_version_snapshot``
+    for drift checking.
+    """
+
+    session_id: str
+    client: "LucidicAI"
+
+
+# Module-level contextvar — values automatically scoped per task in
+# async, per OS thread in sync (until a child thread runs without
+# inheriting). Default None means "no mocking active in this context".
+current_mock_context: contextvars.ContextVar[Optional[MockContext]] = contextvars.ContextVar(
+    "lucidic.mock_context", default=None,
+)
+
+
+def bind_mock_context(ctx: MockContext) -> contextvars.Token:
+    """Set the active mock context for the current execution context.
+
+    Returns a ``Token`` so callers can ``current_mock_context.reset(token)``
+    later — used by the session lifecycle to undo the binding when the
+    session ends. Most callers can ignore the return value if they
+    don't need explicit unbinding (process-end cleanup handles it).
+    """
+    return current_mock_context.set(ctx)
+
+
+def clear_mock_context() -> None:
+    """Unconditionally clear the bound mock context.
+
+    Sets to ``None`` rather than reset via Token — used by session-end
+    paths where the original Token may be lost (cross-thread, REPL).
+    Subsequent ``_current_mock_context()`` calls see None until the
+    next ``bind_mock_context``.
+    """
+    current_mock_context.set(None)
+
+
+def _current_mock_context() -> Optional[MockContext]:
+    """Read the active mock context, or None when no mocking is bound.
+
+    Underscore-prefix because this is consumed by ``@mockable`` /
+    adapters internally, not part of the public user surface. Public
+    callers should use ``client.tools`` methods or the decorator.
+    """
+    return current_mock_context.get(None)

--- a/lucidicai/sdk/tools/mockable.py
+++ b/lucidicai/sdk/tools/mockable.py
@@ -2,10 +2,16 @@
 
 Decoration captures the function's signature, docstring, and source-hash
 into a ``ToolSurface``, registers it (via ``register_tool``), and returns
-a wrapper that — in the **v1** of this ticket — simply runs the original
-function. The wrapper consults ``_current_mock_context()`` in LUC-577c to
-decide whether to route the call through the backend; until that ticket
-lands, the wrapper is effectively a no-op fast path.
+a wrapper that consults ``_current_mock_context()`` at call time.
+
+- **No mock context** (normal observability sessions or no session at
+  all): wrapper runs the original function — one contextvar lookup,
+  zero overhead beyond that.
+- **Mock context active** (session was bound via
+  ``ToolsResource._init_session`` after a tool-backed session start):
+  wrapper routes the call through the transport layer
+  (``emit_call_through_backend`` / ``aemit_call_through_backend``)
+  which handles tier dispatch, PASS_THROUGH fallback, and drift.
 
 Sync + async are detected at decoration time via
 ``inspect.iscoroutinefunction``. Both wrappers attach the captured
@@ -19,9 +25,11 @@ names, and an early SDK-side reject produces a much better error.
 """
 import functools
 import inspect
+import uuid
 from typing import Any, Callable, TypeVar
 
 from ...core.errors import LucidicError
+from .context import _current_mock_context
 from .registry import (
     ToolSurface,
     _compute_source_hash,
@@ -29,6 +37,7 @@ from .registry import (
     _stringify_annotation,
     register_tool,
 )
+from .transport import aemit_call_through_backend, emit_call_through_backend
 
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -115,17 +124,40 @@ def mockable(func: F) -> F:
 
         @functools.wraps(func)
         async def awrapper(*args: Any, **kwargs: Any) -> Any:
-            # v1 fast path — context check goes here in 577c. Until then
-            # the wrapper is transparent: zero behavior change for the user.
-            return await func(*args, **kwargs)
+            ctx = _current_mock_context()
+            if ctx is None:
+                # Fast path: no mock context bound to this task. One
+                # contextvar lookup, then run the user's function
+                # unchanged. Hit every tool call in production sessions
+                # that aren't part of a tool-backed eval run.
+                return await func(*args, **kwargs)
+            return await aemit_call_through_backend(
+                client=ctx.client,
+                session_id=ctx.session_id,
+                tool_name=surface.name,
+                args=args,
+                kwargs=kwargs,
+                real_fn=func,
+                client_event_id=str(uuid.uuid4()),
+            )
 
         awrapper.__lucidic_surface__ = surface  # type: ignore[attr-defined]
         return awrapper  # type: ignore[return-value]
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        # v1 fast path — context check goes here in 577c.
-        return func(*args, **kwargs)
+        ctx = _current_mock_context()
+        if ctx is None:
+            return func(*args, **kwargs)
+        return emit_call_through_backend(
+            client=ctx.client,
+            session_id=ctx.session_id,
+            tool_name=surface.name,
+            args=args,
+            kwargs=kwargs,
+            real_fn=func,
+            client_event_id=str(uuid.uuid4()),
+        )
 
     wrapper.__lucidic_surface__ = surface  # type: ignore[attr-defined]
     return wrapper  # type: ignore[return-value]

--- a/lucidicai/sdk/tools/resource.py
+++ b/lucidicai/sdk/tools/resource.py
@@ -1,0 +1,330 @@
+"""``client.tools`` namespace — the user-facing API for tool dispatch.
+
+Holds the per-client registry (filled by ``@mockable`` decorations +
+adapter ``register_*`` calls), exposes the canonical instance-bound
+decorator (``client.tools.mockable``), and drives the two backend
+side effects that turn registrations into live dispatch:
+
+- ``sync()`` → ``POST /sdk/agent-tools/sync`` — push the registry to
+  the backend so the dashboard surfaces tools and ``mock_call`` can
+  resolve them. Auto-fired on first tool-backed session start via
+  ``_maybe_sync_on_session_start``; manually callable for power users.
+- ``_init_session(session_id)`` → ``POST /sdk/session-init-fixtures`` —
+  ask the backend to materialize per-session DuckDB state and write
+  the ``tool_version_snapshot``. On success, binds a ``MockContext``
+  for the session so subsequent ``@mockable`` calls route through the
+  backend. Called by ``SessionResource.create()``.
+
+Debounce semantics: ``_last_synced_hash`` records the sha256 of the
+sorted registry's source_hashes. Re-firing ``_maybe_sync_on_session_start``
+when the fingerprint hasn't changed is a cheap no-op — customer code
+that creates many sessions in a loop (eval runs, batch processing)
+syncs exactly once per registry change, not per session.
+"""
+import hashlib
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+from ...api.resources.agent_tools_sync import SyncAgentToolsResource
+from ...api.resources.session_init_fixtures import SessionInitFixturesResource
+from ...core.errors import LucidicError
+from .context import MockContext, bind_mock_context
+from .registry import ToolSurface
+
+if TYPE_CHECKING:
+    from ...client import LucidicAI
+
+
+logger = logging.getLogger("Lucidic")
+
+
+class ToolsResource:
+    """User-facing ``client.tools`` namespace.
+
+    Constructed once per ``LucidicAI`` client; held in
+    ``client._resources["tools"]`` and exposed via the ``client.tools``
+    property. Threading: the registry dict is read/written under the
+    GIL only — no explicit lock since decorations happen at import
+    time (single-threaded) and ``sync()`` snapshots before sending.
+    """
+
+    def __init__(self, client: "LucidicAI"):
+        self._client = client
+        self._registry: Dict[str, ToolSurface] = {}
+        # Sync debounce — sha256 of sorted source_hashes. Re-firing
+        # _maybe_sync_on_session_start with an unchanged fingerprint
+        # skips the network round trip.
+        self._last_synced_hash: Optional[str] = None
+
+        self._sync_api = SyncAgentToolsResource(client._http)
+        self._init_fixtures_api = SessionInitFixturesResource(client._http)
+
+        # Note: ``LucidicAI.__init__`` calls ``drain_buffer_into(self)``
+        # after wiring this resource into ``_resources["tools"]``.
+        # Draining here would deadlock — ``drain_buffer_into`` accesses
+        # ``client.tools`` which returns from ``_resources["tools"]``
+        # that's still being constructed.
+
+    # ==================== Public surface ====================
+
+    def mockable(self, func: Callable) -> Callable:
+        """Canonical instance-bound decorator.
+
+        Equivalent to module-level ``lucidic.mockable`` but binds the
+        captured surface to this client's registry directly (no buffer
+        round trip). Useful when multiple ``LucidicAI`` instances coexist
+        in one process — explicit binding avoids the first-wins buffer
+        semantics.
+
+        Example::
+
+            client = lucidic.LucidicAI(api_key="...", agent_id="...")
+
+            @client.tools.mockable
+            def query_emails(sender: str) -> list[dict]:
+                ...
+        """
+        # Delegate to the module-level decorator. Its register_tool
+        # call will see this client via get_active_client() if the
+        # client is bound to the current context — otherwise the
+        # surface falls into the buffer. We force the registry
+        # binding here so this method works even when no client is
+        # currently bound to the contextvar.
+        from .mockable import mockable as _mockable_decorator
+
+        wrapped = _mockable_decorator(func)
+        # Directly stamp this client's registry — the decorator's
+        # register_tool may have buffered if no contextvar client is
+        # active. Idempotent: last-wins matches registry semantics.
+        surface = wrapped.__lucidic_surface__
+        self._registry[surface.name] = surface
+        return wrapped
+
+    def register(self, surface: ToolSurface) -> None:
+        """Add a ``ToolSurface`` directly to this client's registry.
+
+        Used by adapter helpers (LUC-578/579/580) that build surfaces
+        from external tool definitions (LangChain ``BaseTool``, OpenAI
+        function spec, Anthropic tool block) rather than via the
+        ``@mockable`` decoration path.
+        """
+        self._registry[surface.name] = surface
+
+    def snapshot(self) -> List[ToolSurface]:
+        """All registered surfaces in stable name order.
+
+        Used by ``sync()`` to build the wire payload; also useful for
+        inspection / debugging (``client.tools.snapshot()`` in a REPL).
+        """
+        return sorted(self._registry.values(), key=lambda s: s.name)
+
+    def sync(self) -> Dict[str, Any]:
+        """Push the current registry to the backend.
+
+        Builds the wire payload from ``snapshot()``, POSTs to
+        ``/sdk/agent-tools/sync``, updates ``_last_synced_hash`` on
+        success. Returns the backend's ``stats`` payload.
+
+        No-op when the registry is empty (backend would 200 with
+        zero updates; we save the round trip). Logs at INFO so the
+        user sees sync activity in normal verbose logs.
+
+        Raises ``LucidicError`` on backend failures (422 validation,
+        503 lock contention). Doesn't retry — caller decides.
+        """
+        surfaces = self.snapshot()
+        if not surfaces:
+            logger.debug("[ToolsResource] sync() called with empty registry; no-op")
+            return {"synced": True, "stats": {"tools": 0}}
+
+        agent_id = self._client._config.agent_id
+        if not agent_id:
+            raise LucidicError(
+                "client.tools.sync() requires a configured agent_id "
+                "(LUCIDIC_AGENT_ID env var or LucidicAI(agent_id=...))"
+            )
+
+        payload = [_surface_to_wire(s) for s in surfaces]
+        logger.info(
+            "[ToolsResource] syncing %d tool(s) to backend for agent %s",
+            len(payload), str(agent_id)[:8] + "...",
+        )
+        result = self._sync_api.sync(agent_id=str(agent_id), tools=payload)
+        self._last_synced_hash = self._registry_fingerprint(surfaces)
+        return result
+
+    async def async_(self) -> Dict[str, Any]:
+        """Async sibling of ``sync``. Trailing underscore avoids the
+        ``async`` keyword collision."""
+        surfaces = self.snapshot()
+        if not surfaces:
+            return {"synced": True, "stats": {"tools": 0}}
+
+        agent_id = self._client._config.agent_id
+        if not agent_id:
+            raise LucidicError(
+                "client.tools.sync() requires a configured agent_id"
+            )
+
+        payload = [_surface_to_wire(s) for s in surfaces]
+        result = await self._sync_api.async_sync(
+            agent_id=str(agent_id), tools=payload,
+        )
+        self._last_synced_hash = self._registry_fingerprint(surfaces)
+        return result
+
+    # ==================== Lifecycle hooks (called from SessionResource) ====================
+
+    def _init_session(self, session_id: str) -> None:
+        """Initialize per-session fixture state + bind MockContext.
+
+        Called from ``SessionResource.create()`` immediately after the
+        session is created on the backend, when the user provided a
+        ``datasetitem_id`` (the signal that they intend tool-backed
+        dispatch). Three outcomes:
+
+        1. Backend returns ``initialized=True``: session is tool-backed
+           and ready. Bind ``MockContext(session_id, client)`` for
+           ``@mockable`` to consult. Fire the debounced auto-sync so
+           the registry is on the backend before any ``mock_call``.
+
+        2. Backend returns ``initialized=False`` (no DatasetItem on
+           server side, mismatch, no Resources/Tools to snapshot):
+           log DEBUG and continue. Session works as normal observability
+           session; ``@mockable`` calls short-circuit to running the
+           local function.
+
+        3. Backend error or network failure: log WARNING and continue.
+           ``mock_call`` will return ``session_not_initialized`` later
+           if the user attempts dispatch, which surfaces the issue
+           with full typed-exception context.
+
+        NEVER raises — session creation must not be blocked by tool
+        init failures. The session is observability-functional even
+        without tool state.
+        """
+        try:
+            result = self._init_fixtures_api.init(session_id)
+        except LucidicError as exc:
+            logger.warning(
+                "[ToolsResource] session-init-fixtures failed for %s: %s — "
+                "mock_call attempts in this session will return "
+                "session_not_initialized",
+                session_id[:8] + "...", exc,
+            )
+            return
+
+        if not result.get("initialized"):
+            logger.debug(
+                "[ToolsResource] session %s is not tool-backed (reason: %s); "
+                "skipping MockContext binding",
+                session_id[:8] + "...", result.get("reason", "?"),
+            )
+            return
+
+        # Bind MockContext so @mockable wrappers route through transport
+        bind_mock_context(MockContext(session_id=session_id, client=self._client))
+        logger.debug(
+            "[ToolsResource] bound MockContext for session %s "
+            "(fixtures=%d, tools_snapshotted=%d)",
+            session_id[:8] + "...",
+            len(result.get("fixture_ids", [])),
+            len(result.get("tools_snapshotted", [])),
+        )
+
+        # First-session-start sync trigger (debounced). Done after
+        # MockContext binds so any mockable call that fires immediately
+        # after session creation has the backend already aware of the
+        # tools (avoids a transient unknown_tool 404).
+        self._maybe_sync_on_session_start()
+
+    async def _ainit_session(self, session_id: str) -> None:
+        """Async sibling of ``_init_session``. Mirrors all the same
+        contracts including the no-raise guarantee."""
+        try:
+            result = await self._init_fixtures_api.ainit(session_id)
+        except LucidicError as exc:
+            logger.warning(
+                "[ToolsResource] session-init-fixtures (async) failed for %s: %s",
+                session_id[:8] + "...", exc,
+            )
+            return
+
+        if not result.get("initialized"):
+            logger.debug(
+                "[ToolsResource] async session %s not tool-backed (reason: %s)",
+                session_id[:8] + "...", result.get("reason", "?"),
+            )
+            return
+
+        bind_mock_context(MockContext(session_id=session_id, client=self._client))
+        # Sync is best-effort here; await the async version
+        try:
+            await self._maybe_async_sync_on_session_start()
+        except LucidicError as exc:
+            logger.warning("[ToolsResource] auto-sync failed: %s", exc)
+
+    # ==================== Internals ====================
+
+    def _maybe_sync_on_session_start(self) -> None:
+        """Debounced auto-sync of the registry.
+
+        Fingerprints the current registry; if it matches the last
+        sync's fingerprint, no-op (registry hasn't changed → backend
+        already has this exact tool catalog). Otherwise syncs.
+
+        Wraps ``sync()`` errors in WARNING + suppresses — auto-sync is
+        a convenience, not a contract. Manual ``client.tools.sync()``
+        re-raises so power users see real failures.
+        """
+        surfaces = self.snapshot()
+        fingerprint = self._registry_fingerprint(surfaces)
+        if fingerprint == self._last_synced_hash:
+            logger.debug(
+                "[ToolsResource] auto-sync: fingerprint unchanged, skipping"
+            )
+            return
+        try:
+            self.sync()
+        except LucidicError as exc:
+            logger.warning("[ToolsResource] auto-sync failed: %s", exc)
+
+    async def _maybe_async_sync_on_session_start(self) -> None:
+        surfaces = self.snapshot()
+        fingerprint = self._registry_fingerprint(surfaces)
+        if fingerprint == self._last_synced_hash:
+            return
+        try:
+            await self.async_()
+        except LucidicError as exc:
+            logger.warning("[ToolsResource] async auto-sync failed: %s", exc)
+
+    def _registry_fingerprint(
+        self, surfaces: Optional[List[ToolSurface]] = None,
+    ) -> str:
+        """SHA256 of sorted ``name:source_hash`` pairs for debounce.
+
+        Cheap: hashing one line per tool. Stable: sorted by name so
+        re-ordering doesn't trip the comparison.
+        """
+        if surfaces is None:
+            surfaces = self.snapshot()
+        lines = [f"{s.name}:{s.source_hash}" for s in surfaces]
+        return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def _surface_to_wire(surface: ToolSurface) -> Dict[str, Any]:
+    """Convert a ``ToolSurface`` to the JSON shape ``SyncAgentToolsSerializer``
+    accepts.
+
+    The dataclass field names happen to match the serializer's fields
+    1:1; the explicit mapping here documents the contract and keeps a
+    seam for future shape drift.
+    """
+    return {
+        "name": surface.name,
+        "signature": surface.signature,
+        "docstring": surface.docstring,
+        "return_shape": surface.return_shape,
+        "source_hash": surface.source_hash,
+    }

--- a/tests/api/resources/conftest.py
+++ b/tests/api/resources/conftest.py
@@ -1,0 +1,20 @@
+"""Isolation fixtures for tests/api/resources/.
+
+Same rationale as ``tests/sdk/tools/conftest.py`` — clear contextvars
+between tests so a session_id set by an earlier test doesn't leak
+into the legacy ``test_no_active_session_returns_none`` path that
+relies on the contextvar being None.
+"""
+import pytest
+
+from lucidicai.sdk.context import current_session_id
+from lucidicai.sdk.tools.context import current_mock_context
+
+
+@pytest.fixture(autouse=True)
+def _isolate_context_vars():
+    current_session_id.set(None)
+    current_mock_context.set(None)
+    yield
+    current_session_id.set(None)
+    current_mock_context.set(None)

--- a/tests/sdk/tools/conftest.py
+++ b/tests/sdk/tools/conftest.py
@@ -15,9 +15,26 @@ import pytest
 from lucidicai.api.client import HttpClient
 from lucidicai.api.resources.mock_call import MockCallResource
 from lucidicai.core.config import NetworkConfig, SDKConfig
+from lucidicai.sdk.context import current_session_id
+from lucidicai.sdk.tools.context import current_mock_context
 
 
 _STUB_BASE_URL = "https://stub.lucidic.test"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_context_vars():
+    """Clear cross-cutting contextvars between every test in tests/sdk/tools.
+
+    Without this, a test that binds ``current_session_id`` (via a
+    real session creation) leaks the value into the next test —
+    creating order-dependent failures that are hard to track.
+    """
+    current_session_id.set(None)
+    current_mock_context.set(None)
+    yield
+    current_session_id.set(None)
+    current_mock_context.set(None)
 
 
 @pytest.fixture

--- a/tests/sdk/tools/test_context.py
+++ b/tests/sdk/tools/test_context.py
@@ -1,0 +1,79 @@
+"""Tests for ``lucidicai.sdk.tools.context``.
+
+Pins MockContext semantics + contextvar binding. Coverage matters
+because the @mockable wrapper consults _current_mock_context() on
+every call — a regression here silently bypasses backend dispatch.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from lucidicai.sdk.tools.context import (
+    MockContext,
+    _current_mock_context,
+    bind_mock_context,
+    clear_mock_context,
+    current_mock_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_context_var():
+    """Reset the contextvar between tests. Module global persists
+    across tests otherwise — bound state from one would leak."""
+    current_mock_context.set(None)
+    yield
+    current_mock_context.set(None)
+
+
+def _make_ctx(session_id="sess-1") -> MockContext:
+    fake_client = SimpleNamespace(_resources={})
+    return MockContext(session_id=session_id, client=fake_client)
+
+
+class TestBind:
+    def test_no_binding_returns_none(self):
+        assert _current_mock_context() is None
+
+    def test_bind_returns_token(self):
+        ctx = _make_ctx()
+        token = bind_mock_context(ctx)
+        assert _current_mock_context() is ctx
+        # Token can reset back to None
+        current_mock_context.reset(token)
+        assert _current_mock_context() is None
+
+    def test_clear_unsets(self):
+        bind_mock_context(_make_ctx())
+        clear_mock_context()
+        assert _current_mock_context() is None
+
+    def test_rebind_replaces(self):
+        bind_mock_context(_make_ctx(session_id="first"))
+        bind_mock_context(_make_ctx(session_id="second"))
+        assert _current_mock_context().session_id == "second"
+
+
+class TestAsyncIsolation:
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_dont_leak(self):
+        """ContextVar gives each asyncio task its own value.
+
+        Critical for tool-backed eval runs that fire many sessions in
+        parallel — task A's mock context must not leak into task B.
+        """
+        results = []
+
+        async def task(name: str):
+            bind_mock_context(_make_ctx(session_id=name))
+            # Yield to scheduler so other tasks interleave
+            await asyncio.sleep(0)
+            # Each task should see ONLY its own binding
+            ctx = _current_mock_context()
+            results.append((name, ctx.session_id if ctx else None))
+
+        await asyncio.gather(task("a"), task("b"), task("c"))
+        # Order isn't guaranteed but each task sees its own name
+        results_dict = dict(results)
+        assert results_dict == {"a": "a", "b": "b", "c": "c"}

--- a/tests/sdk/tools/test_mockable_dispatch.py
+++ b/tests/sdk/tools/test_mockable_dispatch.py
@@ -1,0 +1,185 @@
+"""Tests for the live-dispatch wiring of ``@mockable``.
+
+LUC-577 covered surface capture + the fast path (no mock context).
+This file pins the behavior with mock context bound: every @mockable
+call should route through ``emit_call_through_backend`` and hit the
+mocked backend endpoint.
+"""
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.sdk.tools.context import (
+    MockContext,
+    bind_mock_context,
+    current_mock_context,
+)
+from lucidicai.sdk.tools.mockable import mockable
+from lucidicai.sdk.tools.registry import _PENDING_BUFFER, _REGISTRY
+
+
+_MOCK_CALL_ENDPOINT = "https://stub.lucidic.test/sdk/mock-call"
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_mock_context.set(None)
+    yield
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_mock_context.set(None)
+
+
+class TestSyncDispatch:
+    @respx.mock
+    def test_no_mock_context_runs_local(self, stub_client):
+        @mockable
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        # No context → wrapper runs func, no network call
+        assert add(2, 3) == 5
+        assert len(respx.calls) == 0
+
+    @respx.mock
+    def test_with_mock_context_routes_to_backend(self, stub_client):
+        route = respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": 999, "tier": "SQL_TEMPLATE",
+                           "was_mocked": True},
+            )
+        )
+
+        @mockable
+        def add(a: int, b: int) -> int:
+            return a + b  # Real impl returns 5; backend mocks 999
+
+        bind_mock_context(MockContext(session_id="sess-1", client=stub_client))
+        result = add(2, 3)
+        assert result == 999  # backend's mocked return_value
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_pass_through_falls_back_to_local(self, stub_client):
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": None, "tier": "PASS_THROUGH",
+                           "was_mocked": False},
+            )
+        )
+
+        @mockable
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        # PASS_THROUGH → transport runs real_fn (the decorated original)
+        assert add(2, 3) == 5
+
+    @respx.mock
+    def test_drift_logs_warning_and_falls_back(self, stub_client, caplog):
+        import logging
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                409,
+                json={"error": {"code": "tool_drift",
+                                "detail": "hash drifted",
+                                "session_hash": "aaa1234567",
+                                "current_hash": "bbb1234567"}},
+            )
+        )
+
+        @mockable
+        def my_tool(x: int) -> int:
+            return x * 2
+
+        bind_mock_context(MockContext(session_id="sess-1", client=stub_client))
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            result = my_tool(7)
+        assert result == 14  # ran the real fn
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("drift" in r.message.lower() for r in warnings)
+
+
+class TestAsyncDispatch:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_no_context_runs_local(self, stub_client):
+        @mockable
+        async def aadd(a: int, b: int) -> int:
+            return a + b
+
+        assert await aadd(2, 3) == 5
+        assert len(respx.calls) == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_with_context_routes(self, stub_client):
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": "from-backend", "tier": "PYTHON",
+                           "was_mocked": True},
+            )
+        )
+
+        @mockable
+        async def aquery(x: str) -> str:
+            return "from-local"
+
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        result = await aquery("anything")
+        assert result == "from-backend"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_pass_through_runs_async_local(self, stub_client):
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": None, "tier": "PASS_THROUGH",
+                           "was_mocked": False},
+            )
+        )
+
+        @mockable
+        async def aquery(x: int) -> int:
+            return x * 3
+
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        result = await aquery(4)
+        assert result == 12
+
+
+class TestClientEventIdUnique:
+    """Each @mockable invocation generates its own client_event_id —
+    backend uses this as the FUNCTION_CALL event's idempotency key,
+    so distinct calls must produce distinct ids."""
+
+    @respx.mock
+    def test_distinct_per_call(self, stub_client):
+        route = respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": 1, "tier": "PYTHON", "was_mocked": True},
+            )
+        )
+
+        @mockable
+        def t():
+            return 0
+
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        t()
+        t()
+        t()
+
+        import json as _json
+        event_ids = [
+            _json.loads(call.request.read()).get("client_event_id")
+            for call in route.calls
+        ]
+        assert len(event_ids) == 3
+        assert all(eid is not None for eid in event_ids)
+        assert len(set(event_ids)) == 3  # all distinct

--- a/tests/sdk/tools/test_resource.py
+++ b/tests/sdk/tools/test_resource.py
@@ -1,0 +1,297 @@
+"""Tests for ``lucidicai.sdk.tools.resource.ToolsResource``.
+
+Covers the user-facing surface (mockable, register, snapshot, sync),
+the lifecycle hooks (_init_session, _maybe_sync_on_session_start) and
+the debounce semantics that keep auto-sync from spamming the backend.
+
+Network calls to ``/sdk/agent-tools/sync`` and
+``/sdk/session-init-fixtures`` are intercepted via respx.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.client import HttpClient
+from lucidicai.core.config import NetworkConfig, SDKConfig
+from lucidicai.sdk.tools.context import _current_mock_context, current_mock_context
+from lucidicai.sdk.tools.registry import (
+    ToolSurface,
+    _PENDING_BUFFER,
+    _REGISTRY,
+)
+from lucidicai.sdk.tools.resource import ToolsResource
+
+
+_BASE_URL = "https://stub.lucidic.test"
+_SYNC_ENDPOINT = f"{_BASE_URL}/sdk/agent-tools/sync"
+_INIT_ENDPOINT = f"{_BASE_URL}/sdk/session-init-fixtures"
+
+
+@pytest.fixture(autouse=True)
+def _clear_module_state():
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_mock_context.set(None)
+    yield
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_mock_context.set(None)
+
+
+@pytest.fixture
+def fake_client():
+    """Minimal LucidicAI stand-in carrying just the fields ToolsResource reads."""
+    class _FakeClient:
+        def __init__(self):
+            network = NetworkConfig(base_url=_BASE_URL)
+            self._config = SDKConfig(
+                api_key="test-key",
+                agent_id="aaaa1111-0000-0000-0000-000000000000",
+                network=network,
+            )
+            self._http = HttpClient(config=self._config)
+            self._resources = {}
+    return _FakeClient()
+
+
+@pytest.fixture
+def tools(fake_client) -> ToolsResource:
+    return ToolsResource(client=fake_client)
+
+
+# ---------- Public surface ----------------------------------------------
+
+
+class TestPublicSurface:
+    def test_register_direct(self, tools):
+        surface = ToolSurface(
+            name="t", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="a" * 64,
+        )
+        tools.register(surface)
+        assert "t" in tools._registry
+
+    def test_snapshot_sorted(self, tools):
+        for name in ("zeta", "alpha", "middle"):
+            tools.register(ToolSurface(
+                name=name, signature={"params": [], "return_type": None},
+                docstring="", return_shape=None, source_hash=name * 10 + "x" * 24,
+            ))
+        names = [s.name for s in tools.snapshot()]
+        assert names == ["alpha", "middle", "zeta"]
+
+    def test_mockable_decorates_into_client_registry(self, tools):
+        @tools.mockable
+        def my_tool(x: int) -> int:
+            return x * 2
+        assert "my_tool" in tools._registry
+        assert my_tool(3) == 6  # wrapper transparent without mock context
+
+    def test_mockable_async(self, tools):
+        import asyncio
+
+        @tools.mockable
+        async def aquery(x: int) -> int:
+            return x + 1
+
+        assert "aquery" in tools._registry
+        assert asyncio.run(aquery(4)) == 5
+
+
+# ---------- sync() ------------------------------------------------------
+
+
+class TestSync:
+    @respx.mock
+    def test_sync_posts_wire_payload(self, tools):
+        route = respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True,
+                                                    "stats": {"created": 1}}),
+        )
+        tools.register(ToolSurface(
+            name="email_sender", signature={"params": [], "return_type": None},
+            docstring="Send an email.", return_shape=None,
+            source_hash="a" * 64,
+        ))
+        result = tools.sync()
+        assert result["synced"] is True
+
+        import json as _json
+        body = _json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "aaaa1111-0000-0000-0000-000000000000"
+        assert len(body["tools"]) == 1
+        assert body["tools"][0]["name"] == "email_sender"
+        assert body["tools"][0]["docstring"] == "Send an email."
+        assert body["tools"][0]["source_hash"] == "a" * 64
+
+    @respx.mock
+    def test_sync_empty_registry_noop(self, tools):
+        # No network call should be made
+        result = tools.sync()
+        assert result["synced"] is True
+        assert len(respx.calls) == 0
+
+    @respx.mock
+    def test_sync_updates_fingerprint(self, tools):
+        respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True, "stats": {}}),
+        )
+        tools.register(ToolSurface(
+            name="t", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="a" * 64,
+        ))
+        assert tools._last_synced_hash is None
+        tools.sync()
+        assert tools._last_synced_hash is not None
+        fingerprint_after_sync = tools._last_synced_hash
+        assert fingerprint_after_sync == tools._registry_fingerprint()
+
+
+# ---------- _maybe_sync_on_session_start (debounce) ----------------------
+
+
+class TestAutoSyncDebounce:
+    @respx.mock
+    def test_first_call_syncs(self, tools):
+        route = respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True, "stats": {}}),
+        )
+        tools.register(ToolSurface(
+            name="t", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="a" * 64,
+        ))
+        tools._maybe_sync_on_session_start()
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_unchanged_registry_skips(self, tools):
+        route = respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True, "stats": {}}),
+        )
+        tools.register(ToolSurface(
+            name="t", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="a" * 64,
+        ))
+        tools._maybe_sync_on_session_start()
+        tools._maybe_sync_on_session_start()  # registry unchanged
+        tools._maybe_sync_on_session_start()  # still unchanged
+        assert route.call_count == 1  # only the first one hit the network
+
+    @respx.mock
+    def test_registry_change_triggers_resync(self, tools):
+        route = respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True, "stats": {}}),
+        )
+        tools.register(ToolSurface(
+            name="t1", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="a" * 64,
+        ))
+        tools._maybe_sync_on_session_start()
+        # Add a new tool
+        tools.register(ToolSurface(
+            name="t2", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="b" * 64,
+        ))
+        tools._maybe_sync_on_session_start()
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_sync_error_swallowed_in_auto_path(self, tools, caplog):
+        import logging
+        respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(503, json={"error": "lock contention"}),
+        )
+        tools.register(ToolSurface(
+            name="t", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="a" * 64,
+        ))
+        # Should not raise
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            tools._maybe_sync_on_session_start()
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("auto-sync failed" in r.message for r in warnings)
+
+
+# ---------- _init_session ------------------------------------------------
+
+
+class TestInitSession:
+    @respx.mock
+    def test_initialized_true_binds_mock_context(self, tools):
+        respx.post(_INIT_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"initialized": True,
+                      "fixture_ids": ["fx-1"], "tools_snapshotted": ["t1"],
+                      "already_initialized": False},
+            )
+        )
+        respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True, "stats": {}}),
+        )
+        tools._init_session("sess-xyz")
+        ctx = _current_mock_context()
+        assert ctx is not None
+        assert ctx.session_id == "sess-xyz"
+        assert ctx.client is tools._client
+
+    @respx.mock
+    def test_initialized_false_no_binding(self, tools):
+        respx.post(_INIT_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"initialized": False, "reason": "no DatasetItem",
+                      "fixture_ids": [], "tools_snapshotted": [],
+                      "already_initialized": False},
+            )
+        )
+        tools._init_session("sess-no-tools")
+        assert _current_mock_context() is None
+
+    @respx.mock
+    def test_init_failure_logs_and_continues(self, tools, caplog):
+        import logging
+        respx.post(_INIT_ENDPOINT).mock(
+            return_value=httpx.Response(500, json={"error": "internal"}),
+        )
+        # Must not raise
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            tools._init_session("sess-1")
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("session-init-fixtures failed" in r.message for r in warnings)
+        assert _current_mock_context() is None
+
+    @respx.mock
+    def test_init_triggers_auto_sync(self, tools):
+        respx.post(_INIT_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"initialized": True, "fixture_ids": [],
+                      "tools_snapshotted": ["t"], "already_initialized": False},
+            )
+        )
+        sync_route = respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True, "stats": {}}),
+        )
+        # Register a tool so sync has something to push
+        tools.register(ToolSurface(
+            name="t", signature={"params": [], "return_type": None},
+            docstring="", return_shape=None, source_hash="a" * 64,
+        ))
+        tools._init_session("sess-1")
+        assert sync_route.call_count == 1
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_init_binds(self, tools):
+        respx.post(_INIT_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"initialized": True, "fixture_ids": [],
+                      "tools_snapshotted": [], "already_initialized": False},
+            )
+        )
+        await tools._ainit_session("sess-async")
+        ctx = _current_mock_context()
+        assert ctx is not None
+        assert ctx.session_id == "sess-async"

--- a/tests/sdk/tools/test_session_wiring.py
+++ b/tests/sdk/tools/test_session_wiring.py
@@ -1,0 +1,196 @@
+"""Integration test for the SessionResource auto-init-fixtures wiring.
+
+Bridges LUC-608's two halves: (1) when `client.sessions.create()` is
+called with `datasetitem_id`, the SessionResource auto-fires
+`/sdk/session-init-fixtures`; (2) on success, ToolsResource binds a
+MockContext so subsequent `@mockable` calls in the same context route
+through the backend.
+
+Real LucidicAI construction is heavy (telemetry init, API key verify,
+etc.) so we mock at the HTTP boundary via respx and use
+``production=True`` to suppress the API-key validation that would fail
+without a real backend.
+"""
+import os
+
+import httpx
+import pytest
+import respx
+
+import lucidicai
+from lucidicai import LucidicAI
+from lucidicai.sdk.tools.context import _current_mock_context, current_mock_context
+from lucidicai.sdk.tools.registry import _PENDING_BUFFER, _REGISTRY
+
+
+_INITSESSION_ENDPOINT = "https://stub.lucidic.test/initsession"
+_INIT_FIXTURES_ENDPOINT = "https://stub.lucidic.test/sdk/session-init-fixtures"
+_SYNC_ENDPOINT = "https://stub.lucidic.test/sdk/agent-tools/sync"
+_MOCK_CALL_ENDPOINT = "https://stub.lucidic.test/sdk/mock-call"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    """Force LUCIDIC_DEBUG off + neutralize .env interference."""
+    monkeypatch.setenv("LUCIDIC_DEBUG", "false")
+    monkeypatch.setenv("LUCIDIC_BASE_URL", "https://stub.lucidic.test")
+    monkeypatch.delenv("LUCIDIC_REGION", raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_mock_context.set(None)
+    yield
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_mock_context.set(None)
+
+
+@pytest.fixture
+def client():
+    """A real LucidicAI with production=True so API-key validation
+    short-circuits. The HTTP client points at the stub URL via the
+    env var fixture above."""
+    return LucidicAI(
+        api_key="test-key",
+        agent_id="aaaa1111-0000-0000-0000-000000000000",
+        production=True,
+    )
+
+
+class TestAutoInit:
+    @respx.mock
+    def test_no_datasetitem_skips_init(self, client):
+        # Session created without datasetitem_id → no init-fixtures call
+        respx.post(_INITSESSION_ENDPOINT).mock(
+            return_value=httpx.Response(
+                201, json={"session_id": "sess-x", "session_name": "test"},
+            )
+        )
+        init_route = respx.post(_INIT_FIXTURES_ENDPOINT)
+
+        client.sessions.create(session_name="test")
+
+        assert init_route.call_count == 0
+        assert _current_mock_context() is None
+
+    @respx.mock
+    def test_with_datasetitem_fires_init(self, client):
+        respx.post(_INITSESSION_ENDPOINT).mock(
+            return_value=httpx.Response(
+                201, json={"session_id": "sess-x", "session_name": "test"},
+            )
+        )
+        respx.post(_INIT_FIXTURES_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"initialized": True, "fixture_ids": [],
+                      "tools_snapshotted": [], "already_initialized": False},
+            )
+        )
+
+        client.sessions.create(
+            session_name="test",
+            datasetitem_id="ditm-1",
+        )
+        # MockContext is bound for the current context
+        ctx = _current_mock_context()
+        assert ctx is not None
+        assert ctx.session_id == "sess-x"
+        assert ctx.client is client
+
+    @respx.mock
+    def test_with_datasetitem_but_backend_not_tool_backed(self, client):
+        # Backend says "this session has no Resources/Tools" — SDK skips
+        # MockContext binding and the session proceeds as a normal one.
+        respx.post(_INITSESSION_ENDPOINT).mock(
+            return_value=httpx.Response(
+                201, json={"session_id": "sess-x", "session_name": "test"},
+            )
+        )
+        respx.post(_INIT_FIXTURES_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"initialized": False, "reason": "no Resources on dataset",
+                      "fixture_ids": [], "tools_snapshotted": [],
+                      "already_initialized": False},
+            )
+        )
+
+        client.sessions.create(
+            session_name="test",
+            datasetitem_id="ditm-1",
+        )
+        assert _current_mock_context() is None
+
+    @respx.mock
+    def test_init_failure_does_not_block_session_creation(self, client):
+        respx.post(_INITSESSION_ENDPOINT).mock(
+            return_value=httpx.Response(
+                201, json={"session_id": "sess-x", "session_name": "test"},
+            )
+        )
+        respx.post(_INIT_FIXTURES_ENDPOINT).mock(
+            return_value=httpx.Response(500, json={"error": "internal"}),
+        )
+
+        # Must not raise — session creation continues even if init fails
+        session = client.sessions.create(
+            session_name="test",
+            datasetitem_id="ditm-1",
+        )
+        assert session is not None
+        assert _current_mock_context() is None
+
+
+class TestEndToEnd:
+    """Decorate + create tool-backed session + invoke. The full chain."""
+
+    @respx.mock
+    def test_full_chain(self, client):
+        # Decorate before session start
+        @lucidicai.mockable
+        def query_emails(sender: str) -> list:
+            return ["local result"]
+
+        # Wire the three backend endpoints
+        respx.post(_INITSESSION_ENDPOINT).mock(
+            return_value=httpx.Response(
+                201, json={"session_id": "sess-1", "session_name": "test"},
+            )
+        )
+        respx.post(_INIT_FIXTURES_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"initialized": True, "fixture_ids": [],
+                      "tools_snapshotted": ["query_emails"],
+                      "already_initialized": False},
+            )
+        )
+        respx.post(_SYNC_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"synced": True, "stats": {}}),
+        )
+        mock_call_route = respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"return_value": ["mocked email"],
+                      "tier": "PYTHON", "was_mocked": True},
+            )
+        )
+
+        # Start session with datasetitem_id (the tool-backed signal)
+        client.sessions.create(
+            session_name="test", datasetitem_id="ditm-1",
+        )
+
+        # Invoke the decorated tool — should hit the backend
+        result = query_emails("alice@example.com")
+        assert result == ["mocked email"]
+        assert mock_call_route.call_count == 1
+
+        # Auto-sync should have fired once (registry had query_emails when
+        # the tool-backed session started)
+        assert len(respx.calls) >= 3  # initsession + init-fixtures + sync + mock-call


### PR DESCRIPTION
Linear: [LUC-608](https://linear.app/lucidic/issue/LUC-608/sdk-33-clienttools-namespace-session-init-wiring-first-session-sync)

- Final foundation ticket: wires LUC-577 registry + LUC-607 transport into the `LucidicAI` lifecycle. After this, a client agent that `@lucidic.mockable`-decorates a function gets full v2 tool-backed dispatch with zero additional plumbing when running under a tool-backed Dataset.
- New `client.tools` (`ToolsResource`): registry, `sync()`, `snapshot()`, `@client.tools.mockable` canonical decorator, lifecycle hooks (`_init_session`, `_maybe_sync_on_session_start` with SHA256 fingerprint debounce).
- `MockContext` + `current_mock_context` contextvar — bound by `ToolsResource._init_session` after a successful `/sdk/session-init-fixtures`. `@mockable` wrappers read it on every call to decide route-through-backend vs fast-path. ContextVar gives per-task isolation for async agent runs.
- `SessionResource.create()` / `acreate()` auto-fire `/sdk/session-init-fixtures` when `datasetitem_id` is passed (the tool-backed signal). NEVER raises — session creation can't be blocked by tool init failures.
- Module-level `lucidic.mockable` as the ergonomic passthrough. Decorations before any `LucidicAI` exists buffer; the next client init drains via `drain_buffer_into(self)`.

Files:
- `lucidicai/sdk/tools/context.py` (new) — `MockContext` + contextvar + bind/clear
- `lucidicai/sdk/tools/resource.py` (new) — `ToolsResource` (the `client.tools` namespace)
- `lucidicai/sdk/tools/mockable.py` — rewire wrapper to call transport when mock context bound
- `lucidicai/sdk/tools/__init__.py` — public re-exports
- `lucidicai/api/resources/agent_tools_sync.py` (new) — thin POST wrapper
- `lucidicai/api/resources/session_init_fixtures.py` (new) — thin POST wrapper
- `lucidicai/api/resources/session.py` — auto-call session-init-fixtures from create()/acreate()
- `lucidicai/client.py` — `tools` property + drain pre-init buffer in `__init__`
- `lucidicai/__init__.py` — re-export `mockable`
- `tests/sdk/tools/test_context.py` (new) — 5 tests
- `tests/sdk/tools/test_resource.py` (new) — 17 tests
- `tests/sdk/tools/test_mockable_dispatch.py` (new) — 8 tests
- `tests/sdk/tools/test_session_wiring.py` (new) — 5 end-to-end integration tests
- `tests/sdk/tools/conftest.py` + `tests/api/resources/conftest.py` — autouse contextvar isolation between tests
