### PR TITLE
LUC-617: coerce list-form JSON Schema types to a string in tool sync

### DIFF
--- a/lucidicai/sdk/tools/registry.py
+++ b/lucidicai/sdk/tools/registry.py
@@ -215,9 +215,18 @@ def _params_from_json_schema(schema: dict) -> list[dict]:
     for prop_name, prop_schema in (schema.get("properties") or {}).items():
         if not isinstance(prop_schema, dict):
             prop_schema = {}
+        # JSON Schema allows "type" to be a string OR a list of strings (the
+        # standard convention for nullable params: ["string", "null"]). The
+        # backend's SyncAgentToolsSerializer requires a string — coerce by
+        # dropping "null" and taking the first remaining type. Falls back to
+        # "any" if the list is empty or contains only "null".
+        prop_type = prop_schema.get("type", "any")
+        if isinstance(prop_type, list):
+            non_null = [t for t in prop_type if t != "null"]
+            prop_type = non_null[0] if non_null else "any"
         out.append({
             "name": prop_name,
-            "type": prop_schema.get("type", "any"),
+            "type": prop_type,
             "default": prop_schema.get("default"),
             "required": prop_name in required,
         })


### PR DESCRIPTION
Linear: [LUC-617](https://linear.app/lucidic/issue/LUC-617/sdk-params-from-json-schema-rejects-list-form-json-schema-type)

Stacked on #65 (LUC-565 M6 Tool System) — same as #66, since `sdk/tools/registry.py` is introduced there.

## Bug

`_params_from_json_schema` passes JSON Schema `"type"` through verbatim. JSON Schema allows `"type"` to be a string OR a list of strings (the convention for nullable params: `["string", "null"]`). Backend's `SyncAgentToolsSerializer` requires a string and rejects lists — fails the entire batch in one transaction.

## Concrete impact

EnterpriseOps-Gym integration: HR MCP server has ~30 tools, at least one with nullable params via `["string", "null"]`. Auto-sync fires, backend 400s, transaction rolls back, **zero HR tools land in the backend**.

```
HTTP 400 validation: {'tools': {'26': {'signature': {'params': {'2': {'type': ['Not a valid string.']}, '3': {'type': ['Not a valid string.']}}}}}}
```

## Fix

In `_params_from_json_schema`, coerce list types to a string before emitting:

```python
prop_type = prop_schema.get("type", "any")
if isinstance(prop_type, list):
    non_null = [t for t in prop_type if t != "null"]
    prop_type = non_null[0] if non_null else "any"
```

Drops `"null"` (JSON Schema's nullable convention), takes the first remaining type, falls back to `"any"` if empty or `["null"]` only.

Affects all three adapters using the helper (openai/anthropic/mcp). OpenAI/Anthropic schemas usually use single-string types so unaffected in practice; MCP servers in the wild use list-form more often.

## Test plan

- [x] `["string", "null"]` → `"string"`
- [x] `["null"]` → `"any"`
- [x] `"string"` unchanged
- [x] missing → `"any"`
- [x] `["integer", "string"]` (rare non-null union) → first type (`"integer"`)
- [ ] EnterpriseOps-Gym smoke re-run: HR tool catalog (~30 tools) lands in backend without 400