### PR TITLE
LUC-580: [SDK] Anthropic tool blocks adapter

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -52,8 +52,11 @@ from .api.resources.prompt import Prompt
 # Tool dispatch (v2 tool-backed)
 from .sdk.tools import mockable
 from .sdk.tools.adapters import (
+    adispatch_anthropic_tool_call,
     adispatch_openai_tool_call,
+    dispatch_anthropic_tool_call,
     dispatch_openai_tool_call,
+    register_anthropic_tools,
     register_openai_tools,
 )
 
@@ -96,6 +99,10 @@ __all__ = [
     "adispatch_openai_tool_call",
     "dispatch_openai_tool_call",
     "register_openai_tools",
+    # Anthropic adapter (LUC-580)
+    "adispatch_anthropic_tool_call",
+    "dispatch_anthropic_tool_call",
+    "register_anthropic_tools",
     # Integrations
     "setup_livekit",
     # Version

--- a/lucidicai/sdk/tools/adapters/__init__.py
+++ b/lucidicai/sdk/tools/adapters/__init__.py
@@ -28,6 +28,11 @@ All adapters share the helpers in ``..registry`` (``ToolSurface``,
 dispatch behavior are uniform across frameworks.
 """
 
+from .anthropic import (
+    adispatch_anthropic_tool_call,
+    dispatch_anthropic_tool_call,
+    register_anthropic_tools,
+)
 from .openai import (
     adispatch_openai_tool_call,
     dispatch_openai_tool_call,
@@ -36,7 +41,12 @@ from .openai import (
 
 
 __all__ = [
+    # OpenAI (LUC-579)
     "adispatch_openai_tool_call",
     "dispatch_openai_tool_call",
     "register_openai_tools",
+    # Anthropic (LUC-580)
+    "adispatch_anthropic_tool_call",
+    "dispatch_anthropic_tool_call",
+    "register_anthropic_tools",
 ]

--- a/lucidicai/sdk/tools/adapters/anthropic.py
+++ b/lucidicai/sdk/tools/adapters/anthropic.py
@@ -1,0 +1,303 @@
+"""Anthropic tool-blocks adapter (LUC-580).
+
+Near-clone of the OpenAI adapter (LUC-579) with two structural
+differences:
+
+1. **Flat tool spec**: Anthropic's ``tools=`` entries are
+   ``{name, description, input_schema}`` at the top level — no
+   ``{type: function, function: {...}}`` nesting like OpenAI. We
+   accept that flat shape directly.
+
+2. **Parsed ``input`` dict**: Anthropic's ``ToolUseBlock.input`` is
+   already a Python dict (unlike OpenAI's ``ChatCompletionMessageToolCall
+   .function.arguments`` which is a JSON-encoded string). No
+   ``json.loads`` needed.
+
+Two surfaces, matching LUC-579 conventions:
+
+- ``register_anthropic_tools(tools)`` — walks ``tools=`` from
+  ``messages.create``, registers each into the active client's
+  registry (or buffers if no client). Same last-wins semantics.
+
+- ``dispatch_anthropic_tool_call(block, impls)`` (+ async sibling)
+  — user-side dispatch. With a mock context: route through transport.
+  Without: invoke ``impls[name]`` directly.
+
+Source hash strategy is identical to LUC-579: sha256 over canonical
+JSON of the spec. Same documented limitation that impl-level drift
+(user's Python impl changing) is invisible to spec-level drift
+detection.
+
+Wire shape (frozen by the Anthropic client SDK):
+
+    TOOLS = [
+        {
+            "name": str,
+            "description": str,
+            "input_schema": <JSON Schema>,
+        },
+        ...
+    ]
+
+    message.content[i] when block.type == "tool_use":
+        .id: str (e.g. "toolu_01ABC")
+        .name: str
+        .input: dict (already parsed)
+"""
+import hashlib
+import json
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+from ....core.errors import LucidicNotInitializedError
+from ..context import _current_mock_context
+from ..registry import (
+    ToolSurface,
+    _params_from_json_schema,
+    register_tool,
+)
+from ..transport import (
+    aemit_call_through_backend,
+    emit_call_through_backend,
+)
+
+if TYPE_CHECKING:
+    from ....client import LucidicAI
+
+
+logger = logging.getLogger("Lucidic")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_anthropic_tools(
+    tools: List[Dict[str, Any]],
+    *,
+    client: Optional["LucidicAI"] = None,
+) -> List[ToolSurface]:
+    """Register Anthropic tools for mockable dispatch.
+
+    Walks the ``tools=`` argument typically passed to
+    ``anthropic.Anthropic().messages.create``. Each entry becomes a
+    ``ToolSurface`` registered via the shared registry (LUC-577a) —
+    either directly into the given client's registry, or via the
+    module-level buffer if no client exists yet.
+
+    Skips malformed entries (non-dict, missing ``name``) silently —
+    matches the lenient handling in the OpenAI adapter so a single
+    bad entry doesn't break registration of valid ones.
+
+    Returns the list of registered ``ToolSurface`` instances.
+
+    Args:
+        tools: The list passed to ``messages.create(tools=...)``.
+        client: Optional explicit ``LucidicAI`` instance. When None,
+            registration uses the active client from the contextvar.
+            Pass explicitly in multi-client processes.
+    """
+    surfaces: List[ToolSurface] = []
+    for spec in tools:
+        if not isinstance(spec, dict):
+            continue
+        if not spec.get("name"):
+            continue
+        surface = _surface_from_anthropic_tool(spec)
+        surfaces.append(surface)
+        _register_into(surface, client)
+    logger.debug(
+        "[Anthropic adapter] registered %d/%d tool(s)",
+        len(surfaces), len(tools),
+    )
+    return surfaces
+
+
+def _surface_from_anthropic_tool(spec: Dict[str, Any]) -> ToolSurface:
+    """Build a ``ToolSurface`` from one Anthropic tool spec.
+
+    ``source_hash`` is the canonical JSON encoding of the spec —
+    matches the LUC-579 strategy. Drift detection responds to any
+    spec change (name, description, input_schema). Impl-level drift
+    in the user's Python is invisible (documented limitation).
+    """
+    name = spec["name"]
+    docstring = spec.get("description", "") or ""
+    params = _params_from_json_schema(spec.get("input_schema", {}) or {})
+    return ToolSurface(
+        name=name,
+        signature={"params": params, "return_type": None},
+        docstring=docstring,
+        return_shape=None,
+        source_hash=_compute_anthropic_source_hash(spec),
+    )
+
+
+def _compute_anthropic_source_hash(spec: Dict[str, Any]) -> str:
+    """SHA256 over the spec's canonical JSON form. Sort keys at every
+    level for determinism."""
+    canonical = json.dumps(spec, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _register_into(
+    surface: ToolSurface, client: Optional["LucidicAI"],
+) -> None:
+    """Route ``register_tool`` through an explicit client or the active
+    contextvar — mirrors the OpenAI adapter's logic."""
+    if client is not None and hasattr(client, "tools"):
+        client.tools._registry[surface.name] = surface  # noqa: SLF001
+        return
+    register_tool(surface)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def dispatch_anthropic_tool_call(
+    block: Any,
+    impls: Dict[str, Callable[..., Any]],
+    *,
+    client: Optional["LucidicAI"] = None,
+    client_event_id: Optional[str] = None,
+) -> Any:
+    """Dispatch one Anthropic ``tool_use`` block.
+
+    Two paths, decided by the ``MockContext`` bound to the current
+    execution context (LUC-608):
+
+    - **No mock context** (normal observability / no session):
+      invoke ``impls[name](**input)`` directly. Missing impl raises
+      a natural ``KeyError``.
+
+    - **Mock context active**: route through ``emit_call_through_backend``
+      from the transport layer. PASS_THROUGH and drift fall back to
+      ``impls.get(name)``.
+
+    Args:
+        block: An Anthropic ``ToolUseBlock`` (or any object / dict
+            with ``.name`` + ``.input``). ``input`` is already a dict
+            in the official SDK; we don't parse JSON.
+        impls: Mapping from tool name → real implementation. Required
+            even in mock context for fallback paths.
+        client: Optional explicit ``LucidicAI``. Defaults to the
+            contextvar-bound active client.
+        client_event_id: Backend idempotency key. Auto-generated UUID
+            when omitted.
+    """
+    name, kwargs = _extract_block(block)
+    ctx = _current_mock_context()
+
+    if ctx is None:
+        return impls[name](**kwargs)
+
+    resolved_client = client or ctx.client
+    if resolved_client is None:
+        raise LucidicNotInitializedError()
+
+    real_fn = impls.get(name)
+    return emit_call_through_backend(
+        client=resolved_client,
+        session_id=ctx.session_id,
+        tool_name=name,
+        args=(),
+        kwargs=kwargs,
+        real_fn=real_fn,
+        client_event_id=client_event_id or str(uuid.uuid4()),
+    )
+
+
+async def adispatch_anthropic_tool_call(
+    block: Any,
+    impls: Dict[str, Callable[..., Any]],
+    *,
+    client: Optional["LucidicAI"] = None,
+    client_event_id: Optional[str] = None,
+) -> Any:
+    """Async sibling of ``dispatch_anthropic_tool_call``.
+
+    Awaits the async transport (``aemit_call_through_backend``) and
+    the async impl. ``impls[name]`` is expected to be an async
+    callable when invoked via this path.
+    """
+    name, kwargs = _extract_block(block)
+    ctx = _current_mock_context()
+
+    if ctx is None:
+        return await impls[name](**kwargs)
+
+    resolved_client = client or ctx.client
+    if resolved_client is None:
+        raise LucidicNotInitializedError()
+
+    real_fn = impls.get(name)
+    return await aemit_call_through_backend(
+        client=resolved_client,
+        session_id=ctx.session_id,
+        tool_name=name,
+        args=(),
+        kwargs=kwargs,
+        real_fn=real_fn,
+        client_event_id=client_event_id or str(uuid.uuid4()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _extract_block(block: Any) -> Tuple[str, Dict[str, Any]]:
+    """Get ``(name, input_dict)`` from a Pydantic ``ToolUseBlock`` OR
+    a hand-rolled dict.
+
+    Anthropic's block has fields at the top level (no ``.function``
+    nesting like OpenAI). ``.input`` is already a parsed dict — no
+    JSON parsing needed.
+
+    Duck-typed so tests can use ``SimpleNamespace`` fakes and real
+    client code can hand us the SDK's typed objects.
+    """
+    if isinstance(block, dict):
+        name = block.get("name")
+        raw_input = block.get("input")
+    else:
+        name = getattr(block, "name", None)
+        raw_input = getattr(block, "input", None)
+
+    if not name or not isinstance(name, str):
+        raise TypeError(
+            f"dispatch_anthropic_tool_call: block must have a 'name' "
+            f"string field; got {type(block).__name__}"
+        )
+
+    if raw_input is None:
+        return name, {}
+    if isinstance(raw_input, dict):
+        return name, raw_input
+    # Defensive: if the SDK changes to ship `input` as a JSON string
+    # (some experimental Anthropic flows do this for streaming), try
+    # to parse. Fall back to empty kwargs on parse failure.
+    if isinstance(raw_input, str):
+        try:
+            parsed = json.loads(raw_input)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "[Anthropic adapter] tool_use %r has un-parseable input "
+                "string %r; passing empty kwargs",
+                name, raw_input,
+            )
+            return name, {}
+        if isinstance(parsed, dict):
+            return name, parsed
+
+    logger.warning(
+        "[Anthropic adapter] tool_use %r input is %s (expected dict); "
+        "passing empty kwargs",
+        name, type(raw_input).__name__,
+    )
+    return name, {}

--- a/lucidicai/sdk/tools/resource.py
+++ b/lucidicai/sdk/tools/resource.py
@@ -163,6 +163,60 @@ class ToolsResource:
             client_event_id=client_event_id,
         )
 
+    # ----- Anthropic adapter (LUC-580) -----
+
+    def register_anthropic(self, tools: List[Dict[str, Any]]) -> List[ToolSurface]:
+        """Canonical instance-bound version of ``register_anthropic_tools``.
+
+        Walks the ``tools=`` list typically passed to
+        ``anthropic.Anthropic().messages.create`` and registers each
+        entry into this client's registry. See
+        ``lucidicai.sdk.tools.adapters.anthropic.register_anthropic_tools``
+        for the full contract.
+        """
+        from .adapters.anthropic import register_anthropic_tools
+
+        return register_anthropic_tools(tools, client=self._client)
+
+    def dispatch_anthropic(
+        self,
+        block: Any,
+        impls: Dict[str, Callable],
+        *,
+        client_event_id: Optional[str] = None,
+    ) -> Any:
+        """Canonical instance-bound version of ``dispatch_anthropic_tool_call``.
+
+        Routes one Anthropic ``tool_use`` block through the mock-call
+        backend when a ``MockContext`` is bound, otherwise invokes
+        ``impls[name]``. See
+        ``lucidicai.sdk.tools.adapters.anthropic.dispatch_anthropic_tool_call``
+        for the full behavior matrix.
+        """
+        from .adapters.anthropic import dispatch_anthropic_tool_call
+
+        return dispatch_anthropic_tool_call(
+            block, impls,
+            client=self._client,
+            client_event_id=client_event_id,
+        )
+
+    async def adispatch_anthropic(
+        self,
+        block: Any,
+        impls: Dict[str, Callable],
+        *,
+        client_event_id: Optional[str] = None,
+    ) -> Any:
+        """Async sibling of ``dispatch_anthropic``."""
+        from .adapters.anthropic import adispatch_anthropic_tool_call
+
+        return await adispatch_anthropic_tool_call(
+            block, impls,
+            client=self._client,
+            client_event_id=client_event_id,
+        )
+
     def snapshot(self) -> List[ToolSurface]:
         """All registered surfaces in stable name order.
 

--- a/tests/sdk/tools/adapters/test_anthropic.py
+++ b/tests/sdk/tools/adapters/test_anthropic.py
@@ -1,0 +1,299 @@
+"""Tests for ``lucidicai.sdk.tools.adapters.anthropic``.
+
+Covers surface extraction from Anthropic's flat ``{name, description,
+input_schema}`` shape, registration into client + module-level buffer
+paths, and the user-side ``dispatch_*_tool_call`` helpers (sync + async,
+with + without mock context, drift fallback, input-shape variants).
+
+Symmetric to ``test_openai.py`` but pins the two structural differences:
+
+- Flat tool spec (no nesting under ``function``)
+- ``ToolUseBlock.input`` is already a dict (no JSON parsing needed)
+"""
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.sdk.tools.adapters.anthropic import (
+    _compute_anthropic_source_hash,
+    _extract_block,
+    _surface_from_anthropic_tool,
+    adispatch_anthropic_tool_call,
+    dispatch_anthropic_tool_call,
+    register_anthropic_tools,
+)
+from lucidicai.sdk.tools.context import MockContext, bind_mock_context
+from lucidicai.sdk.tools.registry import _REGISTRY
+
+
+_MOCK_CALL_ENDPOINT = "https://stub.lucidic.test/sdk/mock-call"
+
+
+def _spec(name="query_emails", **overrides):
+    s = {
+        "name": name,
+        "description": overrides.pop("description", "Get emails"),
+        "input_schema": overrides.pop("input_schema", {
+            "type": "object",
+            "properties": {"sender": {"type": "string"}},
+            "required": ["sender"],
+        }),
+    }
+    s.update(overrides)
+    return s
+
+
+# ---------- Surface extraction -------------------------------------------
+
+
+class TestSurfaceExtraction:
+    def test_basic_flat_spec(self):
+        surface = _surface_from_anthropic_tool(_spec())
+        assert surface.name == "query_emails"
+        assert surface.docstring == "Get emails"
+        assert surface.signature["return_type"] is None
+        assert surface.signature["params"] == [
+            {"name": "sender", "type": "string", "default": None, "required": True},
+        ]
+        assert len(surface.source_hash) == 64
+
+    def test_missing_description_empty(self):
+        spec = _spec()
+        del spec["description"]
+        assert _surface_from_anthropic_tool(spec).docstring == ""
+
+    def test_no_input_schema_empty_params(self):
+        spec = {"name": "no_args", "description": ""}
+        assert _surface_from_anthropic_tool(spec).signature["params"] == []
+
+    def test_with_default(self):
+        spec = _spec(input_schema={
+            "type": "object",
+            "properties": {
+                "sender": {"type": "string"},
+                "limit": {"type": "integer", "default": 50},
+            },
+            "required": ["sender"],
+        })
+        params = _surface_from_anthropic_tool(spec).signature["params"]
+        assert params[1] == {
+            "name": "limit", "type": "integer", "default": 50, "required": False,
+        }
+
+    def test_source_hash_stable(self):
+        spec = _spec()
+        assert _compute_anthropic_source_hash(spec) == _compute_anthropic_source_hash(spec)
+
+    def test_source_hash_changes_on_spec_change(self):
+        a = _spec()
+        b = _spec(description="different")
+        assert _compute_anthropic_source_hash(a) != _compute_anthropic_source_hash(b)
+
+    def test_source_hash_independent_of_key_order(self):
+        a = {"name": "t", "description": "d", "input_schema": {}}
+        b = {"input_schema": {}, "description": "d", "name": "t"}
+        assert _compute_anthropic_source_hash(a) == _compute_anthropic_source_hash(b)
+
+
+# ---------- register_anthropic_tools -------------------------------------
+
+
+class TestRegister:
+    def test_registers_flat_entries(self):
+        surfaces = register_anthropic_tools([_spec()])
+        assert [s.name for s in surfaces] == ["query_emails"]
+        assert "query_emails" in _REGISTRY
+
+    def test_skips_malformed_entries(self):
+        TOOLS = [
+            "not a dict",
+            {"description": "no name"},
+            _spec(name="good"),
+        ]
+        surfaces = register_anthropic_tools(TOOLS)
+        assert [s.name for s in surfaces] == ["good"]
+
+    def test_idempotent_last_wins(self):
+        register_anthropic_tools([_spec(description="v1")])
+        register_anthropic_tools([_spec(description="v2")])
+        assert _REGISTRY["query_emails"].docstring == "v2"
+
+    def test_explicit_client_writes_directly(self):
+        fake_registry = {}
+        fake_tools = SimpleNamespace(_registry=fake_registry)
+        fake_client = SimpleNamespace(tools=fake_tools)
+        register_anthropic_tools([_spec()], client=fake_client)
+        assert "query_emails" in fake_registry
+        assert "query_emails" not in _REGISTRY
+
+
+# ---------- _extract_block -----------------------------------------------
+
+
+class TestExtractBlock:
+    def test_pydantic_style_attribute_access(self):
+        block = SimpleNamespace(name="t", input={"x": 1})
+        name, kwargs = _extract_block(block)
+        assert name == "t"
+        assert kwargs == {"x": 1}
+
+    def test_plain_dict(self):
+        block = {"name": "t", "input": {"x": 2}}
+        name, kwargs = _extract_block(block)
+        assert name == "t"
+        assert kwargs == {"x": 2}
+
+    def test_missing_input_yields_empty(self):
+        block = SimpleNamespace(name="t", input=None)
+        name, kwargs = _extract_block(block)
+        assert kwargs == {}
+
+    def test_no_input_attr_at_all(self):
+        block = SimpleNamespace(name="t")
+        name, kwargs = _extract_block(block)
+        assert kwargs == {}
+
+    def test_string_input_falls_back_to_json_parse(self, caplog):
+        # Defensive code path: if Anthropic ever ships input as JSON string
+        # (e.g. streaming partial), try to parse.
+        block = SimpleNamespace(name="t", input=json.dumps({"x": 5}))
+        name, kwargs = _extract_block(block)
+        assert kwargs == {"x": 5}
+
+    def test_unparseable_string_input_logs_and_empty(self, caplog):
+        import logging
+        block = SimpleNamespace(name="t", input="not json")
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            name, kwargs = _extract_block(block)
+        assert kwargs == {}
+        assert any("un-parseable input" in r.message for r in caplog.records)
+
+    def test_non_dict_non_string_input_logs_and_empty(self, caplog):
+        import logging
+        block = SimpleNamespace(name="t", input=[1, 2, 3])
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            name, kwargs = _extract_block(block)
+        assert kwargs == {}
+
+    def test_missing_name_raises(self):
+        with pytest.raises(TypeError, match="must have a 'name'"):
+            _extract_block(SimpleNamespace(input={}))
+
+
+# ---------- dispatch_anthropic_tool_call (sync) --------------------------
+
+
+def _make_block(name="query", **input_kwargs):
+    return SimpleNamespace(name=name, input=input_kwargs)
+
+
+class TestDispatchNoContext:
+    def test_runs_impl_directly(self):
+        block = _make_block(name="hello", who="world")
+        def hello(who):
+            return f"hi {who}"
+        assert dispatch_anthropic_tool_call(block, impls={"hello": hello}) == "hi world"
+
+    def test_missing_impl_raises_keyerror(self):
+        block = _make_block(name="ghost")
+        with pytest.raises(KeyError, match="ghost"):
+            dispatch_anthropic_tool_call(block, impls={})
+
+
+class TestDispatchWithContext:
+    @respx.mock
+    def test_routes_through_backend(self, stub_client):
+        bind_mock_context(MockContext(session_id="sess-1", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": "mocked-result", "tier": "PYTHON",
+                           "was_mocked": True},
+            )
+        )
+        block = _make_block(name="t", x=5)
+        result = dispatch_anthropic_tool_call(block, impls={"t": lambda x: x})
+        assert result == "mocked-result"
+
+    @respx.mock
+    def test_pass_through_runs_local(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": None, "tier": "PASS_THROUGH",
+                           "was_mocked": False},
+            )
+        )
+        block = _make_block(name="t", x=10)
+        def real(x):
+            return x * 100
+        assert dispatch_anthropic_tool_call(block, impls={"t": real}) == 1000
+
+    @respx.mock
+    def test_drift_logs_warning_falls_back(self, stub_client, caplog):
+        import logging
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                409, json={"error": {"code": "tool_drift", "detail": "...",
+                                     "session_hash": "aaa12345",
+                                     "current_hash": "bbb12345"}},
+            )
+        )
+        block = _make_block(name="t", x=2)
+        def real(x):
+            return x + 100
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            result = dispatch_anthropic_tool_call(block, impls={"t": real})
+        assert result == 102
+        assert any("drift" in r.message.lower() for r in caplog.records)
+
+
+# ---------- adispatch_anthropic_tool_call (async) ------------------------
+
+
+class TestAsyncDispatch:
+    @pytest.mark.asyncio
+    async def test_runs_async_impl_no_context(self):
+        block = _make_block(name="t", x=4)
+        async def aimpl(x):
+            return x * 2
+        assert await adispatch_anthropic_tool_call(block, impls={"t": aimpl}) == 8
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_routes_with_context(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={"return_value": "from-backend", "tier": "PYTHON",
+                           "was_mocked": True},
+            )
+        )
+        block = _make_block(name="t")
+        async def aimpl():
+            return "from-local"
+        assert await adispatch_anthropic_tool_call(
+            block, impls={"t": aimpl},
+        ) == "from-backend"
+
+
+# ---------- Instance-bound surface ---------------------------------------
+
+
+class TestInstanceBoundSurface:
+    def test_register_via_client(self, monkeypatch):
+        monkeypatch.setenv("LUCIDIC_DEBUG", "false")
+        monkeypatch.setenv("LUCIDIC_BASE_URL", "https://stub.lucidic.test")
+        from lucidicai import LucidicAI
+
+        client = LucidicAI(
+            api_key="test-key",
+            agent_id="00000000-0000-0000-0000-000000000000",
+            production=True,
+        )
+        surfaces = client.tools.register_anthropic([_spec(name="instance_tool")])
+        assert [s.name for s in surfaces] == ["instance_tool"]
+        assert "instance_tool" in client.tools._registry


### PR DESCRIPTION
Linear: [LUC-580](https://linear.app/lucidic/issue/LUC-580/sdk-anthropic-tool-blocks-adapter)

- Near-clone of LUC-579 with two structural differences: Anthropic uses a flat `{name, description, input_schema}` spec (no nesting under `function`), and `ToolUseBlock.input` is already a parsed dict (no `json.loads` like OpenAI's `arguments` string).
- `register_anthropic_tools(tools)` registers each entry. Same skip-malformed + last-wins semantics as the OpenAI path.
- `dispatch_anthropic_tool_call(block, impls)` + `adispatch_anthropic_tool_call` — same dispatch matrix: mock-context routes via transport (PASS_THROUGH and drift fall back to `impls[name]`), no-context invokes `impls[name]` directly with natural `KeyError` on missing impl.
- `_extract_block` defensively handles a JSON-string `input` shape (some experimental streaming flows ship it that way) — parses and falls back to empty kwargs on failure.

Verified end-to-end via `_luc580_smoke.py` against real `anthropic.types.ToolUseBlock` objects (synthetic mode). Live API path is wired but hit an account-balance issue at test time; the type-compatibility check is what the smoke validates.

Public surface (instance-canonical + module passthroughs):
- `lucidic.register_anthropic_tools(tools)`
- `lucidic.dispatch_anthropic_tool_call(block, impls)` / `adispatch_anthropic_tool_call`
- `client.tools.register_anthropic(tools)`
- `client.tools.dispatch_anthropic(block, impls)` / `adispatch_anthropic`

Files:
- `lucidicai/sdk/tools/adapters/anthropic.py` (new)
- `lucidicai/sdk/tools/adapters/__init__.py` — re-export
- `lucidicai/sdk/tools/resource.py` — `client.tools.{register,dispatch,adispatch}_anthropic`
- `lucidicai/__init__.py` — module-level re-exports
- `tests/sdk/tools/adapters/test_anthropic.py` (new) — 27 tests covering surface extraction, registration, block extraction (Pydantic + dict + string-input defensive path), dispatch with/without context, drift fallback, async
