### PR TITLE
LUC-616: stop SDK's own .env leaking into consumers

### DIFF
--- a/lucidicai/core/config.py
+++ b/lucidicai/core/config.py
@@ -181,8 +181,12 @@ class SDKConfig:
                       Falls back to LUCIDIC_BASE_URL env var.
             **overrides: Additional configuration overrides
         """
-        from dotenv import load_dotenv
-        load_dotenv()
+        from dotenv import load_dotenv, find_dotenv
+        # usecwd=True anchors the search at the consumer's working directory.
+        # The default walks up from this file's location, which for an
+        # editable install of the SDK finds the SDK's own .env first — that
+        # leaks dev-test settings (e.g. LUCIDIC_DEBUG=True) into consumers.
+        load_dotenv(find_dotenv(usecwd=True))
 
         debug = os.getenv("LUCIDIC_DEBUG", "False").lower() == "true"
 

--- a/lucidicai/sdk/features/feature_flag.py
+++ b/lucidicai/sdk/features/feature_flag.py
@@ -2,7 +2,7 @@ import os
 import logging
 import time
 from typing import Union, List, Dict, Any, Optional, overload, Tuple, Literal
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 from ..init import get_http
 from ...core.errors import APIKeyVerificationError, FeatureFlagError
@@ -135,7 +135,7 @@ def get_feature_flag(
         )
     """
 
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     
     # Determine if single or batch
     is_single = isinstance(flag_name, str)
@@ -482,7 +482,7 @@ async def aget_feature_flag(
         )
     """
 
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     
     # Determine if single or batch
     is_single = isinstance(flag_name, str)

--- a/lucidicai/utils/logger.py
+++ b/lucidicai/utils/logger.py
@@ -6,10 +6,14 @@ LUCIDIC_DEBUG and LUCIDIC_VERBOSE environment variables.
 import os
 import logging
 from typing import Any, Optional
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
-# Load environment variables from .env file
-load_dotenv()
+# Load environment variables from .env file.
+# usecwd=True anchors the search at the consumer's working directory.
+# The default walks up from this file's location, which for an editable
+# install of the SDK finds the SDK's own .env first and leaks dev-test
+# settings (e.g. LUCIDIC_DEBUG=True) into consumers.
+load_dotenv(find_dotenv(usecwd=True))
 
 # Configure base logger
 logging.basicConfig(


### PR DESCRIPTION
Linear: [LUC-616](https://linear.app/lucidic/issue/LUC-616/sdk-sdks-own-env-leaks-into-consumers-via-load-dotenv-editable)

## Summary

Pass `find_dotenv(usecwd=True)` to every `load_dotenv()` call in the SDK so the search anchors at the consumer's working directory, not at the SDK install location. Four call sites touched:

- `lucidicai/core/config.py` (during `SDKConfig.from_env`)
- `lucidicai/utils/logger.py` (module import)
- `lucidicai/sdk/features/feature_flag.py` (×2 — single + batch entry points)

## Bug

`python-dotenv`'s `find_dotenv()` (called implicitly by `load_dotenv()`) walks up not from `cwd` but from **the calling frame's file location** when the script has `__file__`. For an editable install (`pip install -e .` or `uv pip install -e <path>`), the SDK modules live at the developer's local repo path, so the walk finds the **SDK's own `.env`** before any consumer's `.env`.

A regular pip-wheel install doesn't hit this — the wheel directory has no `.env`. **Only editable installs leak.**

## Concrete impact

EnterpriseOps-Gym integration silently picked up `LUCIDIC_DEBUG="True"` from `~/Lucidic/Lucidic-Python/.env` (the SDK's own dev-test .env), which switched the SDK base URL to `http://localhost:8000/api` → `ConnectError: [Errno 61] Connection refused`. Took ~an hour to diagnose because nothing in the consumer repo, the consumer's CLI invocation, or the user's shell env had `LUCIDIC_DEBUG` set.

## Fix shape

```diff
-from dotenv import load_dotenv
-load_dotenv()
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv(usecwd=True))
```

`usecwd=True` forces `find_dotenv` to start at the consumer's working directory. Consumers' own `.env` still gets auto-loaded from their cwd (preserving current intent for wheel-install consumers); SDK's own `.env` no longer leaks.

## Alternative considered

Drop `load_dotenv()` from the SDK entirely and tell consumers to call it themselves. Rejected because it's a behavior break for existing wheel-install consumers who rely on the SDK's auto-loading.

## Test plan

- [x] With `LUCIDIC_DEBUG="True"` in the SDK's own `.env`, editable-install consumer's SDK init no longer flips to `http://localhost:8000/api`. Verified via inline script: `c._config.network.base_url == "https://backend.lucidic.ai/api"`.
- [x] Consumer's `.env` in cwd is still picked up (default `find_dotenv` behavior with `usecwd=True`).
- [ ] No regression in `lucidicai/utils/logger.py` early-init path — it runs before SDKConfig, but only reads env vars (LUCIDIC_DEBUG/LUCIDIC_VERBOSE) that `load_dotenv` populates.