### PR TITLE
LUC-801: fetch module tools per edit site (prompt)

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -66,7 +66,7 @@ from .sdk.tools.adapters import (
 from .integrations.livekit import setup_livekit
 
 # Version
-__version__ = "3.7.1"
+__version__ = "3.7.2"
 
 # All exports
 __all__ = [

--- a/lucidicai/api/resources/training_modules.py
+++ b/lucidicai/api/resources/training_modules.py
@@ -28,22 +28,39 @@ class TrainingModulesAPIResource:
     def __init__(self, http: HttpClient):
         self.http = http
 
-    def list_tools(self, *, session_id: str) -> Dict[str, Any]:
-        """Return module tools available to the session's loaded checkpoint."""
+    def list_tools(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return module tools for a session's checkpoint or an explicit checkpoint.
+
+        Each tool carries its ``edit_site`` (the prompt it's exposed at). Pass
+        ``prompt_name`` to scope to a single edit site server-side (LUC-801), and
+        ``checkpoint_id`` to introspect a checkpoint without a live session.
+        """
         try:
             return self.http.get(
                 "sdk/training-modules/tools",
-                {"session_id": session_id},
+                _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
             )
         except httpx.HTTPStatusError as exc:
             raise LucidicError(_format_training_module_error(exc)) from exc
 
-    async def alist_tools(self, *, session_id: str) -> Dict[str, Any]:
+    async def alist_tools(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Async sibling of ``list_tools``."""
         try:
             return await self.http.aget(
                 "sdk/training-modules/tools",
-                {"session_id": session_id},
+                _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
             )
         except httpx.HTTPStatusError as exc:
             raise LucidicError(_format_training_module_error(exc)) from exc
@@ -121,6 +138,27 @@ class TrainingModulesAPIResource:
             )
         except httpx.HTTPStatusError as exc:
             raise LucidicError(_format_training_module_error(exc)) from exc
+
+
+def _tools_params(
+    *,
+    session_id: Optional[str],
+    prompt_name: Optional[str],
+    checkpoint_id: Optional[str],
+) -> Dict[str, Any]:
+    """Build the /sdk/training-modules/tools query params, omitting unset ones.
+
+    The backend resolves the checkpoint from ``checkpoint_id`` (preferred) or
+    ``session_id``, and ``prompt_name`` scopes to one edit site.
+    """
+    params: Dict[str, Any] = {}
+    if checkpoint_id is not None:
+        params["checkpoint_id"] = checkpoint_id
+    if session_id is not None:
+        params["session_id"] = session_id
+    if prompt_name is not None:
+        params["prompt_name"] = prompt_name
+    return params
 
 
 def _format_training_module_error(exc: httpx.HTTPStatusError) -> str:

--- a/lucidicai/sdk/training_modules/resource.py
+++ b/lucidicai/sdk/training_modules/resource.py
@@ -50,30 +50,68 @@ class TrainingModulesResource:
 
     # ==================== Tool Discovery ====================
 
-    def tools(self, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
-        """List module tools available to a session's loaded checkpoint.
+    def tools(
+        self,
+        session_id: Optional[str] = None,
+        *,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List module tools, each annotated with its ``edit_site``.
 
-        ``session_id`` defaults to the active Lucidic session context, so
-        this works naturally inside ``with client.sessions.create(...)``.
+        Resolves against an explicit ``checkpoint_id`` (introspection) or, by
+        default, the active session's loaded checkpoint (so this works naturally
+        inside ``with client.sessions.create(...)``). Pass ``prompt_name`` -- the
+        prompt at the current LLM call -- to get just the tools that live at that
+        edit site (LUC-801); server-side scoped, so nothing else leaks in.
         """
-        resolved_session_id = self._resolve_session_id(session_id)
-        body = self._api.list_tools(session_id=resolved_session_id)
+        body = self._api.list_tools(
+            **self._tools_kwargs(session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id)
+        )
         return list(body.get("tools") or [])
 
-    async def atools(self, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    async def atools(
+        self,
+        session_id: Optional[str] = None,
+        *,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         """Async sibling of ``tools``."""
-        resolved_session_id = self._resolve_session_id(session_id)
-        body = await self._api.alist_tools(session_id=resolved_session_id)
+        body = await self._api.alist_tools(
+            **self._tools_kwargs(session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id)
+        )
         return list(body.get("tools") or [])
+
+    def _tools_kwargs(
+        self,
+        session_id: Optional[str],
+        *,
+        prompt_name: Optional[str],
+        checkpoint_id: Optional[str],
+    ) -> Dict[str, Any]:
+        # checkpoint_id introspects a checkpoint directly (no session needed);
+        # otherwise resolve the active session so the call works inside a
+        # `with client.sessions.create(...)` block.
+        if checkpoint_id is not None:
+            return {"checkpoint_id": checkpoint_id, "prompt_name": prompt_name}
+        return {"session_id": self._resolve_session_id(session_id), "prompt_name": prompt_name}
 
     def openai_tools(
         self,
         session_id: Optional[str] = None,
         *,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
-        """Return checkpoint module tools as OpenAI function specs."""
-        module_tools = tools if tools is not None else self.tools(session_id)
+        """Return checkpoint module tools as OpenAI function specs.
+
+        Accepts the same ``prompt_name``/``checkpoint_id`` scoping as ``tools``.
+        """
+        module_tools = tools if tools is not None else self.tools(
+            session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id
+        )
         return [
             {
                 "type": "function",
@@ -91,20 +129,31 @@ class TrainingModulesResource:
         self,
         session_id: Optional[str] = None,
         *,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
         """Async sibling of ``openai_tools``."""
-        module_tools = tools if tools is not None else await self.atools(session_id)
+        module_tools = tools if tools is not None else await self.atools(
+            session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id
+        )
         return self.openai_tools(tools=module_tools)
 
     def anthropic_tools(
         self,
         session_id: Optional[str] = None,
         *,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
-        """Return checkpoint module tools as Anthropic tool specs."""
-        module_tools = tools if tools is not None else self.tools(session_id)
+        """Return checkpoint module tools as Anthropic tool specs.
+
+        Accepts the same ``prompt_name``/``checkpoint_id`` scoping as ``tools``.
+        """
+        module_tools = tools if tools is not None else self.tools(
+            session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id
+        )
         return [
             {
                 "name": tool["tool_name"],
@@ -119,10 +168,14 @@ class TrainingModulesResource:
         self,
         session_id: Optional[str] = None,
         *,
+        prompt_name: Optional[str] = None,
+        checkpoint_id: Optional[str] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
     ) -> List[Dict[str, Any]]:
         """Async sibling of ``anthropic_tools``."""
-        module_tools = tools if tools is not None else await self.atools(session_id)
+        module_tools = tools if tools is not None else await self.atools(
+            session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id
+        )
         return self.anthropic_tools(tools=module_tools)
 
     # ==================== Inference ====================

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="lucidicai",
-    version="3.7.1",
+    version="3.7.2",
     packages=find_packages(),
     install_requires=[
         "requests>=2.25.1",

--- a/tests/sdk/training_modules/test_resource.py
+++ b/tests/sdk/training_modules/test_resource.py
@@ -1,0 +1,131 @@
+"""LUC-801: ``client.training_modules`` per-edit-site tool discovery.
+
+Exercises the full high-level -> HTTP path with respx mocking the backend at the
+request boundary, so we verify the real query-param shape (session vs checkpoint,
+prompt_name scoping), the edit_site passthrough, and provider-spec scoping.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.client import HttpClient
+from lucidicai.core.config import NetworkConfig, SDKConfig
+from lucidicai.core.errors import LucidicError
+from lucidicai.sdk.context import current_session_id
+from lucidicai.sdk.training_modules.resource import TrainingModulesResource
+
+_BASE_URL = "https://stub.lucidic.test"
+_ENDPOINT = f"{_BASE_URL}/sdk/training-modules/tools"
+_BODY = {
+    "checkpoint_id": "cp-1",
+    "tools": [
+        {
+            "module_key": "style_tuner",
+            "tool_name": "get_style_guide",
+            "tool_description": "style",
+            "input_schema": {"type": "object"},
+            "edit_site": "Prompt 1",
+        },
+    ],
+}
+
+
+class _FakeClient:
+    """TrainingModulesResource only touches ``client._http``."""
+
+    def __init__(self, http):
+        self._http = http
+
+
+@pytest.fixture
+def resource() -> TrainingModulesResource:
+    config = SDKConfig(
+        api_key="test-key",
+        agent_id="00000000-0000-0000-0000-000000000000",
+        network=NetworkConfig(base_url=_BASE_URL),
+    )
+    return TrainingModulesResource(client=_FakeClient(HttpClient(config=config)))
+
+
+@pytest.fixture
+def in_session():
+    token = current_session_id.set("sess-ctx")
+    try:
+        yield "sess-ctx"
+    finally:
+        current_session_id.reset(token)
+
+
+@respx.mock
+def test_tools_uses_active_session_and_passes_edit_site_through(resource, in_session):
+    route = respx.get(_ENDPOINT).mock(return_value=httpx.Response(200, json=_BODY))
+    tools = resource.tools()
+    assert dict(route.calls.last.request.url.params) == {"session_id": "sess-ctx"}
+    assert tools[0]["edit_site"] == "Prompt 1"
+
+
+@respx.mock
+def test_tools_prompt_name_scopes_server_side(resource, in_session):
+    route = respx.get(_ENDPOINT).mock(return_value=httpx.Response(200, json=_BODY))
+    resource.tools(prompt_name="Prompt 1")
+    assert dict(route.calls.last.request.url.params) == {
+        "session_id": "sess-ctx",
+        "prompt_name": "Prompt 1",
+    }
+
+
+@respx.mock
+def test_tools_checkpoint_id_needs_no_session(resource):
+    # no active session bound; checkpoint_id path must not require one.
+    route = respx.get(_ENDPOINT).mock(return_value=httpx.Response(200, json=_BODY))
+    resource.tools(checkpoint_id="cp-1", prompt_name="Prompt 2")
+    params = dict(route.calls.last.request.url.params)
+    assert params == {"checkpoint_id": "cp-1", "prompt_name": "Prompt 2"}
+    assert "session_id" not in params
+
+
+def test_tools_without_session_or_checkpoint_raises(resource):
+    with pytest.raises(LucidicError):
+        resource.tools()
+
+
+@respx.mock
+def test_openai_tools_scopes_and_shapes(resource, in_session):
+    route = respx.get(_ENDPOINT).mock(return_value=httpx.Response(200, json=_BODY))
+    specs = resource.openai_tools(prompt_name="Prompt 1")
+    assert dict(route.calls.last.request.url.params) == {
+        "session_id": "sess-ctx",
+        "prompt_name": "Prompt 1",
+    }
+    assert specs == [{
+        "type": "function",
+        "function": {
+            "name": "get_style_guide",
+            "description": "style",
+            "parameters": {"type": "object"},
+        },
+    }]
+
+
+@respx.mock
+def test_anthropic_tools_checkpoint_scope(resource):
+    route = respx.get(_ENDPOINT).mock(return_value=httpx.Response(200, json=_BODY))
+    specs = resource.anthropic_tools(checkpoint_id="cp-1")
+    assert dict(route.calls.last.request.url.params) == {"checkpoint_id": "cp-1"}
+    assert specs == [{
+        "name": "get_style_guide",
+        "description": "style",
+        "input_schema": {"type": "object"},
+    }]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_atools_threads_prompt_name(resource, in_session):
+    route = respx.get(_ENDPOINT).mock(return_value=httpx.Response(200, json=_BODY))
+    tools = await resource.atools(prompt_name="Prompt 1")
+    assert dict(route.calls.last.request.url.params) == {
+        "session_id": "sess-ctx",
+        "prompt_name": "Prompt 1",
+    }
+    assert tools[0]["edit_site"] == "Prompt 1"


### PR DESCRIPTION
SDK half of LUC-801 (backend endpoint landed in `luc-791` as #590). A training-module tool is exposed at a particular LLM call, which we represent as a **Prompt (edit site)**. When an EvoSim trains modules across different prompts, the agent — sitting at one LLM call — wants *the tools for this prompt*, not the whole checkpoint's set. The scoping is done server-side; this is the client surface for it, mirroring how LUC-795 (#73) extended `prompts.get()`.

## Changes

`client.training_modules.tools()` / `atools()` (and the `openai_tools` / `anthropic_tools` spec helpers) gain two optional keyword args:

- **`prompt_name`** — scope to a single edit site. Pass the prompt at the current LLM call and you get only the tools that live there (filtered server-side; nothing else leaks in).
- **`checkpoint_id`** — introspect a checkpoint directly, no live session needed (parallels LUC-795's `checkpoint_id` on `prompts.get()`).

Each returned tool now also carries its **`edit_site`** (the module's `target_prompt`), passed straight through.

```python
client.training_modules.tools()                          # active session's checkpoint, all tools (+ edit_site)
client.training_modules.tools(prompt_name="Prompt 1")    # just Prompt 1's tools
client.training_modules.tools(checkpoint_id="cp-…", prompt_name="Prompt 2")  # introspect a checkpoint
client.training_modules.openai_tools(prompt_name="Prompt 1")   # OpenAI specs, scoped
```

**Backward compatible:** `tools(session_id)` is unchanged; the new args default to `None`. The HTTP layer (`TrainingModulesAPIResource.list_tools`/`alist_tools`) now builds params via a small `_tools_params` helper and `session_id` is optional there (it was already keyword-only).

## Tests

`tests/sdk/training_modules/test_resource.py` (new), respx-mocked at the HTTP boundary — verifies the query-param shape (session vs checkpoint, `prompt_name` scoping), the missing-session-and-no-checkpoint error, `edit_site` passthrough, and provider-spec scoping. **7 passed**; the full `tests/sdk` + `tests/api` suites stay green (205 passed).

## Version

Bumps `3.7.1 → 3.7.2`. **Note:** #73 (LUC-795) also targets `3.7.2` off `main` — whichever of these lands second will conflict on the version line and should bump to `3.7.3`.

Depends on the backend `edit_site` / `prompt_name` / `checkpoint_id` support (LUC-801, in `luc-791`). Against an older backend the new params are simply ignored and every tool's `edit_site` is `null`.