### PR TITLE
LUC-900–905: C0 transport foundations

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -32,6 +32,16 @@ from .core.errors import (
     InvalidOperationError,
     PromptError,
     FeatureFlagError,
+    # Typed HTTP/API errors (LUC-900)
+    LucidicAPIError,
+    ValidationError,
+    AuthError,
+    InsufficientScopeError,
+    NotFoundError,
+    ConflictError,
+    RateLimitError,
+    ServiceUnavailableError,
+    APIError,
     # mock_call dispatch error family (LUC-607)
     LucidicMockCallError,
     LucidicToolDriftError,
@@ -46,6 +56,9 @@ from .core.errors import (
     LucidicUnsupportedSQLError,
 )
 from .sdk.training_modules import TrainingModulesResource
+
+# Typed response-model base (LUC-905)
+from .api.models import APIModel, CursorPage
 
 # Prompt object
 from .api.resources.prompt import Prompt
@@ -81,6 +94,16 @@ __all__ = [
     "InvalidOperationError",
     "PromptError",
     "FeatureFlagError",
+    # Typed HTTP/API errors (LUC-900)
+    "LucidicAPIError",
+    "ValidationError",
+    "AuthError",
+    "InsufficientScopeError",
+    "NotFoundError",
+    "ConflictError",
+    "RateLimitError",
+    "ServiceUnavailableError",
+    "APIError",
     # mock_call dispatch error family (LUC-607)
     "LucidicMockCallError",
     "LucidicToolDriftError",
@@ -94,6 +117,9 @@ __all__ = [
     "LucidicMissingImplError",
     "LucidicUnsupportedSQLError",
     "TrainingModulesResource",
+    # Typed response-model base (LUC-905)
+    "APIModel",
+    "CursorPage",
     # Prompt object
     "Prompt",
     # Tool dispatch (v2 tool-backed)

--- a/lucidicai/api/client.py
+++ b/lucidicai/api/client.py
@@ -4,14 +4,56 @@ This module contains only the HTTP client logic using httpx,
 supporting both synchronous and asynchronous operations.
 """
 import asyncio
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import httpx
 
 from ..core.config import SDKConfig, get_config
-from ..core.errors import APIKeyVerificationError
+from ..core.errors import exception_from_response
 from ..utils.logger import debug, info, warning, error, mask_sensitive, truncate_data
+
+
+# Status codes the transport retries with backoff (LUC-901). Connection-level
+# failures are retried separately by the httpx transport's own ``retries=``.
+# 429 (throttled) and 503 (unavailable / workflow couldn't start) are retried.
+_RETRY_STATUSES = frozenset({429, 503})
+
+# Retries are gated to idempotent methods. A POST/PATCH may have committed a
+# write before the backend returned 429/503 — the EvoSim kickoff, for example,
+# commits the run row and only then 503s if Temporal can't start — so a blind
+# retry would duplicate it. GET/HEAD/PUT/DELETE are safe to replay. Trigger
+# endpoints that want at-least-once retry need a server-side idempotency key
+# first (LUC-808); until then POST/PATCH fail fast, as they did pre-C0.
+_IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE", "OPTIONS"})
+
+# Hard ceiling on a single retry sleep, so a large (or proxy-injected)
+# ``Retry-After`` can't pin the calling thread for minutes/hours.
+_MAX_RETRY_DELAY_SECONDS = 30.0
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parse a ``Retry-After: <seconds>`` header. The HTTP-date form is not
+    supported (returns None → caller falls back to computed backoff)."""
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _retry_delay(response: httpx.Response, attempt: int, backoff: float) -> float:
+    """Seconds to wait before the next attempt: honor ``Retry-After`` when the
+    server sends it, else exponential backoff (``backoff * 2**attempt``).
+
+    Clamped to ``_MAX_RETRY_DELAY_SECONDS`` so a huge or proxy-injected
+    ``Retry-After`` can't block the caller for minutes/hours.
+    """
+    retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+    delay = retry_after if retry_after is not None else backoff * (2 ** attempt)
+    return min(delay, _MAX_RETRY_DELAY_SECONDS)
 
 
 class HttpClient:
@@ -123,35 +165,35 @@ class HttpClient:
         data["current_time"] = datetime.now(timezone.utc).isoformat()
         return data
     
-    def _handle_response(self, response: httpx.Response) -> Dict[str, Any]:
-        """Handle HTTP response and parse JSON.
-        
-        Args:
-            response: httpx Response object
-            
-        Returns:
-            Response data as dictionary
-            
-        Raises:
-            APIKeyVerificationError: On 401 Unauthorized responses
-            httpx.HTTPStatusError: On other HTTP errors
+    def _raise_if_error(self, response: httpx.Response) -> None:
+        """Decode a non-2xx response and raise a typed ``LucidicError`` (LUC-900).
+
+        The single decode point: the backend ``{"error": ...}`` /
+        ``{"detail": ...}`` / mock-call ``{"error": {"code"}}`` envelopes all
+        map to typed exceptions via ``exception_from_response``. No-op on 2xx.
         """
-        # Log and raise for HTTP errors
-        if not response.is_success:
-            try:
-                error_data = response.json()
-                error_msg = error_data.get('detail', response.text)
-            except Exception:
-                error_msg = response.text
-            
-            error(f"[HTTP] Error {response.status_code}: {error_msg}")
-            
-            # Raise specific error for authentication/authorization failures
-            if response.status_code in (401, 403):
-                raise APIKeyVerificationError(f"Authentication failed: {error_msg}")
-        
-        response.raise_for_status()
-        
+        if response.is_success:
+            return
+        text = response.text
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+        exc = exception_from_response(
+            response.status_code, body, text, retry_after=retry_after
+        )
+        error(f"[HTTP] Error {response.status_code}: {exc}")
+        raise exc
+
+    def _handle_response(self, response: httpx.Response) -> Dict[str, Any]:
+        """Raise a typed error on non-2xx, else parse and return the JSON body.
+
+        Raises:
+            LucidicError subclass: on any non-2xx response (see ``core.errors``).
+        """
+        self._raise_if_error(response)
+
         # Parse JSON response
         try:
             data = response.json()
@@ -162,10 +204,82 @@ class HttpClient:
             else:
                 # Return text if not JSON
                 data = {"response": response.text}
-        
+
         debug(f"[HTTP] Response ({response.status_code}): {truncate_data(data)}")
-        
+
         return data
+
+    def _send_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> httpx.Response:
+        """Send one request, retrying transient 429/503 on idempotent methods (LUC-901).
+
+        Connection-level failures are retried by the httpx transport's own
+        ``retries=``; this loop adds status-based retries for 429/503, but only
+        for idempotent methods (GET/HEAD/PUT/DELETE) — a POST/PATCH may have
+        committed a write before the error, so retrying could duplicate it.
+        Delays honor ``Retry-After`` (capped). Returns the final response (which
+        may still be an error — ``_handle_response`` types it).
+        """
+        max_retries = self.config.network.max_retries
+        backoff = self.config.network.backoff_factor
+        attempt = 0
+        while True:
+            response = self.sync_client.request(
+                method=method, url=url, params=params, json=json, **kwargs
+            )
+            retryable = (
+                method.upper() in _IDEMPOTENT_METHODS
+                and response.status_code in _RETRY_STATUSES
+            )
+            if retryable and attempt < max_retries:
+                delay = _retry_delay(response, attempt, backoff)
+                warning(
+                    f"[HTTP] {response.status_code} on {method} {url}; "
+                    f"retry {attempt + 1}/{max_retries} in {delay:.2f}s"
+                )
+                time.sleep(delay)
+                attempt += 1
+                continue
+            return response
+
+    async def _asend_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> httpx.Response:
+        """Async sibling of ``_send_with_retry``."""
+        max_retries = self.config.network.max_retries
+        backoff = self.config.network.backoff_factor
+        attempt = 0
+        while True:
+            response = await self.async_client.request(
+                method=method, url=url, params=params, json=json, **kwargs
+            )
+            retryable = (
+                method.upper() in _IDEMPOTENT_METHODS
+                and response.status_code in _RETRY_STATUSES
+            )
+            if retryable and attempt < max_retries:
+                delay = _retry_delay(response, attempt, backoff)
+                warning(
+                    f"[HTTP] {response.status_code} on {method} {url}; "
+                    f"retry {attempt + 1}/{max_retries} in {delay:.2f}s"
+                )
+                await asyncio.sleep(delay)
+                attempt += 1
+                continue
+            return response
     
     # ==================== Synchronous Methods ====================
     
@@ -231,7 +345,27 @@ class HttpClient:
             Response data as dictionary
         """
         return self.request("DELETE", endpoint, params=params)
-    
+
+    def head(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
+        """Make a synchronous HEAD request and return the response headers (LUC-903).
+
+        List endpoints answer HEAD with counts in headers (e.g. ``X-Total-Count``,
+        and sessions' ``X-Tags``) so callers can get a cheap count/tag summary
+        without paging. Raises a typed error on non-2xx.
+
+        Args:
+            endpoint: API endpoint (without base URL)
+            params: Query parameters (same filters as the matching ``.list()``)
+
+        Returns:
+            The response headers (case-insensitive ``httpx.Headers``).
+        """
+        url = f"/{endpoint}"
+        debug(f"[HTTP] HEAD {self.base_url}{url}")
+        response = self._send_with_retry("HEAD", url, params=params)
+        self._raise_if_error(response)
+        return response.headers
+
     def request(
         self,
         method: str,
@@ -264,14 +398,8 @@ class HttpClient:
         if json:
             debug(f"[HTTP] Request body: {truncate_data(mask_sensitive(json))}")
         
-        response = self.sync_client.request(
-            method=method,
-            url=url,
-            params=params,
-            json=json,
-            **kwargs
-        )
-        
+        response = self._send_with_retry(method, url, params=params, json=json, **kwargs)
+
         return self._handle_response(response)
     
     # ==================== Asynchronous Methods ====================
@@ -338,7 +466,15 @@ class HttpClient:
             Response data as dictionary
         """
         return await self.arequest("DELETE", endpoint, params=params)
-    
+
+    async def ahead(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
+        """Async sibling of ``head`` (LUC-903)."""
+        url = f"/{endpoint}"
+        debug(f"[HTTP] HEAD {self.base_url}{url}")
+        response = await self._asend_with_retry("HEAD", url, params=params)
+        self._raise_if_error(response)
+        return response.headers
+
     async def arequest(
         self,
         method: str,
@@ -371,14 +507,8 @@ class HttpClient:
         if json:
             debug(f"[HTTP] Request body: {truncate_data(mask_sensitive(json))}")
         
-        response = await self.async_client.request(
-            method=method,
-            url=url,
-            params=params,
-            json=json,
-            **kwargs
-        )
-        
+        response = await self._asend_with_retry(method, url, params=params, json=json, **kwargs)
+
         return self._handle_response(response)
     
     # ==================== Lifecycle Methods ====================

--- a/lucidicai/api/downloads.py
+++ b/lucidicai/api/downloads.py
@@ -1,0 +1,37 @@
+"""Presigned-URL download fetch-through (LUC-904).
+
+Backend read paths — event raw blobs (``GET .../events/{id}?raw=true``) and
+training-module export downloads (``GET .../download-url``) — return
+short-lived presigned S3 GET URLs (5-20 min). These helpers download the bytes
+directly from S3 with **no** Lucidic auth header, mirroring the presigned
+PUT-upload path in ``sdk/event.py``.
+
+Never cache a presigned URL — it expires. Fetch the presigned URL fresh from
+the API each time and download immediately.
+"""
+from typing import Optional
+
+import httpx
+
+# Blob downloads can be large; give them a more generous default than the
+# 30s API timeout, but still bounded.
+DEFAULT_TIMEOUT = 60.0
+
+
+def fetch_presigned(url: str, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> bytes:
+    """Download and return the bytes at a presigned URL (sync).
+
+    Raises ``httpx.HTTPStatusError`` on a non-2xx from S3 (e.g. an expired
+    URL → 403). The caller re-requests a fresh presigned URL and retries.
+    """
+    resp = httpx.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.content
+
+
+async def afetch_presigned(url: str, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> bytes:
+    """Async sibling of ``fetch_presigned``."""
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return resp.content

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,0 +1,4 @@
+"""Typed response models for the Lucidic SDK read surface (LUC-905)."""
+from .base import APIModel, CursorPage
+
+__all__ = ["APIModel", "CursorPage"]

--- a/lucidicai/api/models/base.py
+++ b/lucidicai/api/models/base.py
@@ -14,7 +14,7 @@ owning model's ``from_dict`` override.
 ``CursorPage`` lives here too since it is the paginated container of models;
 the iteration helpers that walk ``next`` live in ``api/pagination.py``.
 """
-import dataclasses
+from dataclasses import asdict, dataclass, fields
 from typing import Any, Dict, List, Optional, Type, TypeVar
 from urllib.parse import parse_qs, urlparse
 
@@ -39,7 +39,7 @@ class APIModel:
                 f"{cls.__name__}.from_dict expected a dict, got "
                 f"{type(data).__name__}"
             )
-        field_names = {f.name for f in dataclasses.fields(cls)}
+        field_names = {f.name for f in fields(cls)}
         known = {k: v for k, v in data.items() if k in field_names}
         extra = {k: v for k, v in data.items() if k not in field_names}
         obj = cls(**known)
@@ -59,7 +59,7 @@ class APIModel:
 
     def to_dict(self) -> Dict[str, Any]:
         """Shallow dict of the declared dataclass fields (excludes ``extra``)."""
-        return dataclasses.asdict(self)
+        return asdict(self)
 
 
 def _extract_cursor(url: Optional[str]) -> Optional[str]:
@@ -71,7 +71,7 @@ def _extract_cursor(url: Optional[str]) -> Optional[str]:
     return values[0] if values else None
 
 
-@dataclasses.dataclass
+@dataclass
 class CursorPage:
     """One page of a cursor-paginated list endpoint.
 

--- a/lucidicai/api/models/base.py
+++ b/lucidicai/api/models/base.py
@@ -1,0 +1,106 @@
+"""Typed response-model base for the SDK read surface (LUC-905).
+
+Read methods return typed dataclasses instead of raw dicts. Each model is a
+plain ``@dataclass`` that mixes in ``APIModel`` and is built from backend JSON
+via ``from_dict`` — which ignores unrecognized keys (kept on ``.extra`` for
+forward-compat, so a newer backend can add fields without breaking an older
+SDK) and lets the dataclass surface a clear error for a genuinely missing
+required field.
+
+No pydantic — this extends the SDK's lone prior model precedent, the ``Prompt``
+dataclass (``api/resources/prompt.py``). Nested typed models convert in the
+owning model's ``from_dict`` override.
+
+``CursorPage`` lives here too since it is the paginated container of models;
+the iteration helpers that walk ``next`` live in ``api/pagination.py``.
+"""
+import dataclasses
+from typing import Any, Dict, List, Optional, Type, TypeVar
+from urllib.parse import parse_qs, urlparse
+
+T = TypeVar("T", bound="APIModel")
+
+
+class APIModel:
+    """Mixin for typed backend response models.
+
+    Subclasses must be ``@dataclass``. ``APIModel`` is intentionally *not*
+    itself a dataclass so that a base field (e.g. a defaulted ``extra``) does
+    not force every subclass field to carry a default — the classic dataclass
+    inheritance ordering trap. Unknown backend fields are stashed on a private
+    ``_extra`` attribute and exposed read-only via ``.extra``.
+    """
+
+    @classmethod
+    def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
+        """Build a model from a backend JSON object, ignoring unknown keys."""
+        if not isinstance(data, dict):
+            raise TypeError(
+                f"{cls.__name__}.from_dict expected a dict, got "
+                f"{type(data).__name__}"
+            )
+        field_names = {f.name for f in dataclasses.fields(cls)}
+        known = {k: v for k, v in data.items() if k in field_names}
+        extra = {k: v for k, v in data.items() if k not in field_names}
+        obj = cls(**known)
+        # object.__setattr__ works whether or not the subclass is frozen.
+        object.__setattr__(obj, "_extra", extra)
+        return obj
+
+    @classmethod
+    def from_list(cls: Type[T], items: List[Dict[str, Any]]) -> List[T]:
+        """Build a list of models from a list of backend JSON objects."""
+        return [cls.from_dict(item) for item in items]
+
+    @property
+    def extra(self) -> Dict[str, Any]:
+        """Backend fields not mapped to a declared attribute (forward-compat)."""
+        return getattr(self, "_extra", {})
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Shallow dict of the declared dataclass fields (excludes ``extra``)."""
+        return dataclasses.asdict(self)
+
+
+def _extract_cursor(url: Optional[str]) -> Optional[str]:
+    """Pull the ``cursor`` query param out of a paginated ``next``/``previous``
+    URL. Returns None when there is no such page or no cursor present."""
+    if not url:
+        return None
+    values = parse_qs(urlparse(url).query).get("cursor")
+    return values[0] if values else None
+
+
+@dataclasses.dataclass
+class CursorPage:
+    """One page of a cursor-paginated list endpoint.
+
+    ``results`` are typed models when a ``model`` was supplied to
+    ``from_body``, else raw dicts. ``next_cursor`` / ``previous_cursor`` are the
+    extracted cursor tokens (None at the ends). ``raw`` is the untouched body.
+    """
+
+    results: List[Any]
+    next_cursor: Optional[str]
+    previous_cursor: Optional[str]
+    raw: Dict[str, Any]
+
+    @classmethod
+    def from_body(
+        cls, body: Dict[str, Any], *, model: Optional[Type[APIModel]] = None
+    ) -> "CursorPage":
+        raw_results = body.get("results", []) if isinstance(body, dict) else []
+        results = [
+            model.from_dict(item) if model is not None else item
+            for item in raw_results
+        ]
+        return cls(
+            results=results,
+            next_cursor=_extract_cursor(body.get("next") if isinstance(body, dict) else None),
+            previous_cursor=_extract_cursor(body.get("previous") if isinstance(body, dict) else None),
+            raw=body if isinstance(body, dict) else {},
+        )
+
+    @property
+    def has_next(self) -> bool:
+        return self.next_cursor is not None

--- a/lucidicai/api/pagination.py
+++ b/lucidicai/api/pagination.py
@@ -1,0 +1,56 @@
+"""Cursor-pagination iteration for the SDK read surface (LUC-902).
+
+v2 list endpoints return ``{"results": [...], "next": <url|null>,
+"previous": <url|null>}`` with ``?page_size`` (default 50, max 200),
+``?cursor``, and an allow-listed ``?ordering``. ``paginate`` / ``apaginate``
+return a lazy iterator that transparently follows ``next``, yielding typed
+items so callers can write ``for agent in client.agents.list(...)``.
+
+Following ``next`` re-issues the page request through the authed
+``HttpClient`` (the ``fetch`` callback extracts and forwards the ``cursor``)
+rather than hitting the raw ``next`` URL directly, so auth headers, retry, and
+base-URL handling are all preserved. For single-page / manual control, call
+the endpoint once and wrap the body with ``CursorPage.from_body``.
+"""
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Iterator, Optional, Type
+
+from .models.base import APIModel, CursorPage, _extract_cursor
+
+__all__ = ["paginate", "apaginate", "CursorPage"]
+
+# fetch(cursor) -> raw page body. cursor is None for the first page.
+_SyncFetch = Callable[[Optional[str]], Dict[str, Any]]
+_AsyncFetch = Callable[[Optional[str]], Awaitable[Dict[str, Any]]]
+
+
+def _convert(item: Any, model: Optional[Type[APIModel]]) -> Any:
+    return model.from_dict(item) if model is not None else item
+
+
+def paginate(fetch: _SyncFetch, *, model: Optional[Type[APIModel]] = None) -> Iterator[Any]:
+    """Lazily yield every item across all pages.
+
+    ``fetch(cursor)`` performs one page request (``cursor=None`` first) and
+    returns the raw ``{results, next, previous}`` body. Each item is converted
+    via ``model.from_dict`` when a ``model`` is given, else yielded raw.
+    """
+    cursor: Optional[str] = None
+    while True:
+        body = fetch(cursor)
+        for item in (body.get("results", []) if isinstance(body, dict) else []):
+            yield _convert(item, model)
+        cursor = _extract_cursor(body.get("next") if isinstance(body, dict) else None)
+        if cursor is None:
+            return
+
+
+async def apaginate(fetch: _AsyncFetch, *, model: Optional[Type[APIModel]] = None) -> AsyncIterator[Any]:
+    """Async sibling of ``paginate`` — ``async for item in apaginate(...)``."""
+    cursor: Optional[str] = None
+    while True:
+        body = await fetch(cursor)
+        for item in (body.get("results", []) if isinstance(body, dict) else []):
+            yield _convert(item, model)
+        cursor = _extract_cursor(body.get("next") if isinstance(body, dict) else None)
+        if cursor is None:
+            return

--- a/lucidicai/api/resources/agent_tools_sync.py
+++ b/lucidicai/api/resources/agent_tools_sync.py
@@ -19,10 +19,7 @@ Backend contract (``api/views/sdk_agent_tools.py``, frozen):
 import logging
 from typing import Any, Dict, List
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import LucidicError
 
 logger = logging.getLogger("Lucidic")
 
@@ -52,21 +49,17 @@ class SyncAgentToolsResource:
         "drift_count": int, ...}}`` (exact shape is informational; the
         SDK only checks synced=True).
 
-        Raises ``LucidicError`` on any non-2xx. The validation-failure
-        path (422) carries a structured error body in
-        ``exc.response.json()["errors"]`` — surfaced inline in the
-        exception message so callers see the bad payload field without
-        manual parsing.
+        Raises a typed ``LucidicError`` on any non-2xx. A 422 validation
+        failure surfaces as ``ValidationError`` with the ``{<field>: [...]}}``
+        payload on ``.details``; a 503 (lock contention) is retried by the
+        transport first, then raised as ``ServiceUnavailableError``.
         """
         body = {"agent_id": agent_id, "tools": tools}
         logger.debug(
             "[SyncAgentToolsResource] syncing %d tool(s) for agent %s",
             len(tools), agent_id[:8] + "...",
         )
-        try:
-            return self.http.post("sdk/agent-tools/sync", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_sync_error(exc)) from exc
+        return self.http.post("sdk/agent-tools/sync", body)
 
     async def async_sync(
         self,
@@ -76,26 +69,4 @@ class SyncAgentToolsResource:
     ) -> Dict[str, Any]:
         """Async sibling of ``sync``."""
         body = {"agent_id": agent_id, "tools": tools}
-        try:
-            return await self.http.apost("sdk/agent-tools/sync", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_sync_error(exc)) from exc
-
-
-def _format_sync_error(exc: httpx.HTTPStatusError) -> str:
-    """Best-effort human-readable error from a non-2xx /sdk/agent-tools/sync.
-
-    422 carries ``{"errors": {<field>: [...messages]}}`` from
-    Tool.clean; 503 carries ``{"error": <str>}``; other shapes fall
-    back to status + raw body.
-    """
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
-    if isinstance(body, dict):
-        if "errors" in body:
-            return f"HTTP {exc.response.status_code} validation: {body['errors']}"
-        if "error" in body:
-            return f"HTTP {exc.response.status_code}: {body['error']}"
-    return f"HTTP {exc.response.status_code}: {body!r}"
+        return await self.http.apost("sdk/agent-tools/sync", body)

--- a/lucidicai/api/resources/mock_call.py
+++ b/lucidicai/api/resources/mock_call.py
@@ -32,13 +32,8 @@ Backend contract (`api/views/sdk_mock_call.py`, frozen):
 import logging
 from typing import Any, Dict, Optional
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import (
-    LucidicMockCallError,
-    error_class_for_code,
-)
+from ...core.errors import APIError, LucidicMockCallError
 
 logger = logging.getLogger("Lucidic")
 
@@ -49,54 +44,20 @@ def _truncate_id(id_str: Optional[str]) -> str:
     return f"{id_str[:8]}..." if len(id_str) > 8 else id_str
 
 
-def _exception_from_http_error(exc: httpx.HTTPStatusError) -> LucidicMockCallError:
-    """Translate a non-2xx response into the appropriate typed exception.
+def _as_mock_error(exc: APIError) -> LucidicMockCallError:
+    """Wrap a generic/untyped API error as a mock-call ``malformed_response``.
 
-    Backend envelope (LUC-584) is uniform: ``{"error": {"code": str,
-    "detail": str, ...code-specific keys...}}``. Look up the class by
-    `code` via ``error_class_for_code`` (returns the base class for
-    unknown codes — forward-compat with backend additions).
-
-    Falls back to ``LucidicMockCallError`` with a synthetic detail when
-    the body isn't parseable as the documented envelope (truncated
-    responses, proxy errors that don't pass the JSON through, etc.).
+    The central decoder (LUC-900) already produces the typed
+    ``LucidicMockCallError`` family for the ``{"error": {"code"}}`` envelope
+    (propagated untouched), and specific typed errors for recognized statuses
+    — ``InsufficientScopeError`` / ``AuthError`` / ``RateLimitError`` /
+    ``ValidationError`` etc. — which callers should see with their type and
+    fields intact, so those propagate too. Only a bare ``APIError`` (an
+    unparseable / proxy body, or an unmapped status) is wrapped here, so
+    ``sdk/tools/transport.py`` can still ``except LucidicMockCallError`` for the
+    genuinely-malformed case.
     """
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return LucidicMockCallError(
-            code="malformed_response",
-            detail=f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}",
-        )
-
-    err = body.get("error") if isinstance(body, dict) else None
-    if not isinstance(err, dict) or "code" not in err:
-        return LucidicMockCallError(
-            code="malformed_response",
-            detail=f"HTTP {exc.response.status_code}: {body!r}",
-        )
-
-    code = err["code"]
-    detail = err.get("detail", "")
-    extra = {k: v for k, v in err.items() if k not in ("code", "detail")}
-    cls = error_class_for_code(code)
-
-    # Each typed subclass that adds attributes does so via its own
-    # __init__ keyword params. Pass the extra dict through; classes that
-    # don't recognize a key still accept it via the base's **extra
-    # channel and stash it as an attribute.
-    #
-    # When `cls is LucidicMockCallError` (unknown code → forward-compat
-    # fallback), pass the actual code through so the exception carries
-    # the backend's wire value instead of the class-level default.
-    try:
-        if cls is LucidicMockCallError:
-            return cls(detail, code=code, **extra)
-        return cls(detail, **extra)
-    except TypeError:
-        # Defensive: if a subclass added a stricter __init__ in the
-        # future and rejects an unknown kwarg, fall back to the base.
-        return LucidicMockCallError(code=code, detail=detail, **extra)
+    return LucidicMockCallError(code="malformed_response", detail=str(exc))
 
 
 class MockCallResource:
@@ -150,8 +111,10 @@ class MockCallResource:
 
         try:
             return self.http.post("sdk/mock-call", body)
-        except httpx.HTTPStatusError as exc:
-            raise _exception_from_http_error(exc) from exc
+        except LucidicMockCallError:
+            raise
+        except APIError as exc:
+            raise _as_mock_error(exc) from exc
 
     async def acall(
         self,
@@ -177,8 +140,10 @@ class MockCallResource:
 
         try:
             return await self.http.apost("sdk/mock-call", body)
-        except httpx.HTTPStatusError as exc:
-            raise _exception_from_http_error(exc) from exc
+        except LucidicMockCallError:
+            raise
+        except APIError as exc:
+            raise _as_mock_error(exc) from exc
 
     # ==================== create() / acreate() — legacy LUC-483 API ====================
 

--- a/lucidicai/api/resources/session_init_fixtures.py
+++ b/lucidicai/api/resources/session_init_fixtures.py
@@ -23,10 +23,7 @@ Backend contract (``api/views/sdk_session_fixtures.py``):
 import logging
 from typing import Any, Dict
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import LucidicError
 
 logger = logging.getLogger("Lucidic")
 
@@ -44,37 +41,20 @@ class SessionInitFixturesResource:
         True → session is tool-backed and ready for mock_call; False →
         no-op (session has no DatasetItem or no Resources/tools).
 
-        Raises ``LucidicError`` on 4xx/5xx with the backend's error
-        string. The session_not_found path (404) is a real bug — the
-        session_id was wrong or already finished — but we surface it
-        as a plain ``LucidicError`` since the caller in
-        ``SessionResource.create()`` already swallows + warns.
+        Raises a typed ``LucidicError`` (e.g. ``NotFoundError`` on a wrong /
+        finished session_id, ``ServiceUnavailableError`` after the transport
+        exhausts its 503 retry budget) on non-2xx. The caller in
+        ``SessionResource.create()`` already swallows + warns, so these don't
+        surface to the user.
         """
         body = {"session_id": session_id}
         logger.debug(
             "[SessionInitFixturesResource] init session %s",
             session_id[:8] + "..." if len(session_id) > 8 else session_id,
         )
-        try:
-            return self.http.post("sdk/session-init-fixtures", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_init_error(exc)) from exc
+        return self.http.post("sdk/session-init-fixtures", body)
 
     async def ainit(self, session_id: str) -> Dict[str, Any]:
         """Async sibling of ``init``."""
         body = {"session_id": session_id}
-        try:
-            return await self.http.apost("sdk/session-init-fixtures", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_init_error(exc)) from exc
-
-
-def _format_init_error(exc: httpx.HTTPStatusError) -> str:
-    """Best-effort human-readable error from a non-2xx response."""
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
-    if isinstance(body, dict) and "error" in body:
-        return f"HTTP {exc.response.status_code}: {body['error']}"
-    return f"HTTP {exc.response.status_code}: {body!r}"
+        return await self.http.apost("sdk/session-init-fixtures", body)

--- a/lucidicai/api/resources/training_modules.py
+++ b/lucidicai/api/resources/training_modules.py
@@ -5,14 +5,16 @@ Thin wrappers over the backend inference-time Training Modules endpoints:
 - GET /sdk/training-modules/tools
 - POST /sdk/training-modules/inferences
 - GET /sdk/training-modules/inferences/{inference_run_id}
+
+Non-2xx responses raise a typed ``LucidicError`` from the central transport
+decoder (LUC-900) — e.g. ``NotFoundError``, ``ValidationError`` (with
+``.details``), or ``ServiceUnavailableError`` after the transport's 503 retry
+budget is exhausted. This module no longer hand-formats error strings.
 """
 import logging
 from typing import Any, Dict, Optional
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import LucidicError
 
 logger = logging.getLogger("Lucidic")
 
@@ -41,13 +43,10 @@ class TrainingModulesAPIResource:
         ``prompt_name`` to scope to a single edit site server-side (LUC-801), and
         ``checkpoint_id`` to introspect a checkpoint without a live session.
         """
-        try:
-            return self.http.get(
-                "sdk/training-modules/tools",
-                _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return self.http.get(
+            "sdk/training-modules/tools",
+            _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
+        )
 
     async def alist_tools(
         self,
@@ -57,13 +56,10 @@ class TrainingModulesAPIResource:
         checkpoint_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Async sibling of ``list_tools``."""
-        try:
-            return await self.http.aget(
-                "sdk/training-modules/tools",
-                _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return await self.http.aget(
+            "sdk/training-modules/tools",
+            _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
+        )
 
     def submit_inference(
         self,
@@ -81,10 +77,7 @@ class TrainingModulesAPIResource:
         }
         if client_event_id is not None:
             body["client_event_id"] = client_event_id
-        try:
-            return self.http.post("sdk/training-modules/inferences", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return self.http.post("sdk/training-modules/inferences", body)
 
     async def asubmit_inference(
         self,
@@ -102,10 +95,7 @@ class TrainingModulesAPIResource:
         }
         if client_event_id is not None:
             body["client_event_id"] = client_event_id
-        try:
-            return await self.http.apost("sdk/training-modules/inferences", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return await self.http.apost("sdk/training-modules/inferences", body)
 
     def get_inference(
         self,
@@ -115,13 +105,10 @@ class TrainingModulesAPIResource:
     ) -> Dict[str, Any]:
         """Fetch an existing Training Module inference run."""
         params = {"session_id": session_id} if session_id else None
-        try:
-            return self.http.get(
-                f"sdk/training-modules/inferences/{inference_run_id}",
-                params,
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return self.http.get(
+            f"sdk/training-modules/inferences/{inference_run_id}",
+            params,
+        )
 
     async def aget_inference(
         self,
@@ -131,13 +118,10 @@ class TrainingModulesAPIResource:
     ) -> Dict[str, Any]:
         """Async sibling of ``get_inference``."""
         params = {"session_id": session_id} if session_id else None
-        try:
-            return await self.http.aget(
-                f"sdk/training-modules/inferences/{inference_run_id}",
-                params,
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return await self.http.aget(
+            f"sdk/training-modules/inferences/{inference_run_id}",
+            params,
+        )
 
 
 def _tools_params(
@@ -159,18 +143,3 @@ def _tools_params(
     if prompt_name is not None:
         params["prompt_name"] = prompt_name
     return params
-
-
-def _format_training_module_error(exc: httpx.HTTPStatusError) -> str:
-    """Best-effort human-readable Training Modules error."""
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
-
-    if isinstance(body, dict):
-        if "error" in body:
-            return f"HTTP {exc.response.status_code}: {body['error']}"
-        if "errors" in body:
-            return f"HTTP {exc.response.status_code} validation: {body['errors']}"
-    return f"HTTP {exc.response.status_code}: {body!r}"

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -8,10 +8,123 @@ class LucidicError(Exception):
     pass
 
 
-class APIKeyVerificationError(LucidicError):
-    """Exception for API key verification errors"""
-    def __init__(self, message):
-        super().__init__(f"Could not verify Lucidic API key: {message}")
+# ---------------------------------------------------------------------------
+# HTTP / API errors (LUC-900)
+# ---------------------------------------------------------------------------
+#
+# Every non-2xx response from the Lucidic API is decoded once, centrally, in
+# ``HttpClient._handle_response`` and raised as one of the typed exceptions
+# below (all subclasses of ``LucidicError``, so ``except LucidicError`` still
+# catches everything). The backend error envelope is one of:
+#
+#   {"error": "<message>"}                       -> message
+#   {"error": "Validation failed", "details": …} -> message + details
+#   {"errors": {<field>: [...]}}                 -> ValidationError(details=…)
+#   {"detail": "<message>"}                      -> message (DRF default)
+#   {"error": {"code": str, ...}}                -> mock-call family (below)
+#
+# ``exception_from_response`` does the decoding; ``_STATUS_TO_CLASS`` maps
+# status codes to the generic classes.
+
+
+class LucidicAPIError(LucidicError):
+    """Base for a typed non-2xx response from the Lucidic API.
+
+    Carries the HTTP ``status_code``, the decoded ``response_body`` (when the
+    body was JSON), the raw ``response_text``, and any field-level ``details``
+    so callers can inspect a failure without re-parsing the response.
+    """
+
+    # Subclasses pin their canonical status; the base leaves it None.
+    status_code: Optional[int] = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        details: Any = None,
+        response_body: Any = None,
+        response_text: Optional[str] = None,
+    ):
+        if status_code is not None:
+            self.status_code = status_code
+        self.details = details
+        self.response_body = response_body
+        self.response_text = response_text
+        super().__init__(message)
+
+
+class ValidationError(LucidicAPIError):
+    """400 / 422 — invalid input. ``details`` carries field-level errors when
+    the backend returns ``{"errors": {...}}`` or ``{"details": {...}}``."""
+    status_code = 400
+
+
+class AuthError(LucidicAPIError):
+    """401 — missing or invalid API key."""
+    status_code = 401
+
+
+class APIKeyVerificationError(AuthError):
+    """Exception for API key verification errors.
+
+    Kept as a distinct type + message for the init/verify path and for
+    back-compat with callers that ``except APIKeyVerificationError``; it is now
+    an ``AuthError`` subclass so ``except AuthError`` catches it too.
+    """
+    def __init__(self, message, **kwargs: Any):
+        super().__init__(f"Could not verify Lucidic API key: {message}", **kwargs)
+
+
+class InsufficientScopeError(LucidicAPIError):
+    """403 — the API key lacks the required capability scope.
+
+    ``required_scope`` names the missing ``resource:verb`` when the backend
+    reports it, so the message can tell the user which preset/key to mint.
+    """
+    status_code = 403
+
+    def __init__(self, message: str, *, required_scope: Optional[str] = None, **kwargs: Any):
+        self.required_scope = required_scope
+        super().__init__(message, **kwargs)
+
+
+class NotFoundError(LucidicAPIError):
+    """404 — resource not found, **or** an agent-bound key that can't see it
+    (the backend returns 404 rather than 403 to avoid leaking existence)."""
+    status_code = 404
+
+
+class ConflictError(LucidicAPIError):
+    """409 — conflict, typically a duplicate (unique-constraint) violation."""
+    status_code = 409
+
+
+class RateLimitError(LucidicAPIError):
+    """429 — throttled. Raised only after the transport's retry budget is
+    exhausted; ``retry_after`` carries the server's hint when present."""
+    status_code = 429
+
+    def __init__(self, message: str, *, retry_after: Optional[float] = None, **kwargs: Any):
+        self.retry_after = retry_after
+        super().__init__(message, **kwargs)
+
+
+class ServiceUnavailableError(LucidicAPIError):
+    """503 — temporarily unavailable (Temporal / S3 degraded, or a workflow
+    couldn't start). Retryable; raised only after the transport's retry budget
+    is exhausted. ``retry_after`` carries the server's hint when present."""
+    status_code = 503
+
+    def __init__(self, message: str, *, retry_after: Optional[float] = None, **kwargs: Any):
+        self.retry_after = retry_after
+        super().__init__(message, **kwargs)
+
+
+class APIError(LucidicAPIError):
+    """Any other non-2xx (5xx, unmapped codes, or an unparseable/malformed
+    body). The catch-all so callers always get a typed ``LucidicAPIError``."""
 
 class LucidicNotInitializedError(LucidicError):
     """Exception for calling Lucidic functions before Lucidic Client is initialized (lai.init())"""
@@ -239,6 +352,98 @@ def error_class_for_code(code: str) -> Type[LucidicMockCallError]:
     generic `LucidicError`.
     """
     return _CODE_TO_CLASS.get(code, LucidicMockCallError)
+
+
+# ---------------------------------------------------------------------------
+# Central non-2xx decoding (LUC-900)
+# ---------------------------------------------------------------------------
+
+# Status -> generic typed exception. The mock-call ``{"error": {"code"}}``
+# family is matched by *shape*, not status, before this map is consulted.
+_STATUS_TO_CLASS: dict[int, Type[LucidicAPIError]] = {
+    400: ValidationError,
+    401: APIKeyVerificationError,  # back-compat: keep the verify-key type on 401
+    403: InsufficientScopeError,
+    404: NotFoundError,
+    409: ConflictError,
+    422: ValidationError,
+    429: RateLimitError,
+    503: ServiceUnavailableError,
+}
+
+
+def _mock_error_from_envelope(err: dict) -> LucidicMockCallError:
+    """Build the typed mock-call exception from a decoded
+    ``{"code": str, "detail": str, ...code-specific}`` error object.
+
+    Mirrors the forward-compat handling of the former
+    ``mock_call._exception_from_http_error``: unknown codes fall back to the
+    base ``LucidicMockCallError`` carrying the wire ``code``.
+    """
+    # Caller guarantees "code" is present (matched by shape before dispatch).
+    code = err["code"]
+    detail = err.get("detail", "")
+    extra = {k: v for k, v in err.items() if k not in ("code", "detail")}
+    cls = error_class_for_code(code)
+    try:
+        if cls is LucidicMockCallError:
+            return cls(detail, code=code, **extra)
+        return cls(detail, **extra)
+    except TypeError:
+        # Defensive: a subclass with a stricter __init__ rejecting an unknown
+        # kwarg still degrades to the base class.
+        return LucidicMockCallError(code=code, detail=detail, **extra)
+
+
+def exception_from_response(
+    status_code: int,
+    body: Any,
+    text: str = "",
+    *,
+    retry_after: Optional[float] = None,
+) -> LucidicError:
+    """Decode a non-2xx response into a typed exception.
+
+    Shapes handled, in priority order: the mock-call ``{"error": {"code"}}``
+    family, ``{"errors": {...}}`` validation dicts, ``{"error": "..."}`` (with
+    optional ``details``), DRF ``{"detail": "..."}``, then a text fallback.
+    Unknown/absent status codes yield ``APIError`` so callers always get a
+    typed ``LucidicAPIError``.
+    """
+    details: Any = None
+    message: Optional[str] = None
+
+    if isinstance(body, dict):
+        err = body.get("error")
+        # Mock-call family is keyed by shape (a nested dict with a "code"),
+        # which no generic endpoint returns — safe to match regardless of path.
+        if isinstance(err, dict) and "code" in err:
+            return _mock_error_from_envelope(err)
+        if isinstance(body.get("errors"), dict):
+            details = body["errors"]
+            message = "Validation failed"
+        elif isinstance(err, str):
+            message = err
+            if isinstance(body.get("details"), (dict, list)):
+                details = body["details"]
+        elif isinstance(body.get("detail"), str):
+            message = body["detail"]
+
+    if message is None:
+        message = text or f"HTTP {status_code}"
+
+    cls = _STATUS_TO_CLASS.get(status_code, APIError)
+    kwargs: dict = {
+        "status_code": status_code,
+        "details": details,
+        "response_body": body if isinstance(body, dict) else None,
+        "response_text": text,
+    }
+    if cls in (RateLimitError, ServiceUnavailableError):
+        kwargs["retry_after"] = retry_after
+    if cls is InsufficientScopeError and isinstance(body, dict):
+        kwargs["required_scope"] = body.get("required_scope")
+    return cls(message, **kwargs)
 
 
 def install_error_handler():

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures for transport-layer tests (tests/api/).
+
+Build a hermetic ``HttpClient`` against a stub URL with configs constructed
+directly (never ``from_env`` — that honors ``LUCIDIC_DEBUG`` and would
+silently redirect to localhost). ``backoff_factor`` is tiny and retry sleeps
+are patched out in the retry tests, so nothing here actually waits.
+"""
+import pytest
+
+from lucidicai.api.client import HttpClient
+from lucidicai.core.config import NetworkConfig, SDKConfig
+
+BASE_URL = "https://stub.lucidic.test"
+
+
+@pytest.fixture
+def base_url() -> str:
+    return BASE_URL
+
+
+@pytest.fixture
+def http() -> HttpClient:
+    config = SDKConfig(
+        api_key="test-key",
+        agent_id="00000000-0000-0000-0000-000000000000",
+        network=NetworkConfig(base_url=BASE_URL, max_retries=3, backoff_factor=0.01),
+    )
+    return HttpClient(config=config)

--- a/tests/api/resources/test_mock_call.py
+++ b/tests/api/resources/test_mock_call.py
@@ -15,11 +15,13 @@ from lucidicai.api.client import HttpClient
 from lucidicai.api.resources.mock_call import MockCallResource
 from lucidicai.core.config import NetworkConfig, SDKConfig
 from lucidicai.core.errors import (
+    InsufficientScopeError,
     LucidicMockCallError,
     LucidicToolBlockedError,
     LucidicToolDriftError,
     LucidicUnknownToolError,
     LucidicUnsupportedSQLError,
+    RateLimitError,
 )
 
 
@@ -198,6 +200,27 @@ class TestCallErrors:
         with pytest.raises(LucidicMockCallError) as exc_info:
             resource.call(session_id="s", tool_name="t", kwargs={})
         assert exc_info.value.code == "malformed_response"
+
+
+class TestCallPropagatesTypedErrors:
+    """Well-typed non-mock errors (auth / scope / rate-limit) must propagate
+    with their type + fields intact — NOT be flattened to malformed_response.
+    Only a genuinely untyped/malformed body becomes a mock error."""
+
+    @respx.mock
+    def test_403_scope_propagates_with_fields(self, resource):
+        respx.post(_ENDPOINT).mock(return_value=httpx.Response(
+            403, json={"error": "missing scope", "required_scope": "tool:mock"}))
+        with pytest.raises(InsufficientScopeError) as ei:
+            resource.call(session_id="s", tool_name="t", kwargs={})
+        assert ei.value.required_scope == "tool:mock"
+
+    @respx.mock
+    def test_429_rate_limit_propagates(self, resource):
+        respx.post(_ENDPOINT).mock(return_value=httpx.Response(
+            429, json={"detail": "slow down"}))
+        with pytest.raises(RateLimitError):
+            resource.call(session_id="s", tool_name="t", kwargs={})
 
 
 # ---------- acall (async) ------------------------------------------------

--- a/tests/api/test_downloads.py
+++ b/tests/api/test_downloads.py
@@ -1,0 +1,35 @@
+"""LUC-904 — presigned-URL GET fetch-through."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.downloads import afetch_presigned, fetch_presigned
+
+_PRESIGNED = "https://s3.example.com/bucket/key?X-Amz-Signature=deadbeef"
+
+
+class TestFetchPresigned:
+    @respx.mock
+    def test_returns_bytes(self):
+        respx.get(_PRESIGNED).mock(return_value=httpx.Response(200, content=b"blob-bytes"))
+        assert fetch_presigned(_PRESIGNED) == b"blob-bytes"
+
+    @respx.mock
+    def test_no_auth_header_sent(self):
+        # Presigned download bypasses the authed HttpClient — S3 needs no
+        # Lucidic Authorization header.
+        route = respx.get(_PRESIGNED).mock(return_value=httpx.Response(200, content=b"x"))
+        fetch_presigned(_PRESIGNED)
+        assert "Authorization" not in route.calls.last.request.headers
+
+    @respx.mock
+    def test_expired_url_raises(self):
+        respx.get(_PRESIGNED).mock(return_value=httpx.Response(403, text="expired"))
+        with pytest.raises(httpx.HTTPStatusError):
+            fetch_presigned(_PRESIGNED)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afetch_returns_bytes(self):
+        respx.get(_PRESIGNED).mock(return_value=httpx.Response(200, content=b"async-blob"))
+        assert await afetch_presigned(_PRESIGNED) == b"async-blob"

--- a/tests/api/test_head.py
+++ b/tests/api/test_head.py
@@ -1,0 +1,48 @@
+"""LUC-903 — HEAD count/tags helpers."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.core.errors import NotFoundError
+
+_URL = "https://stub.lucidic.test/sdk/v2/sessions"
+
+
+class TestHead:
+    @respx.mock
+    def test_returns_headers(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "42", "X-Tags": "prod,canary"}))
+        headers = http.head("sdk/v2/sessions")
+        assert headers["X-Total-Count"] == "42"
+        assert headers["X-Tags"] == "prod,canary"
+
+    @respx.mock
+    def test_case_insensitive(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "7"}))
+        headers = http.head("sdk/v2/sessions")
+        assert headers["x-total-count"] == "7"
+
+    @respx.mock
+    def test_forwards_filter_params(self, http):
+        route = respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "3"}))
+        http.head("sdk/v2/sessions", {"production": "true", "agent_id": "a1"})
+        sent = route.calls.last.request
+        assert sent.url.params["production"] == "true"
+        assert sent.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_error_raises_typed(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(404))
+        with pytest.raises(NotFoundError):
+            http.head("sdk/v2/sessions")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ahead_returns_headers(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "9"}))
+        headers = await http.ahead("sdk/v2/sessions")
+        assert headers["X-Total-Count"] == "9"

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,5 +1,5 @@
 """LUC-905 — typed response-model base."""
-import dataclasses
+from dataclasses import dataclass
 from typing import List, Optional
 
 import pytest
@@ -7,7 +7,7 @@ import pytest
 from lucidicai.api.models.base import APIModel
 
 
-@dataclasses.dataclass
+@dataclass
 class _Agent(APIModel):
     agent_id: str
     name: Optional[str] = None

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,0 +1,59 @@
+"""LUC-905 — typed response-model base."""
+import dataclasses
+from typing import List, Optional
+
+import pytest
+
+from lucidicai.api.models.base import APIModel
+
+
+@dataclasses.dataclass
+class _Agent(APIModel):
+    agent_id: str
+    name: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+
+class TestFromDict:
+    def test_maps_known_fields(self):
+        a = _Agent.from_dict({"agent_id": "a1", "name": "bot", "tags": ["x"]})
+        assert a.agent_id == "a1"
+        assert a.name == "bot"
+        assert a.tags == ["x"]
+
+    def test_unknown_fields_go_to_extra(self):
+        a = _Agent.from_dict({"agent_id": "a1", "created_at": "2026", "future_flag": True})
+        assert a.extra == {"created_at": "2026", "future_flag": True}
+        # ...and don't blow up construction (forward-compat).
+        assert a.agent_id == "a1"
+
+    def test_missing_optional_uses_default(self):
+        a = _Agent.from_dict({"agent_id": "a1"})
+        assert a.name is None and a.tags is None
+
+    def test_missing_required_raises(self):
+        with pytest.raises(TypeError):
+            _Agent.from_dict({"name": "no-id"})
+
+    def test_non_dict_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            _Agent.from_dict(["not", "a", "dict"])
+
+    def test_extra_defaults_empty(self):
+        a = _Agent.from_dict({"agent_id": "a1"})
+        assert a.extra == {}
+
+
+class TestFromList:
+    def test_builds_list(self):
+        items = _Agent.from_list([{"agent_id": "1"}, {"agent_id": "2", "name": "b"}])
+        assert [i.agent_id for i in items] == ["1", "2"]
+        assert items[1].name == "b"
+
+
+class TestToDict:
+    def test_excludes_extra(self):
+        a = _Agent.from_dict({"agent_id": "a1", "name": "bot", "unknown": 9})
+        d = a.to_dict()
+        assert d == {"agent_id": "a1", "name": "bot", "tags": None}
+        assert "unknown" not in d

--- a/tests/api/test_pagination.py
+++ b/tests/api/test_pagination.py
@@ -1,0 +1,102 @@
+"""LUC-902 — cursor-pagination lazy iterator."""
+import dataclasses
+from typing import Optional
+
+import pytest
+
+from lucidicai.api.models.base import APIModel, CursorPage, _extract_cursor
+from lucidicai.api.pagination import apaginate, paginate
+
+
+@dataclasses.dataclass
+class _Item(APIModel):
+    id: str
+    name: Optional[str] = None
+
+
+def _page(results, next_cursor):
+    nxt = f"https://stub.lucidic.test/things?cursor={next_cursor}" if next_cursor else None
+    return {"results": results, "next": nxt, "previous": None}
+
+
+class TestExtractCursor:
+    def test_pulls_cursor_param(self):
+        assert _extract_cursor("https://x/things?cursor=abc123&page_size=50") == "abc123"
+
+    def test_none_when_no_next(self):
+        assert _extract_cursor(None) is None
+
+    def test_none_when_no_cursor_param(self):
+        assert _extract_cursor("https://x/things?page_size=50") is None
+
+
+class TestPaginate:
+    def test_follows_next_across_pages(self):
+        pages = {
+            None: _page([{"id": "1"}, {"id": "2"}], "c1"),
+            "c1": _page([{"id": "3"}], "c2"),
+            "c2": _page([{"id": "4"}], None),
+        }
+        seen_cursors = []
+
+        def fetch(cursor):
+            seen_cursors.append(cursor)
+            return pages[cursor]
+
+        ids = [item.id for item in paginate(fetch, model=_Item)]
+        assert ids == ["1", "2", "3", "4"]
+        assert seen_cursors == [None, "c1", "c2"]
+
+    def test_single_page_stops(self):
+        calls = []
+
+        def fetch(cursor):
+            calls.append(cursor)
+            return _page([{"id": "only"}], None)
+
+        items = list(paginate(fetch, model=_Item))
+        assert len(items) == 1 and items[0].id == "only"
+        assert calls == [None]  # no second request
+
+    def test_raw_dicts_when_no_model(self):
+        def fetch(cursor):
+            return _page([{"id": "1"}], None)
+
+        items = list(paginate(fetch))
+        assert items == [{"id": "1"}]
+
+    def test_empty_results(self):
+        def fetch(cursor):
+            return {"results": [], "next": None}
+
+        assert list(paginate(fetch, model=_Item)) == []
+
+
+class TestCursorPage:
+    def test_from_body_typed(self):
+        page = CursorPage.from_body(_page([{"id": "1"}], "next-cur"), model=_Item)
+        assert isinstance(page.results[0], _Item)
+        assert page.next_cursor == "next-cur"
+        assert page.previous_cursor is None
+        assert page.has_next is True
+
+    def test_from_body_last_page(self):
+        page = CursorPage.from_body(_page([{"id": "1"}], None), model=_Item)
+        assert page.has_next is False
+
+
+class TestAsyncPaginate:
+    @pytest.mark.asyncio
+    async def test_apaginate_follows_next(self):
+        pages = {
+            None: _page([{"id": "1"}], "c1"),
+            "c1": _page([{"id": "2"}], None),
+        }
+
+        async def fetch(cursor):
+            return pages[cursor]
+
+        got = []
+        async for item in apaginate(fetch, model=_Item):
+            got.append(item.id)
+        assert got == ["1", "2"]

--- a/tests/api/test_pagination.py
+++ b/tests/api/test_pagination.py
@@ -1,5 +1,5 @@
 """LUC-902 — cursor-pagination lazy iterator."""
-import dataclasses
+from dataclasses import dataclass
 from typing import Optional
 
 import pytest
@@ -8,7 +8,7 @@ from lucidicai.api.models.base import APIModel, CursorPage, _extract_cursor
 from lucidicai.api.pagination import apaginate, paginate
 
 
-@dataclasses.dataclass
+@dataclass
 class _Item(APIModel):
     id: str
     name: Optional[str] = None

--- a/tests/api/test_transport_errors.py
+++ b/tests/api/test_transport_errors.py
@@ -1,0 +1,145 @@
+"""LUC-900 — central error-envelope decode + typed exception hierarchy.
+
+Backend is mocked via respx at the HTTP boundary so we exercise the real
+``HttpClient._handle_response`` → ``exception_from_response`` path and assert
+each envelope/status maps to the right typed ``LucidicError`` subclass.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.core.errors import (
+    APIError,
+    APIKeyVerificationError,
+    AuthError,
+    ConflictError,
+    exception_from_response,
+    InsufficientScopeError,
+    LucidicError,
+    LucidicUnknownToolError,
+    NotFoundError,
+    RateLimitError,
+    ServiceUnavailableError,
+    ValidationError,
+)
+
+_URL = "https://stub.lucidic.test/agents"
+
+
+def _mock(status, json=None, text=None, headers=None):
+    if json is not None:
+        return httpx.Response(status, json=json, headers=headers or {})
+    return httpx.Response(status, text=text or "", headers=headers or {})
+
+
+class TestTypedDecode:
+    @respx.mock
+    def test_400_error_string_is_validation_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(400, {"error": "bad input"}))
+        with pytest.raises(ValidationError) as ei:
+            http.get("agents")
+        assert str(ei.value) == "bad input"
+        assert ei.value.status_code == 400
+
+    @respx.mock
+    def test_400_validation_envelope_carries_details(self, http):
+        respx.get(_URL).mock(return_value=_mock(
+            400, {"error": "Validation failed", "details": {"name": ["required"]}}))
+        with pytest.raises(ValidationError) as ei:
+            http.get("agents")
+        assert ei.value.details == {"name": ["required"]}
+
+    @respx.mock
+    def test_422_errors_dict_is_validation_error_with_details(self, http):
+        respx.get(_URL).mock(return_value=_mock(
+            422, {"errors": {"tools": ["bad source_hash"]}}))
+        with pytest.raises(ValidationError) as ei:
+            http.get("agents")
+        assert ei.value.details == {"tools": ["bad source_hash"]}
+
+    @respx.mock
+    def test_401_is_api_key_verification_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(401, {"detail": "no key"}))
+        with pytest.raises(APIKeyVerificationError) as ei:
+            http.get("agents")
+        # Still an AuthError so `except AuthError` works.
+        assert isinstance(ei.value, AuthError)
+
+    @respx.mock
+    def test_403_is_insufficient_scope_and_names_scope(self, http):
+        respx.get(_URL).mock(return_value=_mock(
+            403, {"error": "missing scope", "required_scope": "agent:read"}))
+        with pytest.raises(InsufficientScopeError) as ei:
+            http.get("agents")
+        assert ei.value.required_scope == "agent:read"
+
+    @respx.mock
+    def test_404_is_not_found(self, http):
+        respx.get(_URL).mock(return_value=_mock(404, {"error": "gone"}))
+        with pytest.raises(NotFoundError):
+            http.get("agents")
+
+    @respx.mock
+    def test_409_is_conflict(self, http):
+        respx.get(_URL).mock(return_value=_mock(409, {"error": "duplicate"}))
+        with pytest.raises(ConflictError):
+            http.get("agents")
+
+    @respx.mock
+    def test_500_json_is_generic_api_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(500, {"detail": "boom"}))
+        with pytest.raises(APIError) as ei:
+            http.get("agents")
+        assert ei.value.status_code == 500
+        assert str(ei.value) == "boom"
+
+    @respx.mock
+    def test_non_json_body_is_api_error_with_text(self, http):
+        respx.get(_URL).mock(return_value=_mock(500, text="<html>500</html>"))
+        with pytest.raises(APIError) as ei:
+            http.get("agents")
+        assert ei.value.response_text == "<html>500</html>"
+
+    @respx.mock
+    def test_mock_call_code_family_still_produced_centrally(self, http):
+        # A `{"error": {"code"}}` body maps to the mock-call typed family even
+        # from a generic endpoint — the family is keyed by shape, not path.
+        respx.get(_URL).mock(return_value=_mock(
+            404, {"error": {"code": "unknown_tool", "detail": "no tool"}}))
+        with pytest.raises(LucidicUnknownToolError):
+            http.get("agents")
+
+    @respx.mock
+    def test_every_typed_error_is_a_lucidic_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(404, {"error": "x"}))
+        with pytest.raises(LucidicError):
+            http.get("agents")
+
+
+class TestDecoderUnit:
+    """Direct unit coverage of exception_from_response for the statuses the
+    transport retries (429/503), which the HttpClient path would retry first."""
+
+    def test_429_maps_to_rate_limit(self):
+        exc = exception_from_response(429, {"error": "slow down"}, retry_after=1.5)
+        assert isinstance(exc, RateLimitError)
+        assert exc.retry_after == 1.5
+
+    def test_503_maps_to_service_unavailable(self):
+        exc = exception_from_response(503, {"error": "degraded"}, retry_after=2.0)
+        assert isinstance(exc, ServiceUnavailableError)
+        assert exc.retry_after == 2.0
+
+    def test_unmapped_status_is_api_error(self):
+        exc = exception_from_response(418, {"error": "teapot"})
+        assert type(exc) is APIError
+        assert exc.status_code == 418
+
+
+class TestAsyncDecode:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_path_raises_typed(self, http):
+        respx.get(_URL).mock(return_value=_mock(404, {"error": "gone"}))
+        with pytest.raises(NotFoundError):
+            await http.aget("agents")

--- a/tests/api/test_transport_retry.py
+++ b/tests/api/test_transport_retry.py
@@ -1,0 +1,137 @@
+"""LUC-901 — 429/503 retry + backoff + Retry-After.
+
+Retry sleeps are patched out (and recorded) so the tests assert the retry
+count and computed delays without actually waiting.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.core.errors import NotFoundError, ServiceUnavailableError
+
+
+@pytest.fixture
+def sleeps(monkeypatch):
+    """Record + skip sync retry sleeps."""
+    recorded = []
+    monkeypatch.setattr("lucidicai.api.client.time.sleep", lambda s: recorded.append(s))
+    return recorded
+
+
+@pytest.fixture
+def asleeps(monkeypatch):
+    """Record + skip async retry sleeps."""
+    recorded = []
+
+    async def _fake(s):
+        recorded.append(s)
+
+    monkeypatch.setattr("lucidicai.api.client.asyncio.sleep", _fake)
+    return recorded
+
+
+_URL = "https://stub.lucidic.test/agents"
+
+
+class TestRetry:
+    @respx.mock
+    def test_503_then_success_is_retried(self, http, sleeps):
+        route = respx.get(_URL).mock(side_effect=[
+            httpx.Response(503, json={"error": "degraded"}),
+            httpx.Response(200, json={"ok": True}),
+        ])
+        assert http.get("agents") == {"ok": True}
+        assert route.call_count == 2
+        # First backoff = backoff_factor * 2**0 = 0.01.
+        assert sleeps == [pytest.approx(0.01)]
+
+    @respx.mock
+    def test_exponential_backoff_across_two_retries(self, http, sleeps):
+        route = respx.get(_URL).mock(side_effect=[
+            httpx.Response(503),
+            httpx.Response(503),
+            httpx.Response(200, json={"ok": 1}),
+        ])
+        http.get("agents")
+        assert route.call_count == 3
+        assert sleeps == [pytest.approx(0.01), pytest.approx(0.02)]
+
+    @respx.mock
+    def test_retry_after_header_overrides_backoff(self, http, sleeps):
+        respx.get(_URL).mock(side_effect=[
+            httpx.Response(429, headers={"Retry-After": "2"}),
+            httpx.Response(200, json={"ok": 1}),
+        ])
+        http.get("agents")
+        assert sleeps == [pytest.approx(2.0)]
+
+    @respx.mock
+    def test_exhausts_retries_then_raises_typed(self, http, sleeps):
+        # max_retries=3 -> 1 initial + 3 retries = 4 attempts, all 503.
+        route = respx.get(_URL).mock(return_value=httpx.Response(503, json={"error": "down"}))
+        with pytest.raises(ServiceUnavailableError):
+            http.get("agents")
+        assert route.call_count == 4
+        assert len(sleeps) == 3
+
+    @respx.mock
+    def test_non_retryable_status_not_retried(self, http, sleeps):
+        route = respx.get(_URL).mock(return_value=httpx.Response(404, json={"error": "x"}))
+        with pytest.raises(NotFoundError):
+            http.get("agents")
+        assert route.call_count == 1
+        assert sleeps == []
+
+    @respx.mock
+    def test_post_not_retried_may_have_committed(self, http, sleeps):
+        # A POST may have committed a write before the 503 (e.g. the EvoSim
+        # kickoff commits the run row, then 503s), so it must NOT be retried —
+        # retrying would duplicate. Fails fast, like pre-C0.
+        route = respx.post("https://stub.lucidic.test/sdk/thing").mock(
+            return_value=httpx.Response(503, json={"error": "down"}))
+        with pytest.raises(ServiceUnavailableError):
+            http.post("sdk/thing", {"a": 1})
+        assert route.call_count == 1
+        assert sleeps == []
+
+    @respx.mock
+    def test_put_is_retried(self, http, sleeps):
+        # PUT is idempotent -> safe to replay.
+        route = respx.put("https://stub.lucidic.test/sdk/thing").mock(side_effect=[
+            httpx.Response(503),
+            httpx.Response(200, json={"ok": True}),
+        ])
+        assert http.put("sdk/thing", {"a": 1})["ok"] is True
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_retry_after_is_capped(self, http, sleeps):
+        # A huge / proxy-injected Retry-After is clamped so it can't pin the
+        # caller thread for minutes (_MAX_RETRY_DELAY_SECONDS = 30).
+        respx.get(_URL).mock(side_effect=[
+            httpx.Response(503, headers={"Retry-After": "3600"}),
+            httpx.Response(200, json={"ok": 1}),
+        ])
+        http.get("agents")
+        assert sleeps == [pytest.approx(30.0)]
+
+
+class TestAsyncRetry:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_503_then_success(self, http, asleeps):
+        route = respx.get(_URL).mock(side_effect=[
+            httpx.Response(503),
+            httpx.Response(200, json={"ok": True}),
+        ])
+        assert await http.aget("agents") == {"ok": True}
+        assert route.call_count == 2
+        assert asleeps == [pytest.approx(0.01)]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_exhausts_and_raises(self, http, asleeps):
+        route = respx.get(_URL).mock(return_value=httpx.Response(503))
+        with pytest.raises(ServiceUnavailableError):
+            await http.aget("agents")
+        assert route.call_count == 4


### PR DESCRIPTION
First milestone of the **SDK-First Parity — Python Client** project — the shared `HttpClient` mechanics every read/write ticket downstream depends on. Extends the existing transport chokepoint; no new architecture. Ships as one cohesive PR because the six tickets are one interlocking transport-layer change with no individually-shippable surface.

## Tickets
- **LUC-900** — decode the backend error envelope once in `_handle_response` and raise a typed `LucidicError` hierarchy (`ValidationError`, `AuthError`, `InsufficientScopeError`, `NotFoundError`, `ConflictError`, `RateLimitError`, `ServiceUnavailableError`, `APIError`). Consolidates the four hand-rolled per-resource decoders onto the central path; the `LucidicMockCallError` code-family is matched by shape and preserved.
- **LUC-901** — retry 429/503 with exponential backoff + `Retry-After` (the previously-dead `backoff_factor`).
- **LUC-902** — `CursorPage` + lazy `paginate`/`apaginate` that follow `next`, yielding typed items.
- **LUC-903** — `head()`/`ahead()` → `X-Total-Count` / `X-Tags` for cheap counts.
- **LUC-904** — presigned-GET fetch-through (no auth header, never caches the URL).
- **LUC-905** — `APIModel` typed-dataclass base (`from_dict` tolerant of unknown fields for forward-compat), extending the `Prompt` precedent.

## Adversarial review — fixes folded in
A multi-agent review of the diff caught three real issues, fixed here:
- **Retry gated to idempotent methods** (GET/HEAD/PUT/DELETE). A POST that commits then 503s — e.g. the EvoSim kickoff commits the run row, then fails Temporal start — must not be retried or it duplicates the write. POST/PATCH fail fast, as pre-C0.
- **Retry-After sleep capped** (`_MAX_RETRY_DELAY_SECONDS = 30`) so a large/proxy-injected value can't pin the caller for minutes.
- **mock_call shim narrowed** to `except APIError`, so typed auth/scope/throttle errors propagate with their fields intact instead of being flattened to `malformed_response`.

## Notes
- **Behavior change:** 403 now raises `InsufficientScopeError` (was `APIKeyVerificationError`, which lumped 401/403). No live impact — scoped keys aren't shipped yet — but stale `Raises APIKeyVerificationError` docstrings in `sdk/features/dataset.py`/`session.py`/`feature_flag.py` should be refreshed in a follow-up.
- Deferred the cosmetic `User-Agent: lucidic-sdk/2.0` version fix (avoids a circular-import fiddle).
- Version bump is deferred to the umbrella→`main` merge (target `3.8.0`), not per sub-PR.
- 259 hermetic tests pass (50 new for C0; the 181-test tools path confirms the mock_call consolidation didn't regress).

## Files
- `lucidicai/api/client.py` — typed `_raise_if_error`/`_handle_response`, idempotent-gated retry sender, `head`/`ahead`
- `lucidicai/core/errors.py` — typed HTTP exception hierarchy + `exception_from_response` decoder
- `lucidicai/api/models/` (new) — `APIModel` + `CursorPage`
- `lucidicai/api/pagination.py` (new) — `paginate`/`apaginate`
- `lucidicai/api/downloads.py` (new) — presigned fetch-through
- `lucidicai/__init__.py` — export new exceptions + model base
- `lucidicai/api/resources/{mock_call,session_init_fixtures,agent_tools_sync,training_modules}.py` — simplified onto the central decoder
- `tests/api/` — errors, retry, pagination, head, downloads, models + mock_call typed-propagation cases