### PR TITLE
LUC-578: [SDK] LangChain framework adapter

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -57,6 +57,7 @@ from .sdk.tools.adapters import (
     dispatch_anthropic_tool_call,
     dispatch_openai_tool_call,
     register_anthropic_tools,
+    register_langchain_tools,
     register_openai_tools,
 )
 
@@ -103,6 +104,8 @@ __all__ = [
     "adispatch_anthropic_tool_call",
     "dispatch_anthropic_tool_call",
     "register_anthropic_tools",
+    # LangChain adapter (LUC-578)
+    "register_langchain_tools",
     # Integrations
     "setup_livekit",
     # Version

--- a/lucidicai/sdk/tools/adapters/__init__.py
+++ b/lucidicai/sdk/tools/adapters/__init__.py
@@ -33,6 +33,7 @@ from .anthropic import (
     dispatch_anthropic_tool_call,
     register_anthropic_tools,
 )
+from .langchain import register_langchain_tools
 from .openai import (
     adispatch_openai_tool_call,
     dispatch_openai_tool_call,
@@ -49,4 +50,6 @@ __all__ = [
     "adispatch_anthropic_tool_call",
     "dispatch_anthropic_tool_call",
     "register_anthropic_tools",
+    # LangChain (LUC-578)
+    "register_langchain_tools",
 ]

--- a/lucidicai/sdk/tools/adapters/langchain.py
+++ b/lucidicai/sdk/tools/adapters/langchain.py
@@ -1,0 +1,288 @@
+"""LangChain framework adapter (LUC-578).
+
+Structurally different from the OpenAI / Anthropic adapters because
+LangChain hands us **Python callables** (``BaseTool.func``), not JSON
+specs. We can transparently replace the callable with a mockable
+wrapper — the framework's dispatch loop (``agent.invoke``,
+``tool.invoke``, ``tool._run``) calls our wrapper instead of the
+user's original function. No user-side ``dispatch_*`` helper needed.
+
+Single surface:
+
+- ``register_langchain_tools(tools)`` — walks a list of
+  ``BaseTool`` instances. For each: extracts the tool surface from
+  ``args_schema`` (Pydantic) + name + description, registers via
+  the shared registry, then replaces ``tool.func`` with a mockable
+  wrapper. Idempotent via the ``__lucidic_wrapped__`` sentinel that
+  ``make_mockable_wrapper`` stamps.
+
+Why no separate ``register_langchain_agent``: the modern (1.x)
+LangChain agent API doesn't expose ``agent.tools`` consistently across
+``AgentExecutor`` / ``RunnableAgent`` / ``langgraph`` paths. Asking
+the user to pass the tool list explicitly is one extra line and
+avoids LangChain-version-specific introspection. Add a thin agent
+walker later if a real workflow needs it.
+
+Pydantic schema → params: LangChain accepts both Pydantic v1 and v2
+args schemas. ``model_json_schema()`` is available on both in modern
+versions (v1 via the ``pydantic_v1`` compat shim). Using JSON Schema
+as the intermediate form lets us reuse ``_params_from_json_schema``
+from registry.py — same surface shape as OpenAI / Anthropic adapters.
+
+Source hash strategy combines the JSON schema (signature equivalent)
++ the tool's function source. Behavioral drift in the user's impl
+DOES surface here (unlike OpenAI / Anthropic adapters where we only
+see the spec) — LangChain hands us the actual Python function.
+
+Async tools (``tool.coroutine`` or ``StructuredTool.from_function(..., coroutine=...)``)
+are handled — ``make_mockable_wrapper`` sniffs ``iscoroutinefunction``
+on the wrapped callable and produces the matching wrapper. The
+``tool.coroutine`` field is wrapped separately from ``tool.func`` so
+both sync and async dispatch paths through LangChain route correctly.
+"""
+import hashlib
+import inspect
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+from ..mockable import make_mockable_wrapper
+from ..registry import (
+    ToolSurface,
+    _params_from_callable,
+    _params_from_json_schema,
+    _stringify_annotation,
+    register_tool,
+)
+
+if TYPE_CHECKING:
+    from ....client import LucidicAI
+
+
+logger = logging.getLogger("Lucidic")
+
+
+# ---------------------------------------------------------------------------
+# Registration + wrapping
+# ---------------------------------------------------------------------------
+
+
+def register_langchain_tools(
+    tools: List[Any],
+    *,
+    client: Optional["LucidicAI"] = None,
+) -> List[ToolSurface]:
+    """Register and wrap a list of LangChain ``BaseTool`` instances.
+
+    For each tool: extract a ``ToolSurface`` and register it, then
+    transparently replace ``tool.func`` (and ``tool.coroutine`` if
+    present) with a mockable wrapper. After this call, normal LangChain
+    dispatch (``tool.invoke(...)``, ``agent.invoke(...)``) routes
+    through our backend when a ``MockContext`` is bound, and runs the
+    original function otherwise.
+
+    Idempotent: re-registering the same tool is a no-op for the wrap
+    step (sentinel check via ``__lucidic_wrapped__``). The registry
+    side is last-wins as elsewhere.
+
+    Args:
+        tools: List of ``BaseTool`` instances (``Tool``, ``StructuredTool``,
+            or any ``BaseTool`` subclass with a ``.func`` attribute).
+        client: Optional explicit ``LucidicAI`` for the registry binding.
+            Defaults to the contextvar-bound active client.
+
+    Returns:
+        The list of ``ToolSurface`` instances captured. Order matches
+        the input list.
+    """
+    surfaces: List[ToolSurface] = []
+    for tool in tools:
+        # Skip non-tool objects defensively — tests + REPL workflows
+        # sometimes pass a mixed list.
+        if not _looks_like_basetool(tool):
+            logger.debug(
+                "[LangChain adapter] skipping %r — not a BaseTool",
+                type(tool).__name__,
+            )
+            continue
+
+        surface = _surface_from_langchain_tool(tool)
+        surfaces.append(surface)
+        _register_into(surface, client)
+        _wrap_tool_callables(tool, surface)
+
+    logger.debug(
+        "[LangChain adapter] registered %d/%d tool(s)",
+        len(surfaces), len(tools),
+    )
+    return surfaces
+
+
+def _looks_like_basetool(obj: Any) -> bool:
+    """Duck-type check for LangChain ``BaseTool`` shape.
+
+    Avoids a hard import of ``langchain_core.tools.BaseTool`` so the
+    SDK doesn't require LangChain at import time for users who don't
+    use it. The minimal contract: has ``name`` (str) and either
+    ``func`` or ``coroutine`` (callable).
+    """
+    name = getattr(obj, "name", None)
+    if not isinstance(name, str):
+        return False
+    func = getattr(obj, "func", None)
+    coro = getattr(obj, "coroutine", None)
+    return callable(func) or callable(coro)
+
+
+# ---------------------------------------------------------------------------
+# Surface extraction
+# ---------------------------------------------------------------------------
+
+
+def _surface_from_langchain_tool(tool: Any) -> ToolSurface:
+    """Build a ``ToolSurface`` for one ``BaseTool``.
+
+    Source for each field:
+
+    - ``name``: ``tool.name`` (required by ``BaseTool``).
+    - ``docstring``: ``tool.description`` (LangChain treats this as
+      the tool's docstring — same role as the OpenAI ``description``).
+    - ``signature.params``: ``tool.args_schema.model_json_schema()`` if
+      ``args_schema`` is set (the typical ``StructuredTool`` /
+      ``Tool(args_schema=...)`` path), otherwise inspect
+      ``tool.func`` directly via ``_params_from_callable``.
+    - ``signature.return_type``: stringified return annotation of
+      ``tool.func`` (best-effort; many LangChain tools don't annotate
+      and we end up with None).
+    - ``source_hash``: combines name + signature + body source. Body
+      source comes from ``inspect.getsource(tool.func)`` so drift
+      detection picks up behavioral changes — a real advantage over
+      the OpenAI / Anthropic adapters where we only see the spec.
+    """
+    name = tool.name
+    docstring = (tool.description or "") if hasattr(tool, "description") else ""
+    func = getattr(tool, "func", None) or getattr(tool, "coroutine", None)
+
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is not None and hasattr(args_schema, "model_json_schema"):
+        try:
+            params = _params_from_json_schema(args_schema.model_json_schema())
+        except Exception:
+            # Defensive: a v1 / v2 compat mismatch shouldn't kill
+            # registration. Fall back to callable introspection.
+            logger.warning(
+                "[LangChain adapter] args_schema.model_json_schema() failed "
+                "for tool %r; falling back to callable introspection",
+                name,
+            )
+            params = _params_from_callable(func) if callable(func) else []
+    elif callable(func):
+        params = _params_from_callable(func)
+    else:
+        params = []
+
+    return_type: Optional[str] = None
+    if callable(func):
+        try:
+            sig = inspect.signature(func)
+            return_type = _stringify_annotation(sig.return_annotation)
+        except (TypeError, ValueError):
+            return_type = None
+
+    body_source = ""
+    if callable(func):
+        try:
+            body_source = inspect.getsource(func)
+        except (OSError, TypeError):
+            body_source = ""
+
+    signature = {"params": params, "return_type": return_type}
+
+    return ToolSurface(
+        name=name,
+        signature=signature,
+        docstring=docstring,
+        return_shape=None,
+        source_hash=_compute_langchain_source_hash(
+            name=name,
+            signature=signature,
+            body_source=body_source,
+        ),
+    )
+
+
+def _compute_langchain_source_hash(
+    *,
+    name: str,
+    signature: dict,
+    body_source: str,
+) -> str:
+    """SHA256 over ``name + signature_json + body_source``.
+
+    Uses the same canonical encoding pattern as
+    ``registry._compute_source_hash`` but keyed on the LangChain
+    surface (signature derived from args_schema + body from
+    ``inspect.getsource``). Newlines in body normalized to ``\\n`` so
+    editor line-ending churn doesn't trip drift.
+    """
+    body = (body_source or "").replace("\r\n", "\n").replace("\r", "\n")
+    sig_json = json.dumps(signature, sort_keys=True, separators=(",", ":"))
+    payload = f"{name}\n{sig_json}\n{body}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# tool.func / tool.coroutine replacement
+# ---------------------------------------------------------------------------
+
+
+def _wrap_tool_callables(tool: Any, surface: ToolSurface) -> None:
+    """Replace ``tool.func`` and/or ``tool.coroutine`` with mockable wrappers.
+
+    Idempotent via the ``__lucidic_wrapped__`` sentinel that
+    ``make_mockable_wrapper`` stamps onto its output. Re-wrapping an
+    already-wrapped tool is a no-op — common in dev workflows where
+    the agent is re-instantiated on hot reload, or registration runs
+    inside a loop.
+
+    Each callable (sync ``func``, async ``coroutine``) is wrapped
+    independently so the right wrapper-flavor is produced. LangChain
+    dispatches to ``func`` for sync ``invoke()`` and ``coroutine`` for
+    ``ainvoke()``; both must route through us when mocking is active.
+    """
+    func = getattr(tool, "func", None)
+    if callable(func) and not getattr(func, "__lucidic_wrapped__", False):
+        try:
+            tool.func = make_mockable_wrapper(surface, func)
+        except (TypeError, AttributeError) as exc:
+            # Some BaseTool subclasses make `func` immutable (Pydantic
+            # frozen=True). Surface as a warning rather than silently
+            # failing — user can use @mockable directly or switch to a
+            # mutable Tool variant.
+            logger.warning(
+                "[LangChain adapter] couldn't replace tool.func on %r (%s); "
+                "this tool won't route through the backend. Decorate the "
+                "underlying function with @mockable instead.",
+                surface.name, exc,
+            )
+
+    coroutine = getattr(tool, "coroutine", None)
+    if callable(coroutine) and not getattr(coroutine, "__lucidic_wrapped__", False):
+        try:
+            tool.coroutine = make_mockable_wrapper(surface, coroutine)
+        except (TypeError, AttributeError) as exc:
+            logger.warning(
+                "[LangChain adapter] couldn't replace tool.coroutine on %r (%s)",
+                surface.name, exc,
+            )
+
+
+def _register_into(
+    surface: ToolSurface, client: Optional["LucidicAI"],
+) -> None:
+    """Route ``register_tool`` through an explicit client or the active
+    contextvar — mirrors the OpenAI + Anthropic adapter logic."""
+    if client is not None and hasattr(client, "tools"):
+        client.tools._registry[surface.name] = surface  # noqa: SLF001
+        return
+    register_tool(surface)

--- a/lucidicai/sdk/tools/mockable.py
+++ b/lucidicai/sdk/tools/mockable.py
@@ -96,40 +96,33 @@ def _capture_surface(func: Callable) -> ToolSurface:
     )
 
 
-def mockable(func: F) -> F:
-    """Mark ``func`` as a mockable tool.
+def make_mockable_wrapper(surface: ToolSurface, func: Callable) -> Callable:
+    """Build the mockable dispatch wrapper for ``func`` against ``surface``.
 
-    Captures the surface at decoration time (raises ``LucidicError`` on
-    invalid input) and returns a wrapper that — in the v1 of this ticket
-    — runs the original function unchanged. The dispatch-intercept layer
-    is wired into this wrapper by LUC-577c once the
-    ``_current_mock_context()`` machinery exists.
+    Decoupled from ``mockable`` so framework adapters (LUC-578 LangChain)
+    can reuse the same wrapper logic when they already have a captured
+    surface (from the framework's own tool spec) and an underlying
+    Python callable from the framework that needs to be wrapped.
 
-    Sniffs ``async def`` via ``inspect.iscoroutinefunction`` and returns
-    the matching wrapper. Attaches ``__lucidic_surface__: ToolSurface``
-    to the wrapper for introspection.
+    Behavior matches the ``@mockable`` decorator:
 
-    Example::
+    - **No mock context**: wrapper runs ``func`` unchanged.
+    - **Mock context active**: routes through transport (sync or async
+      depending on ``func`` shape).
 
-        @mockable
-        def query_unread_emails(sender: str, limit: int = 50) -> list[dict]:
-            ...
+    Marks the wrapper with ``__lucidic_surface__`` (the ``ToolSurface``)
+    and ``__lucidic_wrapped__ = True`` (idempotency sentinel — adapters
+    use this to skip re-wrapping already-wrapped tools).
 
-        query_unread_emails.__lucidic_surface__  # → ToolSurface(name="query_unread_emails", ...)
+    Sniffs async via ``inspect.iscoroutinefunction(func)``. Async funcs
+    get an async wrapper; sync funcs get a sync wrapper.
     """
-    surface = _capture_surface(func)
-    register_tool(surface)
-
     if inspect.iscoroutinefunction(func):
 
         @functools.wraps(func)
         async def awrapper(*args: Any, **kwargs: Any) -> Any:
             ctx = _current_mock_context()
             if ctx is None:
-                # Fast path: no mock context bound to this task. One
-                # contextvar lookup, then run the user's function
-                # unchanged. Hit every tool call in production sessions
-                # that aren't part of a tool-backed eval run.
                 return await func(*args, **kwargs)
             return await aemit_call_through_backend(
                 client=ctx.client,
@@ -142,7 +135,8 @@ def mockable(func: F) -> F:
             )
 
         awrapper.__lucidic_surface__ = surface  # type: ignore[attr-defined]
-        return awrapper  # type: ignore[return-value]
+        awrapper.__lucidic_wrapped__ = True  # type: ignore[attr-defined]
+        return awrapper
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -160,4 +154,29 @@ def mockable(func: F) -> F:
         )
 
     wrapper.__lucidic_surface__ = surface  # type: ignore[attr-defined]
-    return wrapper  # type: ignore[return-value]
+    wrapper.__lucidic_wrapped__ = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+def mockable(func: F) -> F:
+    """Mark ``func`` as a mockable tool.
+
+    Captures the surface at decoration time (raises ``LucidicError`` on
+    invalid input), registers it, and returns a dispatch wrapper that
+    consults ``_current_mock_context()`` at call time.
+
+    Sniffs ``async def`` via ``inspect.iscoroutinefunction`` and returns
+    the matching wrapper. Attaches ``__lucidic_surface__: ToolSurface``
+    to the wrapper for introspection.
+
+    Example::
+
+        @mockable
+        def query_unread_emails(sender: str, limit: int = 50) -> list[dict]:
+            ...
+
+        query_unread_emails.__lucidic_surface__  # → ToolSurface(name="query_unread_emails", ...)
+    """
+    surface = _capture_surface(func)
+    register_tool(surface)
+    return make_mockable_wrapper(surface, func)  # type: ignore[return-value]

--- a/lucidicai/sdk/tools/resource.py
+++ b/lucidicai/sdk/tools/resource.py
@@ -217,6 +217,26 @@ class ToolsResource:
             client_event_id=client_event_id,
         )
 
+    # ----- LangChain adapter (LUC-578) -----
+
+    def register_langchain_tools(self, tools: List[Any]) -> List[ToolSurface]:
+        """Canonical instance-bound version of ``register_langchain_tools``.
+
+        Walks a list of LangChain ``BaseTool`` instances. For each:
+        extracts the surface, registers it into this client's registry,
+        and transparently replaces ``tool.func`` (and ``tool.coroutine``
+        if present) with a mockable wrapper. After this call, normal
+        LangChain dispatch routes through our backend when a
+        ``MockContext`` is bound — no user-side ``dispatch_*`` helper
+        needed (LangChain owns the dispatch loop).
+
+        See ``lucidicai.sdk.tools.adapters.langchain.register_langchain_tools``
+        for the full contract.
+        """
+        from .adapters.langchain import register_langchain_tools
+
+        return register_langchain_tools(tools, client=self._client)
+
     def snapshot(self) -> List[ToolSurface]:
         """All registered surfaces in stable name order.
 

--- a/tests/sdk/tools/adapters/test_langchain.py
+++ b/tests/sdk/tools/adapters/test_langchain.py
@@ -1,0 +1,327 @@
+"""Tests for ``lucidicai.sdk.tools.adapters.langchain``.
+
+Covers surface extraction from both ``Tool`` (no ``args_schema``) and
+``StructuredTool`` (Pydantic ``args_schema``) shapes, transparent
+``tool.func`` replacement, idempotency of re-registration, and
+dispatch behavior via LangChain's own ``tool.invoke()`` path.
+
+LangChain is the most invasive adapter — it replaces the framework's
+function pointer, so these tests pin the contract that
+``tool.invoke(...)`` routes through our backend when a ``MockContext``
+is bound and runs the original callable otherwise.
+"""
+import asyncio
+
+import httpx
+import pytest
+import respx
+from langchain_core.tools import StructuredTool, Tool
+
+from lucidicai.sdk.tools.adapters.langchain import (
+    _compute_langchain_source_hash,
+    _looks_like_basetool,
+    _surface_from_langchain_tool,
+    register_langchain_tools,
+)
+from lucidicai.sdk.tools.context import MockContext, bind_mock_context
+from lucidicai.sdk.tools.registry import _REGISTRY
+
+
+_MOCK_CALL_ENDPOINT = "https://stub.lucidic.test/sdk/mock-call"
+
+
+# ---------- _looks_like_basetool -----------------------------------------
+
+
+class TestLooksLikeBasetool:
+    def test_real_tool_passes(self):
+        t = Tool(name="t", description="d", func=lambda x: x)
+        assert _looks_like_basetool(t) is True
+
+    def test_real_structured_tool_passes(self):
+        def fn(x: int) -> int:
+            """LangChain requires a docstring when no description given."""
+            return x
+        t = StructuredTool.from_function(func=fn)
+        assert _looks_like_basetool(t) is True
+
+    def test_plain_dict_rejected(self):
+        # dicts don't have .name as an attribute (only as a key), so they
+        # fail the duck-type check. Reject is the correct behavior — the
+        # caller meant to pass a BaseTool, not a raw dict.
+        assert _looks_like_basetool({"name": "t", "func": lambda: 0}) is False
+
+    def test_no_callable_rejected(self):
+        from types import SimpleNamespace
+        assert _looks_like_basetool(SimpleNamespace(name="x")) is False
+
+    def test_no_name_rejected(self):
+        assert _looks_like_basetool(lambda: 0) is False
+
+
+# ---------- Surface extraction -------------------------------------------
+
+
+class TestSurfaceExtraction:
+    def test_plain_tool_with_no_args_schema(self):
+        def query(q: str) -> str:
+            """Search."""
+            return q
+        t = Tool(name="query", description="Run a query", func=query)
+        surface = _surface_from_langchain_tool(t)
+        assert surface.name == "query"
+        assert surface.docstring == "Run a query"
+        # Plain Tool has no args_schema → fall back to callable introspection
+        assert surface.signature["params"] == [
+            {"name": "q", "type": "str", "default": None, "required": True},
+        ]
+        assert surface.signature["return_type"] == "str"
+        assert len(surface.source_hash) == 64
+
+    def test_structured_tool_uses_args_schema(self):
+        def get_weather(city: str, unit: str = "celsius") -> dict:
+            """Weather."""
+            return {}
+        t = StructuredTool.from_function(
+            func=get_weather, name="get_weather",
+            description="Get the weather",
+        )
+        surface = _surface_from_langchain_tool(t)
+        assert surface.name == "get_weather"
+        assert surface.docstring == "Get the weather"
+        # StructuredTool synthesizes a Pydantic args_schema; JSON schema
+        # type strings ("string") not Python types ("str") — the
+        # _params_from_json_schema path was taken.
+        names = [p["name"] for p in surface.signature["params"]]
+        assert names == ["city", "unit"]
+        types = {p["name"]: p["type"] for p in surface.signature["params"]}
+        assert types["city"] == "string"
+        assert types["unit"] == "string"
+        # Defaults preserved
+        defaults = {p["name"]: p["default"] for p in surface.signature["params"]}
+        assert defaults["unit"] == "celsius"
+
+    def test_source_hash_stable(self):
+        sig = {"params": [], "return_type": None}
+        h1 = _compute_langchain_source_hash(
+            name="t", signature=sig, body_source="def t(): pass",
+        )
+        h2 = _compute_langchain_source_hash(
+            name="t", signature=sig, body_source="def t(): pass",
+        )
+        assert h1 == h2
+
+    def test_source_hash_picks_up_body_change(self):
+        """LangChain adapter is the only one that catches impl-level drift
+        because it has access to the user's actual function source."""
+        sig = {"params": [], "return_type": None}
+        h1 = _compute_langchain_source_hash(
+            name="t", signature=sig, body_source="def t(): return 1",
+        )
+        h2 = _compute_langchain_source_hash(
+            name="t", signature=sig, body_source="def t(): return 2",
+        )
+        assert h1 != h2
+
+
+# ---------- register_langchain_tools --------------------------------------
+
+
+class TestRegisterAndWrap:
+    def test_registers_into_module_buffer(self):
+        t = Tool(name="t1", description="", func=lambda x: x)
+        surfaces = register_langchain_tools([t])
+        assert [s.name for s in surfaces] == ["t1"]
+        assert "t1" in _REGISTRY
+
+    def test_skips_non_basetool_entries(self):
+        t = Tool(name="good", description="", func=lambda x: x)
+        surfaces = register_langchain_tools([t, "not a tool", 42, None])
+        assert [s.name for s in surfaces] == ["good"]
+
+    def test_wraps_tool_func_with_sentinel(self):
+        original_called = []
+        def original(x):
+            original_called.append(x)
+            return x * 2
+
+        t = Tool(name="t", description="", func=original)
+        # Pre-registration: not wrapped
+        assert not getattr(t.func, "__lucidic_wrapped__", False)
+
+        register_langchain_tools([t])
+        # Post-registration: wrapped + carries surface
+        assert getattr(t.func, "__lucidic_wrapped__", False) is True
+        assert hasattr(t.func, "__lucidic_surface__")
+
+        # Calling the wrapped func with no mock context runs the original
+        assert t.func(5) == 10
+        assert original_called == [5]
+
+    def test_invoke_via_langchain_runs_original_no_context(self):
+        def real(q):
+            return f"real:{q}"
+
+        t = Tool(name="t", description="", func=real)
+        register_langchain_tools([t])
+        # LangChain's invoke() goes through tool.func → our wrapper → no
+        # mock context → real fn
+        assert t.invoke({"q": "hello"}) == "real:hello"
+
+    def test_idempotent_rewrap(self):
+        t = Tool(name="t", description="", func=lambda x: x)
+        register_langchain_tools([t])
+        first_wrapper = t.func
+        register_langchain_tools([t])  # same tool registered again
+        # Sentinel check skips re-wrap; func unchanged
+        assert t.func is first_wrapper
+
+    def test_async_coroutine_wrapped_too(self):
+        async def aimpl(x):
+            return x + 1
+        # StructuredTool can take a coroutine for ainvoke()
+        st = StructuredTool.from_function(
+            func=lambda x: x, coroutine=aimpl,
+            name="dual", description="d",
+        )
+        register_langchain_tools([st])
+        assert getattr(st.func, "__lucidic_wrapped__", False) is True
+        assert getattr(st.coroutine, "__lucidic_wrapped__", False) is True
+
+
+# ---------- Dispatch through LangChain with mock context ------------------
+
+
+class TestDispatchWithContext:
+    @respx.mock
+    def test_invoke_routes_through_backend(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"return_value": "mocked-by-backend",
+                      "tier": "PYTHON", "was_mocked": True},
+            )
+        )
+        t = Tool(name="t", description="",
+                 func=lambda q: f"local:{q}")
+        register_langchain_tools([t])
+
+        # LangChain's tool.invoke goes through our wrapper now
+        result = t.invoke({"q": "hello"})
+        assert result == "mocked-by-backend"
+
+    @respx.mock
+    def test_invoke_pass_through_falls_back_local(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"return_value": None, "tier": "PASS_THROUGH",
+                      "was_mocked": False},
+            )
+        )
+        called = []
+        def real(q):
+            called.append(q)
+            return f"local:{q}"
+
+        t = Tool(name="t", description="", func=real)
+        register_langchain_tools([t])
+        result = t.invoke({"q": "x"})
+        assert result == "local:x"
+        assert called == ["x"]
+
+    @respx.mock
+    def test_invoke_drift_falls_back(self, stub_client, caplog):
+        import logging
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                409,
+                json={"error": {"code": "tool_drift", "detail": "drift",
+                                "session_hash": "aaa", "current_hash": "bbb"}},
+            )
+        )
+        t = Tool(name="t", description="", func=lambda q: f"local:{q}")
+        register_langchain_tools([t])
+        with caplog.at_level(logging.WARNING, logger="Lucidic"):
+            result = t.invoke({"q": "x"})
+        assert result == "local:x"
+        assert any("drift" in r.message.lower() for r in caplog.records)
+
+
+# ---------- Async dispatch -----------------------------------------------
+
+
+class TestAsyncDispatch:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ainvoke_routes_through_backend(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"return_value": "from-backend",
+                      "tier": "PYTHON", "was_mocked": True},
+            )
+        )
+
+        async def acoroutine(q: str) -> str:
+            return f"local-async:{q}"
+
+        st = StructuredTool.from_function(
+            func=lambda q: f"local-sync:{q}",
+            coroutine=acoroutine,
+            name="dual", description="d",
+        )
+        register_langchain_tools([st])
+        result = await st.ainvoke({"q": "x"})
+        assert result == "from-backend"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ainvoke_pass_through_runs_async_local(self, stub_client):
+        bind_mock_context(MockContext(session_id="s", client=stub_client))
+        respx.post(_MOCK_CALL_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={"return_value": None, "tier": "PASS_THROUGH",
+                      "was_mocked": False},
+            )
+        )
+
+        async def acoroutine(q):
+            return f"local-async:{q}"
+
+        st = StructuredTool.from_function(
+            func=lambda q: f"local-sync:{q}",
+            coroutine=acoroutine,
+            name="dual", description="d",
+        )
+        register_langchain_tools([st])
+        result = await st.ainvoke({"q": "y"})
+        assert result == "local-async:y"
+
+
+# ---------- Instance-bound surface ---------------------------------------
+
+
+class TestInstanceBoundSurface:
+    def test_register_via_client(self, monkeypatch):
+        monkeypatch.setenv("LUCIDIC_DEBUG", "false")
+        monkeypatch.setenv("LUCIDIC_BASE_URL", "https://stub.lucidic.test")
+        from lucidicai import LucidicAI
+
+        client = LucidicAI(
+            api_key="test-key",
+            agent_id="00000000-0000-0000-0000-000000000000",
+            production=True,
+        )
+        t = Tool(name="instance_tool", description="",
+                 func=lambda x: x)
+        surfaces = client.tools.register_langchain_tools([t])
+        assert [s.name for s in surfaces] == ["instance_tool"]
+        assert "instance_tool" in client.tools._registry
+        # tool.func still wrapped after instance-bound registration
+        assert getattr(t.func, "__lucidic_wrapped__", False) is True


### PR DESCRIPTION
Linear: [LUC-578](https://linear.app/lucidic/issue/LUC-578/sdk-langchain-framework-adapter)

- Most invasive adapter: transparently replaces `tool.func` (and `tool.coroutine` for async) on real `langchain_core.tools.BaseTool` instances. LangChain's own dispatch loop (`tool.invoke`, `llm.bind_tools`) calls our wrapper instead of the user's original function. No user-side `dispatch_*` helper needed.
- Refactored `mockable.py`: extracted `make_mockable_wrapper(surface, func)` as a shared helper so `@mockable` and the LangChain adapter use identical wrapper logic. Wrappers carry `__lucidic_surface__` + `__lucidic_wrapped__` (idempotency sentinel).
- Source hash uniquely catches impl-level drift here — unlike OpenAI/Anthropic where we only see the spec, LangChain hands us the actual Python function so `inspect.getsource` picks up behavioral changes.
- Async tools: `tool.coroutine` wrapped separately from `tool.func` so both `tool.invoke()` and `tool.ainvoke()` route correctly.

Public surface:
- `lucidic.register_langchain_tools(tools)`
- `client.tools.register_langchain_tools(tools)`

Verified via `_luc578_smoke.py`:
- **Synthetic**: real `Tool` + `StructuredTool` instances, `tool.invoke()` routes through wrapped `tool.func` to mocked backend
- **`--live`**: real `ChatOpenAI.bind_tools([tool]).invoke(...)` → AIMessage with tool_calls → `tool.invoke(call['args'])` → wrapped func → transport → mocked backend → returned `mocked_backend_live`. Full end-to-end against real LangChain 1.x + OpenAI.

Files:
- `lucidicai/sdk/tools/adapters/langchain.py` (new) — adapter
- `lucidicai/sdk/tools/mockable.py` — extracted `make_mockable_wrapper`
- `lucidicai/sdk/tools/adapters/__init__.py` — re-export
- `lucidicai/sdk/tools/resource.py` — `client.tools.register_langchain_tools`
- `lucidicai/__init__.py` — module-level re-export
- `tests/sdk/tools/adapters/test_langchain.py` (new) — 21 tests covering surface extraction (Tool + StructuredTool), wrap replacement, idempotency, dispatch through `tool.invoke`/`tool.ainvoke`, drift fallback
