### PR TITLE
LUC-579: [SDK] OpenAI function calling adapter

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -51,6 +51,11 @@ from .api.resources.prompt import Prompt
 
 # Tool dispatch (v2 tool-backed)
 from .sdk.tools import mockable
+from .sdk.tools.adapters import (
+    adispatch_openai_tool_call,
+    dispatch_openai_tool_call,
+    register_openai_tools,
+)
 
 # Integrations
 from .integrations.livekit import setup_livekit
@@ -87,6 +92,10 @@ __all__ = [
     "Prompt",
     # Tool dispatch (v2 tool-backed)
     "mockable",
+    # OpenAI adapter (LUC-579)
+    "adispatch_openai_tool_call",
+    "dispatch_openai_tool_call",
+    "register_openai_tools",
     # Integrations
     "setup_livekit",
     # Version

--- a/lucidicai/sdk/tools/adapters/__init__.py
+++ b/lucidicai/sdk/tools/adapters/__init__.py
@@ -1,0 +1,42 @@
+"""Framework-specific adapter modules for the v2 tool-backed dispatch chain.
+
+Each adapter exposes two surfaces:
+
+- ``register_*_tools(tools)`` — discover tool surfaces from the
+  framework's native shape (OpenAI / Anthropic JSON specs, LangChain
+  ``BaseTool`` instances) and register them via
+  ``lucidicai.sdk.tools.registry.register_tool``. Buffers when no
+  ``LucidicAI`` client is alive yet; the next client init drains.
+
+- ``dispatch_*_tool_call(call, impls)`` (+ async sibling) — route one
+  tool invocation through ``emit_call_through_backend`` when a
+  ``MockContext`` is bound to the current execution context, else
+  invoke ``impls[name]`` directly. This is the user-side dispatch
+  helper for frameworks (OpenAI, Anthropic) where the framework
+  doesn't own the Python function pointer.
+
+LangChain is the exception: ``register_langchain_agent`` transparently
+replaces ``tool.func`` (or ``tool._run``) with a mockable wrapper, so
+the framework's own dispatch loop routes through us — no user-side
+``dispatch_*`` call needed.
+
+All adapters share the helpers in ``..registry`` (``ToolSurface``,
+``_params_from_json_schema``, ``_params_from_callable``,
+``_compute_source_hash``, ``register_tool``) and the transport in
+``..transport`` (``emit_call_through_backend`` /
+``aemit_call_through_backend``) so the on-wire shape and the
+dispatch behavior are uniform across frameworks.
+"""
+
+from .openai import (
+    adispatch_openai_tool_call,
+    dispatch_openai_tool_call,
+    register_openai_tools,
+)
+
+
+__all__ = [
+    "adispatch_openai_tool_call",
+    "dispatch_openai_tool_call",
+    "register_openai_tools",
+]

--- a/lucidicai/sdk/tools/adapters/openai.py
+++ b/lucidicai/sdk/tools/adapters/openai.py
@@ -1,0 +1,338 @@
+"""OpenAI function-calling adapter (LUC-579).
+
+Two surfaces:
+
+1. ``register_openai_tools(tools)`` — walks the ``tools=`` list passed
+   to ``openai.chat.completions.create``. Each ``{"type": "function",
+   "function": {...}}`` entry becomes a ``ToolSurface``. Non-function
+   entries (``code_interpreter``, ``file_search``, etc.) are skipped
+   silently. Reuses the shared ``_params_from_json_schema`` helper
+   from ``registry.py`` so the on-wire signature shape is identical
+   to ``@mockable`` + Anthropic + LangChain adapters.
+
+2. ``dispatch_openai_tool_call(call, impls)`` (+ async sibling) — the
+   user-side dispatch helper. OpenAI hands us JSON tool calls; the
+   actual Python implementations live in user code (``impls`` dict).
+   When a ``MockContext`` is bound, route through the transport
+   (PASS_THROUGH / drift → fall back to ``impls[name]``). Otherwise
+   invoke ``impls[name]`` directly.
+
+The asymmetry with LangChain is structural — OpenAI's "tool" is a
+JSON Schema, not a Python callable we can wrap. The user holds the
+implementations and must invoke our dispatch helper at every dispatch
+site.
+
+Wire shape (frozen by the OpenAI client SDK):
+
+    TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": str,
+                "description": str,
+                "parameters": <JSON Schema>,
+            },
+        },
+        ...
+    ]
+
+    response.choices[0].message.tool_calls[i] has:
+        .id: str
+        .function.name: str
+        .function.arguments: str (JSON-encoded kwargs)
+
+We duck-type call extraction (attribute access or dict subscript) so
+this adapter works with both the official Pydantic-typed response
+objects and hand-rolled dict shapes used in tests.
+"""
+import hashlib
+import json
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+from ....core.errors import LucidicNotInitializedError
+from ...context import get_active_client
+from ..context import _current_mock_context
+from ..registry import (
+    ToolSurface,
+    _params_from_json_schema,
+    register_tool,
+)
+from ..transport import (
+    aemit_call_through_backend,
+    emit_call_through_backend,
+)
+
+if TYPE_CHECKING:
+    from ....client import LucidicAI
+
+
+logger = logging.getLogger("Lucidic")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_openai_tools(
+    tools: List[Dict[str, Any]],
+    *,
+    client: Optional["LucidicAI"] = None,
+) -> List[ToolSurface]:
+    """Register OpenAI function-calling tools for mockable dispatch.
+
+    Walks the ``tools=`` argument typically passed to
+    ``openai.chat.completions.create``. Each ``{"type": "function",
+    "function": {...}}`` entry becomes a ``ToolSurface`` registered via
+    the shared registry (LUC-577a) — either directly into the given
+    client's registry, or via the module-level buffer if no client
+    exists yet (the next ``LucidicAI(...)`` drains it).
+
+    Non-function entries (``code_interpreter``, ``file_search``,
+    ``web_search``, etc.) are silently skipped — they're not mockable
+    surfaces, just OpenAI-managed tools the model can invoke without
+    going through user code.
+
+    Re-registration is idempotent in the last-wins sense — same name
+    overwrites the prior surface (matches ``@mockable`` semantics).
+
+    Returns the list of ``ToolSurface`` instances that were registered
+    (useful for tests + REPL inspection; user code can ignore).
+
+    Args:
+        tools: The list passed to ``chat.completions.create(tools=...)``.
+        client: Optional explicit ``LucidicAI`` instance. When None,
+            registration uses the active client from the contextvar
+            (set by the most recent ``LucidicAI(...)`` construction).
+            Pass explicitly in multi-client processes where the active
+            context may not point at the right one.
+    """
+    surfaces: List[ToolSurface] = []
+    for entry in tools:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("type") != "function":
+            continue
+        spec = entry.get("function")
+        if not isinstance(spec, dict):
+            continue
+        surface = _surface_from_openai_function(spec)
+        surfaces.append(surface)
+        _register_into(surface, client)
+    logger.debug(
+        "[OpenAI adapter] registered %d/%d function tool(s)",
+        len(surfaces), len(tools),
+    )
+    return surfaces
+
+
+def _surface_from_openai_function(spec: Dict[str, Any]) -> ToolSurface:
+    """Build a ``ToolSurface`` from one OpenAI function spec.
+
+    ``source_hash`` is the canonical JSON encoding of the spec (sorted
+    keys, no whitespace). Means drift detection responds to ANY change
+    in the spec — name, description, parameters schema. The user's
+    Python impl is invisible to us at registration time, so impl-level
+    drift goes undetected (documented limitation; the ``@mockable``
+    decorator path catches both).
+    """
+    name = spec["name"]
+    docstring = spec.get("description", "") or ""
+    params = _params_from_json_schema(spec.get("parameters", {}) or {})
+    return ToolSurface(
+        name=name,
+        signature={"params": params, "return_type": None},
+        docstring=docstring,
+        return_shape=None,
+        source_hash=_compute_openai_source_hash(spec),
+    )
+
+
+def _compute_openai_source_hash(spec: Dict[str, Any]) -> str:
+    """SHA256 over the spec's canonical JSON form. Sort keys at every
+    level. Always 64-char lowercase hex (matches the backend's
+    expected shape via ``SyncAgentToolsSerializer``).
+    """
+    canonical = json.dumps(spec, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _register_into(
+    surface: ToolSurface, client: Optional["LucidicAI"],
+) -> None:
+    """Route ``register_tool`` through an explicit client or the active
+    contextvar.
+
+    If ``client`` is given, write directly into ``client.tools._registry``
+    — explicit binding wins over context detection (matches the
+    "instance-canonical, module passthrough" choice from LUC-608).
+    Otherwise fall through to the shared ``register_tool`` which uses
+    ``get_active_client()`` to find the right registry (or buffers).
+    """
+    if client is not None and hasattr(client, "tools"):
+        client.tools._registry[surface.name] = surface  # noqa: SLF001
+        return
+    register_tool(surface)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def dispatch_openai_tool_call(
+    call: Any,
+    impls: Dict[str, Callable[..., Any]],
+    *,
+    client: Optional["LucidicAI"] = None,
+    client_event_id: Optional[str] = None,
+) -> Any:
+    """Dispatch one OpenAI tool_call.
+
+    Two paths, decided by the ``MockContext`` bound to the current
+    execution context (set when a tool-backed session is created —
+    LUC-608):
+
+    - **No mock context** (normal observability / no session):
+      invoke ``impls[name](**kwargs)`` directly. Missing ``impls[name]``
+      raises ``KeyError`` — the user forgot to wire the implementation.
+
+    - **Mock context active**: route through ``emit_call_through_backend``
+      from the transport layer. PASS_THROUGH and drift fall back to
+      ``impls.get(name)`` (None is acceptable; the transport raises
+      ``LucidicMissingImplError`` if needed).
+
+    Args:
+        call: An OpenAI ``ChatCompletionMessageToolCall`` (or any
+            object / dict with ``.function.name`` + ``.function.arguments``).
+            ``arguments`` is a JSON string per the OpenAI spec; we
+            parse it here.
+        impls: Mapping from tool name → real Python implementation.
+            The user holds these; OpenAI's tools= ships only JSON
+            Schema. Required even in mock context — fallback paths
+            (PASS_THROUGH, drift) need it.
+        client: Optional explicit ``LucidicAI``. Defaults to the
+            contextvar-bound active client; raises
+            ``LucidicNotInitializedError`` if neither is available
+            AND a mock context is set (a dispatch request without
+            either is an unrecoverable config error).
+        client_event_id: Backend idempotency key. Auto-generated as a
+            fresh UUID per call when omitted.
+
+    Returns:
+        Whatever the resolved invocation returned — backend's
+        ``return_value`` for mocked calls, ``impls[name]``'s return
+        for the local paths.
+    """
+    name, kwargs = _extract_call(call)
+    ctx = _current_mock_context()
+
+    if ctx is None:
+        # No mock context bound. Run the local impl directly — missing
+        # impl is a natural KeyError that surfaces the user's bug.
+        return impls[name](**kwargs)
+
+    # Mock context active. Resolve the client for transport.
+    resolved_client = client or ctx.client
+    if resolved_client is None:
+        raise LucidicNotInitializedError()
+
+    real_fn = impls.get(name)
+    return emit_call_through_backend(
+        client=resolved_client,
+        session_id=ctx.session_id,
+        tool_name=name,
+        args=(),
+        kwargs=kwargs,
+        real_fn=real_fn,
+        client_event_id=client_event_id or str(uuid.uuid4()),
+    )
+
+
+async def adispatch_openai_tool_call(
+    call: Any,
+    impls: Dict[str, Callable[..., Any]],
+    *,
+    client: Optional["LucidicAI"] = None,
+    client_event_id: Optional[str] = None,
+) -> Any:
+    """Async sibling of ``dispatch_openai_tool_call``.
+
+    Same behavior matrix; awaits the async transport
+    (``aemit_call_through_backend``) and the async impl. The user's
+    ``impls[name]`` is expected to be an async callable when the
+    adapter is invoked via this path.
+    """
+    name, kwargs = _extract_call(call)
+    ctx = _current_mock_context()
+
+    if ctx is None:
+        return await impls[name](**kwargs)
+
+    resolved_client = client or ctx.client
+    if resolved_client is None:
+        raise LucidicNotInitializedError()
+
+    real_fn = impls.get(name)
+    return await aemit_call_through_backend(
+        client=resolved_client,
+        session_id=ctx.session_id,
+        tool_name=name,
+        args=(),
+        kwargs=kwargs,
+        real_fn=real_fn,
+        client_event_id=client_event_id or str(uuid.uuid4()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _extract_call(call: Any) -> Tuple[str, Dict[str, Any]]:
+    """Get ``(name, kwargs)`` from a Pydantic ``ChatCompletionMessageToolCall``
+    OR a hand-rolled dict.
+
+    Duck-typed so tests can construct fake calls with
+    ``SimpleNamespace`` and real client code can hand us the SDK's
+    typed objects. ``arguments`` is a JSON string per the OpenAI spec
+    — parsed here. Empty / malformed arguments default to ``{}``
+    rather than raising; backend will return ``invalid_kwargs`` if
+    the missing context matters.
+    """
+    if hasattr(call, "function"):
+        fn = call.function
+        name = fn.name if hasattr(fn, "name") else fn["name"]
+        raw_args = fn.arguments if hasattr(fn, "arguments") else fn["arguments"]
+    elif isinstance(call, dict):
+        fn = call["function"]
+        name = fn["name"]
+        raw_args = fn["arguments"]
+    else:
+        raise TypeError(
+            f"dispatch_openai_tool_call: expected ChatCompletionMessageToolCall "
+            f"or dict, got {type(call).__name__}"
+        )
+
+    if not raw_args:
+        return name, {}
+    try:
+        parsed = json.loads(raw_args)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "[OpenAI adapter] tool_call %r has un-parseable arguments %r; "
+            "passing empty kwargs",
+            name, raw_args,
+        )
+        return name, {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "[OpenAI adapter] tool_call %r arguments parsed to %s (expected "
+            "dict); passing empty kwargs",
+            name, type(parsed).__name__,
+        )
+        return name, {}
+    return name, parsed

--- a/lucidicai/sdk/tools/resource.py
+++ b/lucidicai/sdk/tools/resource.py
@@ -110,6 +110,59 @@ class ToolsResource:
         """
         self._registry[surface.name] = surface
 
+    # ==================== Framework adapters (LUC-578/579/580) ====================
+
+    def register_openai(self, tools: List[Dict[str, Any]]) -> List[ToolSurface]:
+        """Canonical instance-bound version of ``register_openai_tools``.
+
+        Walks the ``tools=`` list typically passed to
+        ``openai.chat.completions.create`` and registers each
+        function-typed entry into this client's registry. See
+        ``lucidicai.sdk.tools.adapters.openai.register_openai_tools``
+        for the full contract.
+        """
+        from .adapters.openai import register_openai_tools
+
+        return register_openai_tools(tools, client=self._client)
+
+    def dispatch_openai(
+        self,
+        call: Any,
+        impls: Dict[str, Callable],
+        *,
+        client_event_id: Optional[str] = None,
+    ) -> Any:
+        """Canonical instance-bound version of ``dispatch_openai_tool_call``.
+
+        Routes one OpenAI tool_call through the mock-call backend when
+        a ``MockContext`` is bound, otherwise invokes ``impls[name]``.
+        See ``lucidicai.sdk.tools.adapters.openai.dispatch_openai_tool_call``
+        for the full behavior matrix.
+        """
+        from .adapters.openai import dispatch_openai_tool_call
+
+        return dispatch_openai_tool_call(
+            call, impls,
+            client=self._client,
+            client_event_id=client_event_id,
+        )
+
+    async def adispatch_openai(
+        self,
+        call: Any,
+        impls: Dict[str, Callable],
+        *,
+        client_event_id: Optional[str] = None,
+    ) -> Any:
+        """Async sibling of ``dispatch_openai``."""
+        from .adapters.openai import adispatch_openai_tool_call
+
+        return await adispatch_openai_tool_call(
+            call, impls,
+            client=self._client,
+            client_event_id=client_event_id,
+        )
+
     def snapshot(self) -> List[ToolSurface]:
         """All registered surfaces in stable name order.
 

--- a/tests/sdk/tools/adapters/conftest.py
+++ b/tests/sdk/tools/adapters/conftest.py
@@ -1,0 +1,23 @@
+"""Isolation fixtures for adapter tests — clear contextvars between tests.
+
+Mirrors ``tests/sdk/tools/conftest.py``; without this, mock context
+or session bindings from one test leak into the next.
+"""
+import pytest
+
+from lucidicai.sdk.context import current_session_id
+from lucidicai.sdk.tools.context import current_mock_context
+from lucidicai.sdk.tools.registry import _PENDING_BUFFER, _REGISTRY
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_session_id.set(None)
+    current_mock_context.set(None)
+    yield
+    _REGISTRY.clear()
+    _PENDING_BUFFER.clear()
+    current_session_id.set(None)
+    current_mock_context.set(None)

--- a/tests/sdk/tools/adapters/test_openai.py
+++ b/tests/sdk/tools/adapters/test_openai.py
@@ -1,0 +1,391 @@
+"""Tests for ``lucidicai.sdk.tools.adapters.openai``.
+
+Covers surface extraction from OpenAI's nested ``{type: function,
+function: {...}}`` shape, registration into client + module-level
+buffer paths, and the user-side ``dispatch_*_tool_call`` helpers
+(sync + async, with + without mock context, drift fallback,
+missing-impl behavior, malformed argument strings).
+
+Network is mocked at the HTTP boundary via respx — the adapter
+exercises the real transport layer, not stubs, so the contract
+between adapter and transport is also pinned here.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.sdk.tools.adapters.openai import (
+    _compute_openai_source_hash,
+    _extract_call,
+    _surface_from_openai_function,
+    adispatch_openai_tool_call,
+    dispatch_openai_tool_call,
+    register_openai_tools,
+)
+from lucidicai.sdk.tools.context import (
+    MockContext,
+    bind_mock_context,
+)
+from lucidicai.sdk.tools.registry import _PENDING_BUFFER, _REGISTRY
+
+
+_MOCK_CALL_ENDPOINT = "https://stub.lucidic.test/sdk/mock-call"
+
+
+# ---------- Surface extraction -------------------------------------------
+
+
+def _spec(name="query_emails", **extra):
+    s = {
+        "name": name,
+        "description": extra.pop("description", "Get emails"),
+        "parameters": extra.pop("parameters", {
+            "type": "object",
+            "properties": {"sender": {"type": "string"}},
+            "required": ["sender"],
+        }),
+    }
+    s.update(extra)
+    return s
+
+
+class TestSurfaceExtraction:
+    def test_basic_function_spec(self):
+        surface = _surface_from_openai_function(_spec())
+        assert surface.name == "query_emails"
+        assert surface.docstring == "Get emails"
+        assert surface.signature["return_type"] is None
+        assert surface.signature["params"] == [
+            {"name": "sender", "type": "string", "default": None, "required": True},
+        ]
+        assert len(surface.source_hash) == 64
+
+    def test_missing_description_empty(self):
+        spec = _spec()
+        del spec["description"]
+        surface = _surface_from_openai_function(spec)
+        assert surface.docstring == ""
+
+    def test_no_parameters_empty_params(self):
+        surface = _surface_from_openai_function({
+            "name": "no_args_tool", "description": "",
+        })
+        assert surface.signature["params"] == []
+
+    def test_with_default_value(self):
+        spec = _spec(parameters={
+            "type": "object",
+            "properties": {
+                "sender": {"type": "string"},
+                "limit": {"type": "integer", "default": 50},
+            },
+            "required": ["sender"],
+        })
+        params = _surface_from_openai_function(spec).signature["params"]
+        assert params[1] == {
+            "name": "limit", "type": "integer", "default": 50, "required": False,
+        }
+
+    def test_source_hash_stable_across_calls(self):
+        spec = _spec()
+        h1 = _compute_openai_source_hash(spec)
+        h2 = _compute_openai_source_hash(spec)
+        assert h1 == h2
+
+    def test_source_hash_changes_on_spec_change(self):
+        spec_a = _spec()
+        spec_b = _spec(description="Different description")
+        assert _compute_openai_source_hash(spec_a) != _compute_openai_source_hash(spec_b)
+
+    def test_source_hash_independent_of_dict_order(self):
+        # sort_keys=True guarantees order-insensitive hashing
+        spec_a = {"name": "t", "description": "d", "parameters": {}}
+        spec_b = {"description": "d", "parameters": {}, "name": "t"}
+        assert _compute_openai_source_hash(spec_a) == _compute_openai_source_hash(spec_b)
+
+
+# ---------- register_openai_tools ----------------------------------------
+
+
+class TestRegisterOpenAITools:
+    def test_registers_function_entries(self):
+        TOOLS = [{"type": "function", "function": _spec()}]
+        surfaces = register_openai_tools(TOOLS)
+        assert len(surfaces) == 1
+        assert surfaces[0].name == "query_emails"
+        # Buffered into module-level registry (no client active in tests)
+        assert "query_emails" in _REGISTRY
+
+    def test_skips_non_function_entries(self):
+        TOOLS = [
+            {"type": "function", "function": _spec(name="real_tool")},
+            {"type": "code_interpreter"},
+            {"type": "file_search"},
+            {"type": "web_search"},
+        ]
+        surfaces = register_openai_tools(TOOLS)
+        assert [s.name for s in surfaces] == ["real_tool"]
+
+    def test_idempotent_reregister_last_wins(self):
+        spec_a = _spec(description="version 1")
+        spec_b = _spec(description="version 2")
+        register_openai_tools([{"type": "function", "function": spec_a}])
+        register_openai_tools([{"type": "function", "function": spec_b}])
+        # Same name → last-wins
+        assert "query_emails" in _REGISTRY
+        assert _REGISTRY["query_emails"].docstring == "version 2"
+
+    def test_skips_malformed_entries(self):
+        TOOLS = [
+            "not a dict",
+            {"type": "function"},  # no `function` key
+            {"type": "function", "function": "not a dict"},
+            {"type": "function", "function": _spec(name="good")},
+        ]
+        surfaces = register_openai_tools(TOOLS)
+        assert [s.name for s in surfaces] == ["good"]
+
+    def test_explicit_client_writes_directly(self):
+        from types import SimpleNamespace
+        fake_registry = {}
+        fake_tools = SimpleNamespace(_registry=fake_registry)
+        fake_client = SimpleNamespace(tools=fake_tools)
+        TOOLS = [{"type": "function", "function": _spec()}]
+        register_openai_tools(TOOLS, client=fake_client)
+        # Goes to the explicit client's registry, NOT the module-level
+        # buffer
+        assert "query_emails" in fake_registry
+        assert "query_emails" not in _REGISTRY
+
+
+# ---------- _extract_call ------------------------------------------------
+
+
+class TestExtractCall:
+    def test_pydantic_style_attribute_access(self):
+        call = SimpleNamespace(
+            function=SimpleNamespace(
+                name="t",
+                arguments=json.dumps({"x": 1}),
+            ),
+        )
+        name, kwargs = _extract_call(call)
+        assert name == "t"
+        assert kwargs == {"x": 1}
+
+    def test_plain_dict_style(self):
+        call = {"function": {"name": "t", "arguments": json.dumps({"x": 2})}}
+        name, kwargs = _extract_call(call)
+        assert name == "t"
+        assert kwargs == {"x": 2}
+
+    def test_empty_arguments_yields_empty_kwargs(self):
+        call = SimpleNamespace(function=SimpleNamespace(name="t", arguments=""))
+        name, kwargs = _extract_call(call)
+        assert kwargs == {}
+
+    def test_malformed_arguments_yields_empty(self, caplog):
+        import logging
+        call = SimpleNamespace(function=SimpleNamespace(
+            name="t", arguments="not json",
+        ))
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            name, kwargs = _extract_call(call)
+        assert kwargs == {}
+        assert any("un-parseable arguments" in r.message for r in caplog.records)
+
+    def test_non_dict_parsed_arguments_yields_empty(self, caplog):
+        import logging
+        # arguments is a valid JSON value but not an object — e.g. a string
+        call = SimpleNamespace(function=SimpleNamespace(
+            name="t", arguments=json.dumps([1, 2, 3]),
+        ))
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            name, kwargs = _extract_call(call)
+        assert kwargs == {}
+
+    def test_unsupported_call_type_raises(self):
+        with pytest.raises(TypeError, match="expected ChatCompletionMessageToolCall"):
+            _extract_call(42)
+
+
+# ---------- dispatch_openai_tool_call ------------------------------------
+
+
+def _make_call(name="query", **kwargs):
+    return SimpleNamespace(
+        function=SimpleNamespace(name=name, arguments=json.dumps(kwargs)),
+    )
+
+
+class TestDispatchNoContext:
+    def test_runs_impl_directly(self):
+        call = _make_call(name="hello", who="world")
+
+        def hello(who):
+            return f"hi {who}"
+
+        result = dispatch_openai_tool_call(call, impls={"hello": hello})
+        assert result == "hi world"
+
+    def test_missing_impl_raises_keyerror(self):
+        call = _make_call(name="ghost")
+        with pytest.raises(KeyError, match="ghost"):
+            dispatch_openai_tool_call(call, impls={})
+
+
+class TestDispatchWithContext:
+    @respx.mock
+    def test_routes_through_backend(self, stub_client):
+        bind_mock_context(MockContext(session_id="sess-1", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": "mocked-result", "tier": "PYTHON",
+                           "was_mocked": True},
+            )
+        )
+        call = _make_call(name="any_tool", x=5)
+
+        def real_impl(x):
+            return "would-have-been-real"
+
+        result = dispatch_openai_tool_call(call, impls={"any_tool": real_impl})
+        assert result == "mocked-result"
+
+    @respx.mock
+    def test_pass_through_falls_back_to_impl(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": None, "tier": "PASS_THROUGH",
+                           "was_mocked": False},
+            )
+        )
+        call = _make_call(name="t", x=10)
+
+        def real_impl(x):
+            return x * 100
+
+        result = dispatch_openai_tool_call(call, impls={"t": real_impl})
+        assert result == 1000  # local impl ran
+
+    @respx.mock
+    def test_drift_logs_warning_falls_back(self, stub_client, caplog):
+        import logging
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                409, json={"error": {"code": "tool_drift",
+                                     "detail": "...",
+                                     "session_hash": "aaa12345",
+                                     "current_hash": "bbb12345"}},
+            )
+        )
+        call = _make_call(name="t", x=2)
+
+        def real_impl(x):
+            return x + 100
+
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            result = dispatch_openai_tool_call(call, impls={"t": real_impl})
+        assert result == 102
+        assert any("drift" in r.message.lower() for r in caplog.records)
+
+    @respx.mock
+    def test_explicit_client_overrides_context(self, stub_client):
+        # Context has a different (fake) client; explicit kwarg wins
+        from types import SimpleNamespace as SN
+        other_client = SN(_resources={"mock_calls": stub_client._resources["mock_calls"]})
+        bind_mock_context(MockContext(session_id="s", client=other_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": 42, "tier": "PYTHON",
+                           "was_mocked": True},
+            )
+        )
+        call = _make_call(name="t")
+        result = dispatch_openai_tool_call(
+            call, impls={"t": lambda: 0}, client=stub_client,
+        )
+        assert result == 42
+
+
+# ---------- adispatch_openai_tool_call -----------------------------------
+
+
+class TestAsyncDispatch:
+    @pytest.mark.asyncio
+    async def test_runs_async_impl_no_context(self):
+        call = _make_call(name="t", x=4)
+
+        async def aimpl(x):
+            return x * 2
+
+        result = await adispatch_openai_tool_call(call, impls={"t": aimpl})
+        assert result == 8
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_routes_with_context(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": "from-backend",
+                           "tier": "PYTHON", "was_mocked": True},
+            )
+        )
+        call = _make_call(name="t")
+
+        async def aimpl():
+            return "from-local"
+
+        result = await adispatch_openai_tool_call(call, impls={"t": aimpl})
+        assert result == "from-backend"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_pass_through(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": None, "tier": "PASS_THROUGH",
+                           "was_mocked": False},
+            )
+        )
+        call = _make_call(name="t", x=3)
+
+        async def aimpl(x):
+            return x * 5
+
+        result = await adispatch_openai_tool_call(call, impls={"t": aimpl})
+        assert result == 15
+
+
+# ---------- client.tools.register_openai / dispatch_openai ---------------
+
+
+class TestInstanceBoundSurface:
+    """The canonical ``client.tools.register_openai`` / ``dispatch_openai``
+    methods delegate to the module-level adapter functions. Use a real
+    LucidicAI (production=True to skip API-key verify) so ``client.tools``
+    resolves via the actual property."""
+
+    def test_register_via_client(self, monkeypatch):
+        monkeypatch.setenv("LUCIDIC_DEBUG", "false")
+        monkeypatch.setenv("LUCIDIC_BASE_URL", "https://stub.lucidic.test")
+        from lucidicai import LucidicAI
+
+        client = LucidicAI(
+            api_key="test-key",
+            agent_id="00000000-0000-0000-0000-000000000000",
+            production=True,
+        )
+        surfaces = client.tools.register_openai([
+            {"type": "function", "function": _spec(name="instance_tool")},
+        ])
+        assert [s.name for s in surfaces] == ["instance_tool"]
+        assert "instance_tool" in client.tools._registry


### PR DESCRIPTION
Linear: [LUC-579](https://linear.app/lucidic/issue/LUC-579/sdk-openai-function-calling-adapter)

- `register_openai_tools(tools)` walks the `tools=` list passed to `chat.completions.create`, registers each `{type: function, function: {...}}` entry. Non-function entries (code_interpreter, file_search, etc.) skipped silently. Last-wins on re-registration.
- `dispatch_openai_tool_call(call, impls)` + `adispatch_openai_tool_call` — user-side dispatch helpers. With mock context bound: route through `emit_call_through_backend` from LUC-607 (PASS_THROUGH and drift fall back to `impls[name]`). Without context: invoke `impls[name]` directly. Missing impl raises natural `KeyError`.
- Duck-types the call object so both Pydantic `ChatCompletionMessageToolCall` (real OpenAI SDK) and hand-rolled dicts (tests) work via the same dispatch helper.
- Source hash is sha256 over canonical JSON of the spec (sort_keys, no whitespace). Spec-level drift surfaces; impl-level drift in the user's Python code is invisible (documented limitation — `@mockable` decorator path catches both).

Public surface (instance-canonical + module passthroughs, matching LUC-608's convention):
- `lucidic.register_openai_tools(tools)`
- `lucidic.dispatch_openai_tool_call(call, impls)` / `adispatch_openai_tool_call`
- `client.tools.register_openai(tools)`
- `client.tools.dispatch_openai(call, impls)` / `adispatch_openai`

Files:
- `lucidicai/sdk/tools/adapters/__init__.py` (new) — package + re-exports
- `lucidicai/sdk/tools/adapters/openai.py` (new) — adapter implementation
- `lucidicai/sdk/tools/resource.py` — `client.tools.register_openai` / `dispatch_openai` / `adispatch_openai`
- `lucidicai/__init__.py` — module-level re-exports
- `tests/sdk/tools/adapters/test_openai.py` (new) — 28 tests covering surface extraction, registration (skips/idempotency/explicit client), call extraction (Pydantic + dict + malformed), sync + async dispatch, drift fallback, instance-bound API
- `tests/sdk/tools/adapters/conftest.py` (new) — contextvar isolation
