### PR TITLE
LUC-770: Add client.evosims.train() for EvoSim training runs

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -66,7 +66,7 @@ from .sdk.tools.adapters import (
 from .integrations.livekit import setup_livekit
 
 # Version
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 
 # All exports
 __all__ = [

--- a/lucidicai/api/resources/evosim.py
+++ b/lucidicai/api/resources/evosim.py
@@ -1,0 +1,89 @@
+"""EvoSim resource API operations."""
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from ..client import HttpClient
+from ...core.errors import LucidicError
+
+logger = logging.getLogger("Lucidic")
+
+
+class EvoSimResource:
+    """Handle EvoSim-related API operations."""
+
+    def __init__(
+        self,
+        http: HttpClient,
+        agent_id: Optional[str] = None,
+        production: bool = False,
+    ):
+        """Initialize EvoSim resource.
+
+        Args:
+            http: HTTP client instance
+            agent_id: Default agent ID for training runs
+            production: Whether to suppress errors in production mode
+        """
+        self.http = http
+        self._agent_id = agent_id
+        self._production = production
+
+    def train(self, config_json_file: Union[str, Path]) -> Dict[str, Any]:
+        """Start an EvoSim training run from a JSON config file.
+
+        The file must contain a JSON object; its top-level keys become the
+        request payload for the training run. ``agent_id`` is filled in from
+        the client config when the file doesn't provide one.
+
+        Args:
+            config_json_file: Path to the JSON training config
+
+        Returns:
+            Backend response describing the run (successful or failed)
+        """
+        try:
+            payload = _load_training_config(config_json_file)
+            if self._agent_id:
+                payload.setdefault("agent_id", self._agent_id)
+            return self.http.post("sdk/evosim/training-run", payload)
+        except Exception as e:
+            if self._production:
+                logger.error(f"[EvoSimResource] Failed to start training run: {e}")
+                return {"status": "failed", "error": str(e)}
+            raise
+
+    async def atrain(self, config_json_file: Union[str, Path]) -> Dict[str, Any]:
+        """Async sibling of ``train``."""
+        try:
+            payload = _load_training_config(config_json_file)
+            if self._agent_id:
+                payload.setdefault("agent_id", self._agent_id)
+            return await self.http.apost("sdk/evosim/training-run", payload)
+        except Exception as e:
+            if self._production:
+                logger.error(f"[EvoSimResource] Failed to start training run: {e}")
+                return {"status": "failed", "error": str(e)}
+            raise
+
+
+def _load_training_config(config_json_file: Union[str, Path]) -> Dict[str, Any]:
+    """Read a training config file and return its keys as a payload dict."""
+    path = Path(config_json_file)
+    try:
+        raw = path.read_text()
+    except OSError as e:
+        raise LucidicError(f"Cannot read EvoSim config file {path}: {e}") from e
+
+    try:
+        config = json.loads(raw)
+    except ValueError as e:
+        raise LucidicError(f"EvoSim config file {path} is not valid JSON: {e}") from e
+
+    if not isinstance(config, dict):
+        raise LucidicError(
+            f"EvoSim config file {path} must contain a JSON object, "
+            f"got {type(config).__name__}"
+        )
+    return dict(config)

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -31,6 +31,7 @@ from .api.resources.experiment import ExperimentResource
 from .api.resources.prompt import PromptResource
 from .api.resources.feature_flag import FeatureFlagResource
 from .api.resources.evals import EvalsResource
+from .api.resources.evosim import EvoSimResource
 from .api.resources.mock_call import MockCallResource
 from .sdk.training_modules.resource import TrainingModulesResource
 from .sdk.tools.resource import ToolsResource
@@ -161,6 +162,7 @@ class LucidicAI:
             "prompts": PromptResource(self._http, self._config, self._production),
             "feature_flags": FeatureFlagResource(self._http, self._config.agent_id, self._production),
             "evals": EvalsResource(self._http, self._production),
+            "evosims": EvoSimResource(self._http, self._config.agent_id, self._production),
             "mock_calls": MockCallResource(self._http, self._production),
         }
 
@@ -346,6 +348,15 @@ class LucidicAI:
             client.evals.emit(result="excellent", name="quality")
         """
         return self._resources["evals"]
+
+    @property
+    def evosims(self) -> EvoSimResource:
+        """Access EvoSim resource for agent optimization runs.
+
+        Example:
+            result = client.evosims.train("training_config.json")
+        """
+        return self._resources["evosims"]
 
     @property
     def mock_calls(self) -> MockCallResource:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="lucidicai",
-    version="3.7.0",
+    version="3.7.1",
     packages=find_packages(),
     install_requires=[
         "requests>=2.25.1",


### PR DESCRIPTION
- Add `client.evosims.train(config_json_file)` (+ `atrain` async sibling): reads a JSON config file and POSTs its top-level keys to the new `sdk/evosim/training-run` backend endpoint, defaulting `agent_id` from client config
- Returns the backend response dict on success; raises `LucidicError` on bad config files and HTTP failures in dev mode, returns `{"status": "failed", ...}` in production mode
- Bump version to 3.7.1

- `lucidicai/api/resources/evosim.py` — new `EvoSimResource` with `train`/`atrain` and config-file loading/validation
- `lucidicai/client.py` — wire `EvoSimResource` into `_resources`, expose `client.evosims` property
- `lucidicai/__init__.py`, `setup.py` — version 3.7.0 → 3.7.1