### PR TITLE
LUC-729: Add Training Modules SDK support

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -45,6 +45,7 @@ from .core.errors import (
     LucidicMissingImplError,
     LucidicUnsupportedSQLError,
 )
+from .sdk.training_modules import TrainingModulesResource
 
 # Prompt object
 from .api.resources.prompt import Prompt
@@ -65,7 +66,7 @@ from .sdk.tools.adapters import (
 from .integrations.livekit import setup_livekit
 
 # Version
-__version__ = "3.6.0"
+__version__ = "3.7.0"
 
 # All exports
 __all__ = [
@@ -92,6 +93,7 @@ __all__ = [
     "LucidicImplError",
     "LucidicMissingImplError",
     "LucidicUnsupportedSQLError",
+    "TrainingModulesResource",
     # Prompt object
     "Prompt",
     # Tool dispatch (v2 tool-backed)

--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -54,6 +54,7 @@ class SessionResource:
         tags: Optional[List[str]] = None,
         experiment_id: Optional[str] = None,
         datasetitem_id: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
         evaluators: Optional[List[str]] = None,
         auto_end: Optional[bool] = None,
         production_monitoring: bool = False,
@@ -69,6 +70,7 @@ class SessionResource:
             tags: List of tags for filtering/grouping.
             experiment_id: Link session to an experiment.
             datasetitem_id: Link session to a dataset item.
+            checkpoint_id: Load an immutable Training Modules checkpoint.
             evaluators: List of evaluator names to run.
             auto_end: Override client's auto_end setting for this session.
             production_monitoring: Enable lightweight production monitoring.
@@ -118,6 +120,8 @@ class SessionResource:
             session_params["experiment_id"] = experiment_id
         if datasetitem_id:
             session_params["datasetitem_id"] = datasetitem_id
+        if checkpoint_id:
+            session_params["checkpoint_id"] = checkpoint_id
         if evaluators:
             session_params["evaluators"] = evaluators
         if production_monitoring:
@@ -178,6 +182,7 @@ class SessionResource:
         tags: Optional[List[str]] = None,
         experiment_id: Optional[str] = None,
         datasetitem_id: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
         evaluators: Optional[List[str]] = None,
         auto_end: Optional[bool] = None,
         production_monitoring: bool = False,
@@ -219,6 +224,8 @@ class SessionResource:
             session_params["experiment_id"] = experiment_id
         if datasetitem_id:
             session_params["datasetitem_id"] = datasetitem_id
+        if checkpoint_id:
+            session_params["checkpoint_id"] = checkpoint_id
         if evaluators:
             session_params["evaluators"] = evaluators
         if production_monitoring:

--- a/lucidicai/api/resources/training_modules.py
+++ b/lucidicai/api/resources/training_modules.py
@@ -1,0 +1,138 @@
+"""Training Modules SDK HTTP resource.
+
+Thin wrappers over the backend inference-time Training Modules endpoints:
+
+- GET /sdk/training-modules/tools
+- POST /sdk/training-modules/inferences
+- GET /sdk/training-modules/inferences/{inference_run_id}
+"""
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+from ..client import HttpClient
+from ...core.errors import LucidicError
+
+logger = logging.getLogger("Lucidic")
+
+
+class TrainingModulesAPIResource:
+    """HTTP-only Training Modules resource.
+
+    High-level polling and tool-spec shaping live in
+    ``lucidicai.sdk.training_modules.resource.TrainingModulesResource``.
+    This class only knows the backend endpoint shapes.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def list_tools(self, *, session_id: str) -> Dict[str, Any]:
+        """Return module tools available to the session's loaded checkpoint."""
+        try:
+            return self.http.get(
+                "sdk/training-modules/tools",
+                {"session_id": session_id},
+            )
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_training_module_error(exc)) from exc
+
+    async def alist_tools(self, *, session_id: str) -> Dict[str, Any]:
+        """Async sibling of ``list_tools``."""
+        try:
+            return await self.http.aget(
+                "sdk/training-modules/tools",
+                {"session_id": session_id},
+            )
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_training_module_error(exc)) from exc
+
+    def submit_inference(
+        self,
+        *,
+        session_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        client_event_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create or replay a Training Module inference run."""
+        body: Dict[str, Any] = {
+            "session_id": session_id,
+            "tool_name": tool_name,
+            "arguments": arguments,
+        }
+        if client_event_id is not None:
+            body["client_event_id"] = client_event_id
+        try:
+            return self.http.post("sdk/training-modules/inferences", body)
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_training_module_error(exc)) from exc
+
+    async def asubmit_inference(
+        self,
+        *,
+        session_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        client_event_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Async sibling of ``submit_inference``."""
+        body: Dict[str, Any] = {
+            "session_id": session_id,
+            "tool_name": tool_name,
+            "arguments": arguments,
+        }
+        if client_event_id is not None:
+            body["client_event_id"] = client_event_id
+        try:
+            return await self.http.apost("sdk/training-modules/inferences", body)
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_training_module_error(exc)) from exc
+
+    def get_inference(
+        self,
+        *,
+        inference_run_id: str,
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Fetch an existing Training Module inference run."""
+        params = {"session_id": session_id} if session_id else None
+        try:
+            return self.http.get(
+                f"sdk/training-modules/inferences/{inference_run_id}",
+                params,
+            )
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_training_module_error(exc)) from exc
+
+    async def aget_inference(
+        self,
+        *,
+        inference_run_id: str,
+        session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Async sibling of ``get_inference``."""
+        params = {"session_id": session_id} if session_id else None
+        try:
+            return await self.http.aget(
+                f"sdk/training-modules/inferences/{inference_run_id}",
+                params,
+            )
+        except httpx.HTTPStatusError as exc:
+            raise LucidicError(_format_training_module_error(exc)) from exc
+
+
+def _format_training_module_error(exc: httpx.HTTPStatusError) -> str:
+    """Best-effort human-readable Training Modules error."""
+    try:
+        body = exc.response.json()
+    except ValueError:
+        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
+
+    if isinstance(body, dict):
+        if "error" in body:
+            return f"HTTP {exc.response.status_code}: {body['error']}"
+        if "errors" in body:
+            return f"HTTP {exc.response.status_code} validation: {body['errors']}"
+    return f"HTTP {exc.response.status_code}: {body!r}"

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -32,6 +32,7 @@ from .api.resources.prompt import PromptResource
 from .api.resources.feature_flag import FeatureFlagResource
 from .api.resources.evals import EvalsResource
 from .api.resources.mock_call import MockCallResource
+from .sdk.training_modules.resource import TrainingModulesResource
 from .sdk.tools.resource import ToolsResource
 from .core.config import SDKConfig
 from .core.errors import LucidicError
@@ -163,6 +164,8 @@ class LucidicAI:
             "mock_calls": MockCallResource(self._http, self._production),
         }
 
+        self._resources["training_modules"] = TrainingModulesResource(client=self)
+
         # LUC-608: client.tools — namespace for @mockable + adapter
         # registration. ToolsResource is constructed BEFORE the buffer
         # is drained so the client.tools property resolves correctly.
@@ -244,6 +247,16 @@ class LucidicAI:
         full API.
         """
         return self._resources["tools"]
+
+    @property
+    def training_modules(self) -> TrainingModulesResource:
+        """Access checkpoint-backed Training Module tools.
+
+        Use ``client.training_modules.tools()`` to discover module tool
+        schemas for the active session, and ``client.training_modules.call()``
+        to submit + poll a module inference as a normal tool result.
+        """
+        return self._resources["training_modules"]
 
     def _has_tools_resource(self) -> bool:
         """True when ``self.tools`` is wired up.

--- a/lucidicai/sdk/training_modules/__init__.py
+++ b/lucidicai/sdk/training_modules/__init__.py
@@ -1,0 +1,5 @@
+"""Training Modules SDK helpers."""
+
+from .resource import TrainingModulesResource
+
+__all__ = ["TrainingModulesResource"]

--- a/lucidicai/sdk/training_modules/resource.py
+++ b/lucidicai/sdk/training_modules/resource.py
@@ -1,0 +1,597 @@
+"""High-level Training Modules SDK namespace.
+
+``client.training_modules`` is the inference-time SDK surface for
+checkpoint-backed module tools. It hides backend inference-run bookkeeping
+on success and returns structured soft failures for agent-facing failures.
+"""
+import asyncio
+import json
+import logging
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+from ...api.resources.training_modules import TrainingModulesAPIResource
+from ...core.errors import LucidicError
+from ..context import current_session_id
+
+if TYPE_CHECKING:
+    from ...client import LucidicAI
+
+
+logger = logging.getLogger("Lucidic")
+
+ACTIVE_STATUSES = {"PENDING", "SUBMITTED", "RUNNING"}
+
+
+class TrainingModulesResource:
+    """User-facing ``client.training_modules`` namespace.
+
+    Main entry points:
+
+    - ``tools()`` / ``atools()`` list checkpoint module tools for a session.
+    - ``openai_tools()`` and ``anthropic_tools()`` convert those schemas to
+      provider-native tool specs.
+    - ``call()`` / ``acall()`` submit a module inference and poll until a
+      terminal result or SDK timeout.
+    """
+
+    def __init__(
+        self,
+        client: "LucidicAI",
+        *,
+        default_timeout_seconds: float = 300.0,
+        default_poll_interval_seconds: float = 1.0,
+    ):
+        self._client = client
+        self._api = TrainingModulesAPIResource(client._http)
+        self.default_timeout_seconds = default_timeout_seconds
+        self.default_poll_interval_seconds = default_poll_interval_seconds
+
+    # ==================== Tool Discovery ====================
+
+    def tools(self, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """List module tools available to a session's loaded checkpoint.
+
+        ``session_id`` defaults to the active Lucidic session context, so
+        this works naturally inside ``with client.sessions.create(...)``.
+        """
+        resolved_session_id = self._resolve_session_id(session_id)
+        body = self._api.list_tools(session_id=resolved_session_id)
+        return list(body.get("tools") or [])
+
+    async def atools(self, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Async sibling of ``tools``."""
+        resolved_session_id = self._resolve_session_id(session_id)
+        body = await self._api.alist_tools(session_id=resolved_session_id)
+        return list(body.get("tools") or [])
+
+    def openai_tools(
+        self,
+        session_id: Optional[str] = None,
+        *,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return checkpoint module tools as OpenAI function specs."""
+        module_tools = tools if tools is not None else self.tools(session_id)
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["tool_name"],
+                    "description": tool.get("tool_description", "") or "",
+                    "parameters": tool.get("input_schema") or {},
+                },
+            }
+            for tool in module_tools
+            if tool.get("tool_name")
+        ]
+
+    async def aopenai_tools(
+        self,
+        session_id: Optional[str] = None,
+        *,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Async sibling of ``openai_tools``."""
+        module_tools = tools if tools is not None else await self.atools(session_id)
+        return self.openai_tools(tools=module_tools)
+
+    def anthropic_tools(
+        self,
+        session_id: Optional[str] = None,
+        *,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return checkpoint module tools as Anthropic tool specs."""
+        module_tools = tools if tools is not None else self.tools(session_id)
+        return [
+            {
+                "name": tool["tool_name"],
+                "description": tool.get("tool_description", "") or "",
+                "input_schema": tool.get("input_schema") or {},
+            }
+            for tool in module_tools
+            if tool.get("tool_name")
+        ]
+
+    async def aanthropic_tools(
+        self,
+        session_id: Optional[str] = None,
+        *,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Async sibling of ``anthropic_tools``."""
+        module_tools = tools if tools is not None else await self.atools(session_id)
+        return self.anthropic_tools(tools=module_tools)
+
+    # ==================== Inference ====================
+
+    def call(
+        self,
+        tool_name: str,
+        arguments: Optional[Dict[str, Any]] = None,
+        *,
+        session_id: Optional[str] = None,
+        client_event_id: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+        poll_interval_seconds: Optional[float] = None,
+    ) -> Any:
+        """Run a module tool and return the agent-facing result.
+
+        Success returns only ``result["return_value"]`` so the agent sees a
+        normal tool result. Failure and SDK timeout return a structured soft
+        failure dict with enough metadata to debug the run.
+        """
+        resolved_session_id = self._resolve_session_id_for_call(session_id, tool_name)
+        if isinstance(resolved_session_id, dict):
+            return resolved_session_id
+
+        normalized_args, arg_error = self._normalize_arguments(arguments, tool_name)
+        if arg_error is not None:
+            return arg_error
+
+        event_id = client_event_id or str(uuid.uuid4())
+        try:
+            run = self._api.submit_inference(
+                session_id=resolved_session_id,
+                tool_name=tool_name,
+                arguments=normalized_args,
+                client_event_id=event_id,
+            )
+        except Exception as exc:
+            return self._soft_failure(
+                code="training_module_submission_failed",
+                message=str(exc),
+                session_id=resolved_session_id,
+                tool_name=tool_name,
+            )
+
+        return self._poll_to_tool_result(
+            run,
+            session_id=resolved_session_id,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    async def acall(
+        self,
+        tool_name: str,
+        arguments: Optional[Dict[str, Any]] = None,
+        *,
+        session_id: Optional[str] = None,
+        client_event_id: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+        poll_interval_seconds: Optional[float] = None,
+    ) -> Any:
+        """Async sibling of ``call``."""
+        resolved_session_id = self._resolve_session_id_for_call(session_id, tool_name)
+        if isinstance(resolved_session_id, dict):
+            return resolved_session_id
+
+        normalized_args, arg_error = self._normalize_arguments(arguments, tool_name)
+        if arg_error is not None:
+            return arg_error
+
+        event_id = client_event_id or str(uuid.uuid4())
+        try:
+            run = await self._api.asubmit_inference(
+                session_id=resolved_session_id,
+                tool_name=tool_name,
+                arguments=normalized_args,
+                client_event_id=event_id,
+            )
+        except Exception as exc:
+            return self._soft_failure(
+                code="training_module_submission_failed",
+                message=str(exc),
+                session_id=resolved_session_id,
+                tool_name=tool_name,
+            )
+
+        return await self._apoll_to_tool_result(
+            run,
+            session_id=resolved_session_id,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    def dispatch_openai_tool_call(
+        self,
+        call: Any,
+        *,
+        session_id: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+        poll_interval_seconds: Optional[float] = None,
+    ) -> Any:
+        """Dispatch one OpenAI tool call through Training Modules."""
+        tool_name, arguments, client_event_id = _extract_openai_call(call)
+        return self.call(
+            tool_name,
+            arguments,
+            session_id=session_id,
+            client_event_id=client_event_id,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    async def adispatch_openai_tool_call(
+        self,
+        call: Any,
+        *,
+        session_id: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+        poll_interval_seconds: Optional[float] = None,
+    ) -> Any:
+        """Async sibling of ``dispatch_openai_tool_call``."""
+        tool_name, arguments, client_event_id = _extract_openai_call(call)
+        return await self.acall(
+            tool_name,
+            arguments,
+            session_id=session_id,
+            client_event_id=client_event_id,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    def dispatch_anthropic_tool_call(
+        self,
+        block: Any,
+        *,
+        session_id: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+        poll_interval_seconds: Optional[float] = None,
+    ) -> Any:
+        """Dispatch one Anthropic tool_use block through Training Modules."""
+        tool_name, arguments, client_event_id = _extract_anthropic_block(block)
+        return self.call(
+            tool_name,
+            arguments,
+            session_id=session_id,
+            client_event_id=client_event_id,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    async def adispatch_anthropic_tool_call(
+        self,
+        block: Any,
+        *,
+        session_id: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+        poll_interval_seconds: Optional[float] = None,
+    ) -> Any:
+        """Async sibling of ``dispatch_anthropic_tool_call``."""
+        tool_name, arguments, client_event_id = _extract_anthropic_block(block)
+        return await self.acall(
+            tool_name,
+            arguments,
+            session_id=session_id,
+            client_event_id=client_event_id,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    # ==================== Internals ====================
+
+    def _poll_to_tool_result(
+        self,
+        run: Dict[str, Any],
+        *,
+        session_id: str,
+        timeout_seconds: Optional[float],
+        poll_interval_seconds: Optional[float],
+    ) -> Any:
+        deadline = time.monotonic() + self._timeout(timeout_seconds)
+        interval = self._poll_interval(poll_interval_seconds)
+
+        while run.get("status") in ACTIVE_STATUSES:
+            if time.monotonic() >= deadline:
+                return self._timeout_failure(run, timeout_seconds)
+            inference_run_id = run.get("inference_run_id")
+            if not inference_run_id:
+                return self._soft_failure(
+                    code="training_module_malformed_response",
+                    message="Training Module inference response did not include inference_run_id.",
+                    run=run,
+                    session_id=session_id,
+                    tool_name=run.get("tool_name"),
+                )
+            time.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+            try:
+                run = self._api.get_inference(
+                    inference_run_id=str(inference_run_id),
+                    session_id=session_id,
+                )
+            except Exception as exc:
+                return self._soft_failure(
+                    code="training_module_poll_failed",
+                    message=str(exc),
+                    run=run,
+                    session_id=session_id,
+                    tool_name=run.get("tool_name"),
+                )
+
+        return self._terminal_tool_result(run)
+
+    async def _apoll_to_tool_result(
+        self,
+        run: Dict[str, Any],
+        *,
+        session_id: str,
+        timeout_seconds: Optional[float],
+        poll_interval_seconds: Optional[float],
+    ) -> Any:
+        deadline = time.monotonic() + self._timeout(timeout_seconds)
+        interval = self._poll_interval(poll_interval_seconds)
+
+        while run.get("status") in ACTIVE_STATUSES:
+            if time.monotonic() >= deadline:
+                return self._timeout_failure(run, timeout_seconds)
+            inference_run_id = run.get("inference_run_id")
+            if not inference_run_id:
+                return self._soft_failure(
+                    code="training_module_malformed_response",
+                    message="Training Module inference response did not include inference_run_id.",
+                    run=run,
+                    session_id=session_id,
+                    tool_name=run.get("tool_name"),
+                )
+            await asyncio.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+            try:
+                run = await self._api.aget_inference(
+                    inference_run_id=str(inference_run_id),
+                    session_id=session_id,
+                )
+            except Exception as exc:
+                return self._soft_failure(
+                    code="training_module_poll_failed",
+                    message=str(exc),
+                    run=run,
+                    session_id=session_id,
+                    tool_name=run.get("tool_name"),
+                )
+
+        return self._terminal_tool_result(run)
+
+    def _terminal_tool_result(self, run: Dict[str, Any]) -> Any:
+        status = run.get("status")
+        if status == "SUCCEEDED":
+            result = run.get("result") or {}
+            if isinstance(result, dict) and "return_value" in result:
+                return result.get("return_value")
+            return result
+
+        if status == "FAILED":
+            error = run.get("error") or {}
+            message = _error_message(error) or "Training Module inference failed."
+            code = _error_code(error) or "training_module_inference_failed"
+        elif status == "TIMED_OUT":
+            message = "Training Module inference timed out on the backend."
+            code = "training_module_inference_timed_out"
+        elif status == "CANCELLED":
+            message = "Training Module inference was cancelled."
+            code = "training_module_inference_cancelled"
+        else:
+            message = f"Training Module inference ended with unexpected status {status!r}."
+            code = "training_module_inference_unknown_status"
+
+        return self._soft_failure(
+            code=code,
+            message=message,
+            run=run,
+            session_id=run.get("session_id"),
+            tool_name=run.get("tool_name"),
+        )
+
+    def _timeout_failure(
+        self,
+        run: Dict[str, Any],
+        timeout_seconds: Optional[float],
+    ) -> Dict[str, Any]:
+        timeout = self._timeout(timeout_seconds)
+        return self._soft_failure(
+            code="training_module_sdk_timeout",
+            message=f"Training Module inference did not finish within {timeout:g} seconds.",
+            run=run,
+            session_id=run.get("session_id"),
+            tool_name=run.get("tool_name"),
+            extra={"timeout_seconds": timeout},
+        )
+
+    def _soft_failure(
+        self,
+        *,
+        code: str,
+        message: str,
+        run: Optional[Dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+        tool_name: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        metadata: Dict[str, Any] = {
+            "session_id": session_id,
+            "tool_name": tool_name,
+        }
+        if run:
+            metadata.update({
+                "inference_run_id": run.get("inference_run_id"),
+                "checkpoint_id": run.get("checkpoint_id"),
+                "module_key": run.get("module_key"),
+                "status": run.get("status"),
+                "temporal_workflow_id": run.get("temporal_workflow_id"),
+                "temporal_run_id": run.get("temporal_run_id"),
+                "created_at": run.get("created_at"),
+                "updated_at": run.get("updated_at"),
+                "started_at": run.get("started_at"),
+                "completed_at": run.get("completed_at"),
+            })
+        if extra:
+            metadata.update(extra)
+        return {
+            "error": {
+                "code": code,
+                "message": message,
+            },
+            "metadata": {k: v for k, v in metadata.items() if v not in (None, "")},
+        }
+
+    def _resolve_session_id(self, session_id: Optional[str]) -> str:
+        resolved = session_id or current_session_id.get(None)
+        if not resolved:
+            raise LucidicError(
+                "Training Modules require a session_id or an active Lucidic session"
+            )
+        return str(resolved)
+
+    def _resolve_session_id_for_call(
+        self,
+        session_id: Optional[str],
+        tool_name: str,
+    ) -> Union[str, Dict[str, Any]]:
+        try:
+            return self._resolve_session_id(session_id)
+        except LucidicError as exc:
+            return self._soft_failure(
+                code="training_module_missing_session",
+                message=str(exc),
+                tool_name=tool_name,
+            )
+
+    def _normalize_arguments(
+        self,
+        arguments: Optional[Dict[str, Any]],
+        tool_name: str,
+    ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+        if arguments is None:
+            return {}, None
+        if not isinstance(arguments, dict):
+            return {}, self._soft_failure(
+                code="training_module_invalid_arguments",
+                message="Training Module arguments must be a dict.",
+                tool_name=tool_name,
+            )
+        return dict(arguments), None
+
+    def _timeout(self, timeout_seconds: Optional[float]) -> float:
+        timeout = self.default_timeout_seconds if timeout_seconds is None else timeout_seconds
+        try:
+            timeout = float(timeout)
+        except (TypeError, ValueError):
+            timeout = self.default_timeout_seconds
+        return max(0.0, timeout)
+
+    def _poll_interval(self, poll_interval_seconds: Optional[float]) -> float:
+        interval = (
+            self.default_poll_interval_seconds
+            if poll_interval_seconds is None
+            else poll_interval_seconds
+        )
+        try:
+            interval = float(interval)
+        except (TypeError, ValueError):
+            interval = self.default_poll_interval_seconds
+        return max(0.05, interval)
+
+
+def _extract_openai_call(call: Any) -> Tuple[str, Dict[str, Any], str]:
+    if hasattr(call, "function"):
+        fn = call.function
+        name = fn.name if hasattr(fn, "name") else fn["name"]
+        raw_args = fn.arguments if hasattr(fn, "arguments") else fn["arguments"]
+        call_id = getattr(call, "id", None)
+    elif isinstance(call, dict):
+        fn = call["function"]
+        name = fn["name"]
+        raw_args = fn.get("arguments")
+        call_id = call.get("id")
+    else:
+        raise TypeError(
+            "dispatch_openai_tool_call expected an OpenAI tool call object or dict"
+        )
+    return str(name), _parse_json_arguments(raw_args, str(name)), str(call_id or uuid.uuid4())
+
+
+def _extract_anthropic_block(block: Any) -> Tuple[str, Dict[str, Any], str]:
+    if isinstance(block, dict):
+        name = block.get("name")
+        raw_input = block.get("input")
+        block_id = block.get("id")
+    else:
+        name = getattr(block, "name", None)
+        raw_input = getattr(block, "input", None)
+        block_id = getattr(block, "id", None)
+
+    if not name or not isinstance(name, str):
+        raise TypeError("dispatch_anthropic_tool_call expected a block with a name")
+    if raw_input is None:
+        arguments = {}
+    elif isinstance(raw_input, dict):
+        arguments = dict(raw_input)
+    elif isinstance(raw_input, str):
+        arguments = _parse_json_arguments(raw_input, name)
+    else:
+        logger.warning(
+            "[TrainingModulesResource] Anthropic tool_use %r input is %s; passing empty args",
+            name, type(raw_input).__name__,
+        )
+        arguments = {}
+    return name, arguments, str(block_id or uuid.uuid4())
+
+
+def _parse_json_arguments(raw_args: Any, tool_name: str) -> Dict[str, Any]:
+    if not raw_args:
+        return {}
+    try:
+        parsed = json.loads(raw_args)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "[TrainingModulesResource] tool %r had unparseable JSON arguments; passing empty args",
+            tool_name,
+        )
+        return {}
+    if isinstance(parsed, dict):
+        return parsed
+    logger.warning(
+        "[TrainingModulesResource] tool %r arguments parsed to %s; passing empty args",
+        tool_name, type(parsed).__name__,
+    )
+    return {}
+
+
+def _error_code(error: Any) -> Optional[str]:
+    if isinstance(error, dict):
+        value = error.get("code")
+        return str(value) if value else None
+    return None
+
+
+def _error_message(error: Any) -> Optional[str]:
+    if isinstance(error, dict):
+        for key in ("message", "detail", "error"):
+            value = error.get(key)
+            if value:
+                return str(value)
+    if error:
+        return str(error)
+    return None

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="lucidicai",
-    version="3.6.0",
+    version="3.7.0",
     packages=find_packages(),
     install_requires=[
         "requests>=2.25.1",

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     install_requires=[
         "requests>=2.25.1",
         "urllib3",
+        "httpx>=0.27.0",
         "boto3",
         "python-dotenv",
         "langchain",


### PR DESCRIPTION
- Adds checkpoint-aware session creation and a `client.training_modules` namespace for module tool discovery and dispatch.
- Adds submit-and-poll inference helpers that return normal tool results on success and structured soft failures on failure or timeout.
- Bumps SDK version to `3.7.0` and declares the direct `httpx>=0.27.0` runtime dependency used by the SDK HTTP client.

Files changed:
- `lucidicai/api/resources/session.py` - accepts `checkpoint_id` during sync and async session creation.
- `lucidicai/api/resources/training_modules.py` - low-level HTTP resource for module tools and inference runs.
- `lucidicai/sdk/training_modules/` - high-level SDK helpers for provider tool specs, dispatch, polling, and soft failures.
- `lucidicai/client.py` and `lucidicai/__init__.py` - public client/export wiring.
- `setup.py` - version bump to `3.7.0` and direct `httpx` install requirement.