### PR TITLE
LUC-797: Style-tuner E2E demo — webhook harness + train/infer driver (Phase 2)

### DIFF
--- a/evosim_style_tuner_demo.py
+++ b/evosim_style_tuner_demo.py
@@ -1,0 +1,104 @@
+"""LUC-797 Phase 2 — style-tuner train + inference driver (run against local sst dev).
+
+Two modes:
+
+  train  — create a trivial Experiment (EvoSim kickoff requires one), write the
+           training-run config, and call client.evosims.train(...). The rollouts hit
+           the webhook harness; the run publishes a Checkpoint binding BOTH the
+           style_tuner tool (artifact) AND the trained prompt version.
+
+  infer  — bind a published checkpoint to a fresh session, fetch the target prompt
+           (now the TRAINED version, via LUC-793/795 checkpoint-scoped resolution) and
+           call the style_tuner tool (which returns the trained artifact).
+
+The published checkpoint id is handed off manually (the SDK has no EvoSim-status
+poll): after `train`, grab it from the dashboard (or a Checkpoint row with
+source_type=EVOSIM for this agent) and pass it to `infer --checkpoint-id`.
+
+Prereq: the target Prompt must already exist with a base `production` version — the
+SDK cannot create prompts. Seed it once (see the runbook / LUC-797). Requires an SDK
+build with LUC-795 for the checkpoint-scoped prompt fetch.
+
+    LUCIDIC_API_KEY=... LUCIDIC_AGENT_ID=... LUCIDIC_BASE_URL=http://localhost:8000 \
+      TARGET_PROMPT=style_tuner_demo_prompt python3 evosim_style_tuner_demo.py train
+    ... python3 evosim_style_tuner_demo.py infer --checkpoint-id <uuid>
+"""
+import argparse
+import json
+import os
+import tempfile
+
+import lucidicai as lai
+
+AGENT_ID = os.environ["LUCIDIC_AGENT_ID"]
+TARGET_PROMPT = os.environ.get("TARGET_PROMPT", "style_tuner_demo_prompt")
+WEBHOOK_URL = os.environ.get("WEBHOOK_URL", "http://localhost:8799/")
+
+client = lai.LucidicAI(providers=[])
+
+
+def train() -> None:
+    experiment_id = client.experiments.create(experiment_name="style-tuner demo")
+    print(f"experiment_id = {experiment_id}")
+
+    config = {
+        "agent": AGENT_ID,
+        "name": "style-tuner demo",
+        "experiment_id": experiment_id,
+        "webhook_url": WEBHOOK_URL,
+        "module_selections": [
+            {
+                "module_key": "style_tuner",
+                "config": {
+                    "target_prompt": TARGET_PROMPT,
+                    "session_specs": [{}, {}],  # 2 rollout sessions
+                    "window": 2,
+                    "dispatch_chunk": 2,
+                    "deadline_seconds": 300,
+                    "refine_iterations": 0,  # single pass; >0 exercises continue_as_new
+                },
+            }
+        ],
+    }
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump(config, fh)
+        cfg_path = fh.name
+    result = client.evosims.train(cfg_path)
+    print(f"train -> {json.dumps(result, indent=2, default=str)}")
+    print(
+        "\nMake sure the harness is running. When the run finishes, grab the published "
+        "checkpoint id (dashboard / Checkpoint source_type=EVOSIM) and run:\n"
+        "  python3 evosim_style_tuner_demo.py infer --checkpoint-id <uuid>"
+    )
+
+
+def infer(checkpoint_id: str) -> None:
+    session = client.sessions.create(
+        session_name="style-tuner inference", checkpoint_id=checkpoint_id
+    )
+    try:
+        prompt = client.prompts.get(TARGET_PROMPT)  # -> TRAINED version via the checkpoint
+        style = client.training_modules.call("get_style_guide", {})
+        print("=== checkpoint-scoped prompt (trained) ===")
+        print(prompt.content)
+        print("\n=== style_tuner tool result (trained artifact) ===")
+        print(json.dumps(style, indent=2, default=str))
+    finally:
+        session.end()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="mode", required=True)
+    sub.add_parser("train")
+    p_infer = sub.add_parser("infer")
+    p_infer.add_argument("--checkpoint-id", required=True)
+    args = ap.parse_args()
+    if args.mode == "train":
+        train()
+    else:
+        infer(args.checkpoint_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/evosim_style_tuner_demo.py
+++ b/evosim_style_tuner_demo.py
@@ -49,8 +49,8 @@ def train() -> None:
         "module_selections": [
             {
                 "module_key": "style_tuner",
+                "target_prompt": TARGET_PROMPT,  # first-party edit-site field (LUC-799)
                 "config": {
-                    "target_prompt": TARGET_PROMPT,
                     "session_specs": [{}, {}],  # 2 rollout sessions
                     "window": 2,
                     "dispatch_chunk": 2,

--- a/evosim_style_tuner_harness.py
+++ b/evosim_style_tuner_harness.py
@@ -1,0 +1,84 @@
+"""LUC-797 Phase 2 — webhook harness: the client "agent" that gets rolled out.
+
+Run a tiny HTTP server and point the EvoSim's ``webhook_url`` at it. On each rollout
+dispatch the backend POSTs ``{"session_id": ..., ...params}``; this harness then:
+
+  1. starts a Lucidic session with that session_id — the backend binds the in-training
+     candidate checkpoint to it server-side via the LUC-790 pre-link (the SDK does not
+     know the checkpoint id);
+  2. fetches the target prompt (``client.prompts.get`` auto-sends the session context,
+     so with LUC-795 it resolves the CANDIDATE prompt version, not the base label);
+  3. calls the style_tuner tool (an inference against the candidate artifact);
+  4. ends the session — which signals rollout completion back to the training loop.
+
+Requires an SDK build that includes LUC-795 (the checkpoint-scoped prompt fetch): the
+``luc-795-sdk-checkpoint-scoped-prompt-fetch`` branch or a ``lucidicai>=3.7.2`` release.
+
+Usage (env points the client at your local sst-dev backend):
+    LUCIDIC_API_KEY=... LUCIDIC_AGENT_ID=... LUCIDIC_BASE_URL=http://localhost:8000 \
+      TARGET_PROMPT=style_tuner_demo_prompt python3 evosim_style_tuner_harness.py --port 8799
+"""
+import argparse
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import lucidicai as lai
+
+TARGET_PROMPT = os.environ.get("TARGET_PROMPT", "style_tuner_demo_prompt")
+
+# api_key / agent_id / base_url are read from the LUCIDIC_* env vars.
+client = lai.LucidicAI(providers=[])
+
+
+def _run_session(session_id: str, params: dict) -> None:
+    try:
+        session = client.sessions.create(
+            session_id=session_id, session_name=f"rollout::{session_id[:8]}"
+        )
+        try:
+            prompt = client.prompts.get(TARGET_PROMPT)  # -> candidate version via session
+            style = client.training_modules.call("get_style_guide", {})  # inference vs candidate
+            print(
+                f"[harness] session={session_id[:8]} "
+                f"prompt={prompt.content[:70]!r} style={style}"
+            )
+        finally:
+            session.end()  # -> finishSession -> signals rollout completion
+    except Exception as exc:  # a rollout session must never crash the harness
+        print(f"[harness] session {session_id[:8]} failed: {exc}")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        try:
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except ValueError:
+            body = {}
+        session_id = body.get("session_id")
+        # respond fast; run the session off-thread so we don't stall dispatch pacing.
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok": true}')
+        if session_id:
+            threading.Thread(
+                target=_run_session, args=(str(session_id), body), daemon=True
+            ).start()
+
+    def log_message(self, *args) -> None:  # quiet the default access log
+        pass
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8799)
+    args = ap.parse_args()
+    print(f"[harness] listening on :{args.port} (POST any path), target_prompt={TARGET_PROMPT}")
+    ThreadingHTTPServer(("0.0.0.0", args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Phase 2 of the live prompt-editing module (backend Phase 1 is LUC-797 into `luc-791`): the client-side pieces that drive the synthetic `style_tuner` end to end against a local `sst dev` backend.
- `evosim_style_tuner_harness.py` — a webhook server = the rolled-out agent. On each rollout dispatch it starts a session with the given `session_id` (backend binds the candidate checkpoint via the LUC-790 pre-link), fetches the checkpoint-scoped prompt + calls `get_style_guide`, then ends the session (signals completion).
- `evosim_style_tuner_demo.py` — `train` (create Experiment + `evosims.train`) and `infer --checkpoint-id` (bind the published checkpoint, fetch the trained prompt + call the tool).
- **Depends on #73 (LUC-795)** for the checkpoint-scoped prompt fetch — install that branch or `lucidicai>=3.7.2`. **Untested by me** (needs a running local stack); the runbook + prompt-seed snippet are on LUC-797. Additive scripts only — no library changes here.

Files:
- `evosim_style_tuner_harness.py` — webhook harness (client agent)
- `evosim_style_tuner_demo.py` — train / infer driver