### PR TITLE
LUC-906: client.agents reads (list / get / tool_catalog)

### DIFF
--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,4 +1,5 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
+from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
 
-__all__ = ["APIModel", "CursorPage"]
+__all__ = ["APIModel", "CursorPage", "Agent", "AgentToolCatalog", "CatalogTool"]

--- a/lucidicai/api/models/agent.py
+++ b/lucidicai/api/models/agent.py
@@ -1,0 +1,69 @@
+"""Typed response models for client.agents (LUC-906)."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Agent(APIModel):
+    """An agent — the top-level entity every SDK call hangs off.
+
+    Returned by ``client.agents.list()`` / ``.get()``. ``agent_id`` is the id an
+    SDK-first caller needs to bootstrap (``LucidicAI(agent_id=...)``).
+    """
+
+    agent_id: str
+    name: Optional[str] = None
+    icon: Optional[str] = None
+    project_id: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class CatalogTool(APIModel):
+    """One tool in an agent's tool catalog, incl. denormalized usage counters
+    (``call_count`` / ``last_called_at``, bumped at event ingestion)."""
+
+    tool_id: str
+    name: Optional[str] = None
+    tier: Optional[str] = None
+    signature: Optional[Dict[str, Any]] = None
+    docstring: Optional[str] = None
+    return_shape: Optional[Any] = None
+    source_hash: Optional[str] = None
+    drift_acknowledged_hash: Optional[str] = None
+    has_drift: bool = False
+    impl_body: Optional[str] = None
+    impl_entry_point: Optional[str] = None
+    last_seen_at: Optional[str] = None
+    discovered_at: Optional[str] = None
+    call_count: int = 0
+    last_called_at: Optional[str] = None
+    resources: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class AgentToolCatalog(APIModel):
+    """An agent's tool catalog: its tools (typed) plus the deduped, agent-wide
+    reachable Resource set.
+
+    ``resources`` is kept as raw dicts — an auxiliary section most callers
+    don't need typed. ``tools`` are converted to ``CatalogTool`` on construction
+    (the nested-model pattern C1+ resources reuse).
+    """
+
+    agent_id: str
+    agent_name: Optional[str] = None
+    tools: List[CatalogTool] = field(default_factory=list)
+    resources: List[Dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentToolCatalog":
+        obj = super().from_dict(data)
+        # Convert the nested tool dicts to typed CatalogTool models (read the
+        # raw list from `data`, not obj.tools, which super() left as dicts).
+        # `or []` guards against the key being absent OR present-but-null.
+        raw_tools = (data.get("tools") or []) if isinstance(data, dict) else []
+        object.__setattr__(obj, "tools", CatalogTool.from_list(raw_tools))
+        return obj

--- a/lucidicai/api/models/base.py
+++ b/lucidicai/api/models/base.py
@@ -14,7 +14,7 @@ owning model's ``from_dict`` override.
 ``CursorPage`` lives here too since it is the paginated container of models;
 the iteration helpers that walk ``next`` live in ``api/pagination.py``.
 """
-from dataclasses import asdict, dataclass, fields
+from dataclasses import MISSING, asdict, dataclass, fields
 from typing import Any, Dict, List, Optional, Type, TypeVar
 from urllib.parse import parse_qs, urlparse
 
@@ -33,15 +33,32 @@ class APIModel:
 
     @classmethod
     def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
-        """Build a model from a backend JSON object, ignoring unknown keys."""
+        """Build a model from a backend JSON object.
+
+        Unknown keys are ignored (kept on ``.extra`` for forward-compat). A
+        ``null`` for a field that has a default (or ``default_factory``) is
+        dropped so the default applies — turning a backend ``"tools": null``
+        into ``[]`` rather than ``None``, which keeps a downstream
+        ``for x in model.field`` safe. A genuinely missing required field still
+        surfaces a clear ``TypeError`` from the dataclass constructor.
+        """
         if not isinstance(data, dict):
             raise TypeError(
                 f"{cls.__name__}.from_dict expected a dict, got "
                 f"{type(data).__name__}"
             )
-        field_names = {f.name for f in fields(cls)}
-        known = {k: v for k, v in data.items() if k in field_names}
-        extra = {k: v for k, v in data.items() if k not in field_names}
+        field_map = {f.name: f for f in fields(cls)}
+        known: Dict[str, Any] = {}
+        extra: Dict[str, Any] = {}
+        for key, value in data.items():
+            f = field_map.get(key)
+            if f is None:
+                extra[key] = value
+                continue
+            has_default = f.default is not MISSING or f.default_factory is not MISSING
+            if value is None and has_default:
+                continue  # let the field default apply instead of a null
+            known[key] = value
         obj = cls(**known)
         # object.__setattr__ works whether or not the subclass is frozen.
         object.__setattr__(obj, "_extra", extra)

--- a/lucidicai/api/resources/agents.py
+++ b/lucidicai/api/resources/agents.py
@@ -1,0 +1,127 @@
+"""client.agents — agent reads (LUC-906).
+
+Read the org's agents: ``list`` them (discover / enumerate ``agent_id`` s),
+``get`` one back, or inspect an agent's ``tool_catalog``.
+
+(A brand-new caller with *no* ``agent_id`` at all still can't construct the
+client to reach ``list`` — ``LucidicAI`` requires one today; a read-only /
+bootstrap construction mode is a planned follow-up. With any existing key +
+``agent_id`` you can enumerate the rest.)
+
+Reads are data-bearing, so — unlike the telemetry-write resources — they do
+NOT swallow errors in production: a failure raises the typed ``LucidicError``
+subclass the transport decoded (``NotFoundError``, ``InsufficientScopeError``,
+…). Every method has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.agent import Agent, AgentToolCatalog
+from ..models.base import CursorPage
+from ..pagination import apaginate, paginate
+
+_AGENTS = "sdk/v2/agents"
+
+
+class AgentsResource:
+    """Handle for the ``/sdk/v2/agents`` read endpoints."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    # ==================== list ====================
+
+    def list(
+        self, *, page_size: Optional[int] = None, ordering: Optional[str] = None
+    ) -> Iterator[Agent]:
+        """Lazily iterate the org's agents (backend default order: newest first),
+        following pages.
+
+        ``for agent in client.agents.list(): ...`` — a bound key sees only its
+        one agent. ``ordering`` accepts ``id`` / ``-id`` (the only
+        client-selectable ordering field).
+
+        Note: this is a lazy generator — request errors (403/etc.) surface on
+        the first iteration, not at the ``list()`` call. Use ``list_page`` for
+        an eager single-page fetch.
+        """
+        return paginate(
+            lambda cursor: self._page(cursor, page_size, ordering), model=Agent
+        )
+
+    def alist(
+        self, *, page_size: Optional[int] = None, ordering: Optional[str] = None
+    ) -> AsyncIterator[Agent]:
+        """Async sibling of ``list`` — ``async for agent in client.agents.alist()``."""
+        return apaginate(
+            lambda cursor: self._apage(cursor, page_size, ordering), model=Agent
+        )
+
+    def list_page(
+        self,
+        *,
+        cursor: Optional[str] = None,
+        page_size: Optional[int] = None,
+        ordering: Optional[str] = None,
+    ) -> CursorPage:
+        """Fetch a single page of agents (manual pagination control)."""
+        return CursorPage.from_body(self._page(cursor, page_size, ordering), model=Agent)
+
+    async def alist_page(
+        self,
+        *,
+        cursor: Optional[str] = None,
+        page_size: Optional[int] = None,
+        ordering: Optional[str] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage(cursor, page_size, ordering)
+        return CursorPage.from_body(body, model=Agent)
+
+    # ==================== get ====================
+
+    def get(self, agent_id: str) -> Agent:
+        """Read one agent by id. Raises ``NotFoundError`` if it doesn't exist
+        or the (bound) key can't see it."""
+        return Agent.from_dict(self.http.get(f"{_AGENTS}/{agent_id}"))
+
+    async def aget(self, agent_id: str) -> Agent:
+        """Async sibling of ``get``."""
+        return Agent.from_dict(await self.http.aget(f"{_AGENTS}/{agent_id}"))
+
+    # ==================== tool catalog ====================
+
+    def tool_catalog(self, agent_id: str) -> AgentToolCatalog:
+        """Read the agent's tool catalog: per-tool tier/impl/drift + denormalized
+        usage (``call_count`` / ``last_called_at``) and the reachable Resources."""
+        return AgentToolCatalog.from_dict(self.http.get(f"{_AGENTS}/{agent_id}/tool-catalog"))
+
+    async def atool_catalog(self, agent_id: str) -> AgentToolCatalog:
+        """Async sibling of ``tool_catalog``."""
+        body = await self.http.aget(f"{_AGENTS}/{agent_id}/tool-catalog")
+        return AgentToolCatalog.from_dict(body)
+
+    # ==================== internals ====================
+
+    @staticmethod
+    def _params(
+        cursor: Optional[str], page_size: Optional[int], ordering: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        if page_size is not None:
+            params["page_size"] = page_size
+        if ordering is not None:
+            params["ordering"] = ordering
+        return params or None
+
+    def _page(
+        self, cursor: Optional[str], page_size: Optional[int], ordering: Optional[str]
+    ) -> Dict[str, Any]:
+        return self.http.get(_AGENTS, self._params(cursor, page_size, ordering))
+
+    async def _apage(
+        self, cursor: Optional[str], page_size: Optional[int], ordering: Optional[str]
+    ) -> Dict[str, Any]:
+        return await self.http.aget(_AGENTS, self._params(cursor, page_size, ordering))

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -24,6 +24,7 @@ import uuid
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 from .api.client import HttpClient
+from .api.resources.agents import AgentsResource
 from .api.resources.session import SessionResource
 from .api.resources.event import EventResource
 from .api.resources.dataset import DatasetResource
@@ -155,6 +156,7 @@ class LucidicAI:
 
         # Initialize API resources
         self._resources: Dict[str, Any] = {
+            "agents": AgentsResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
             "datasets": DatasetResource(self._http, self._config.agent_id, self._production),
@@ -239,6 +241,17 @@ class LucidicAI:
     def is_valid(self) -> bool:
         """Check if the client is properly configured."""
         return self._valid
+
+    @property
+    def agents(self) -> AgentsResource:
+        """Access agent reads (LUC-906): ``list()`` / ``get(id)`` + ``tool_catalog(id)``.
+
+        Enumerate the org's agents (discover their ``agent_id`` s), read one
+        back, or inspect an agent's tool catalog. (A client still needs an
+        ``agent_id`` to construct today; a read-only bootstrap mode is a planned
+        follow-up.)
+        """
+        return self._resources["agents"]
 
     @property
     def tools(self) -> ToolsResource:

--- a/tests/api/resources/test_agents.py
+++ b/tests/api/resources/test_agents.py
@@ -1,0 +1,159 @@
+"""LUC-906 — client.agents reads (list / get / tool_catalog).
+
+Uses the hermetic ``http`` fixture from tests/api/conftest.py (stub URL,
+retry sleeps irrelevant here). Backend mocked at the HTTP boundary via respx.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.agent import Agent, AgentToolCatalog, CatalogTool
+from lucidicai.api.resources.agents import AgentsResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_AGENTS = f"{_BASE}/sdk/v2/agents"
+
+
+@pytest.fixture
+def agents(http):
+    return AgentsResource(http)
+
+
+def _agent(i, **over):
+    d = {
+        "agent_id": f"a{i}",
+        "name": f"agent-{i}",
+        "icon": "compass",
+        "project_id": None,
+        "created_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+class TestGet:
+    @respx.mock
+    def test_returns_typed_agent(self, agents):
+        respx.get(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = agents.get("a1")
+        assert isinstance(a, Agent)
+        assert a.agent_id == "a1"
+        assert a.name == "agent-1"
+        assert a.icon == "compass"
+
+    @respx.mock
+    def test_404_raises_not_found(self, agents):
+        respx.get(f"{_AGENTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            agents.get("missing")
+
+    @respx.mock
+    def test_tolerates_unknown_fields(self, agents):
+        respx.get(f"{_AGENTS}/a1").mock(
+            return_value=httpx.Response(200, json=_agent(1, future_field="x")))
+        a = agents.get("a1")
+        assert a.extra == {"future_field": "x"}
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages(self, agents):
+        respx.get(_AGENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_agent(1), _agent(2)],
+                                      "next": f"{_AGENTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_agent(3)], "next": None, "previous": None}),
+        ])
+        got = list(agents.list())
+        assert [a.agent_id for a in got] == ["a1", "a2", "a3"]
+        assert all(isinstance(a, Agent) for a in got)
+
+    @respx.mock
+    def test_forwards_ordering_and_page_size(self, agents):
+        route = respx.get(_AGENTS).mock(
+            return_value=httpx.Response(200, json={"results": [_agent(1)], "next": None}))
+        list(agents.list(ordering="id", page_size=10))
+        sent = route.calls.last.request
+        assert sent.url.params["ordering"] == "id"
+        assert sent.url.params["page_size"] == "10"
+
+    @respx.mock
+    def test_list_page_returns_cursor_page(self, agents):
+        respx.get(_AGENTS).mock(return_value=httpx.Response(
+            200, json={"results": [_agent(1)], "next": f"{_AGENTS}?cursor=c9", "previous": None}))
+        page = agents.list_page()
+        assert len(page.results) == 1 and isinstance(page.results[0], Agent)
+        assert page.next_cursor == "c9" and page.has_next
+
+
+class TestToolCatalog:
+    @respx.mock
+    def test_typed_catalog_with_typed_tools(self, agents):
+        catalog = {
+            "agent_id": "a1",
+            "agent_name": "agent-1",
+            "tools": [{
+                "tool_id": "t1", "name": "query_sql", "tier": "SQL_TEMPLATE",
+                "call_count": 5, "last_called_at": "2026-07-22T00:00:00Z",
+                "has_drift": False,
+                "resources": [{"resource_id": "r1", "name": "db", "type": "SQL"}],
+            }],
+            "resources": [{"resource_id": "r1", "name": "db", "type": "SQL",
+                           "tool_names": ["query_sql"]}],
+        }
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(
+            return_value=httpx.Response(200, json=catalog))
+        result = agents.tool_catalog("a1")
+        assert isinstance(result, AgentToolCatalog)
+        assert result.agent_name == "agent-1"
+        assert len(result.tools) == 1
+        assert isinstance(result.tools[0], CatalogTool)
+        assert result.tools[0].call_count == 5
+        assert result.tools[0].name == "query_sql"
+        # The aux resource union stays as raw dicts.
+        assert result.resources[0]["resource_id"] == "r1"
+
+    @respx.mock
+    def test_empty_catalog(self, agents):
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(return_value=httpx.Response(
+            200, json={"agent_id": "a1", "agent_name": "n", "tools": [], "resources": []}))
+        result = agents.tool_catalog("a1")
+        assert result.tools == [] and result.resources == []
+
+    @respx.mock
+    def test_null_tools_and_resources_become_empty(self, agents):
+        # Backend `null` (not []) for the nested lists must not crash or leave
+        # None — the reference nested-conversion + central null-normalization
+        # both turn it into [].
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(return_value=httpx.Response(
+            200, json={"agent_id": "a1", "agent_name": "n", "tools": None, "resources": None}))
+        result = agents.tool_catalog("a1")
+        assert result.tools == [] and result.resources == []
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, agents):
+        respx.get(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = await agents.aget("a1")
+        assert a.agent_id == "a1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist_follows_pages(self, agents):
+        respx.get(_AGENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_agent(1)], "next": f"{_AGENTS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_agent(2)], "next": None}),
+        ])
+        got = [a.agent_id async for a in agents.alist()]
+        assert got == ["a1", "a2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_atool_catalog(self, agents):
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(return_value=httpx.Response(
+            200, json={"agent_id": "a1", "agent_name": "n", "tools": [], "resources": []}))
+        c = await agents.atool_catalog("a1")
+        assert c.agent_id == "a1" and c.tools == []

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,6 +1,6 @@
 """LUC-905 — typed response-model base."""
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -12,6 +12,13 @@ class _Agent(APIModel):
     agent_id: str
     name: Optional[str] = None
     tags: Optional[List[str]] = None
+
+
+@dataclass
+class _WithLists(APIModel):
+    id: str
+    tags: List[str] = field(default_factory=list)
+    meta: Dict[str, Any] = field(default_factory=dict)
 
 
 class TestFromDict:
@@ -42,6 +49,30 @@ class TestFromDict:
     def test_extra_defaults_empty(self):
         a = _Agent.from_dict({"agent_id": "a1"})
         assert a.extra == {}
+
+
+class TestNullNormalization:
+    """A backend `null` for a field with a default must not stick as None —
+    it should fall back to the default (e.g. [] / {}), so downstream
+    iteration stays safe. This is the reference behavior every model relies on."""
+
+    def test_null_list_becomes_empty(self):
+        m = _WithLists.from_dict({"id": "1", "tags": None, "meta": None})
+        assert m.tags == []
+        assert m.meta == {}
+
+    def test_absent_list_uses_default(self):
+        m = _WithLists.from_dict({"id": "1"})
+        assert m.tags == [] and m.meta == {}
+
+    def test_present_list_preserved(self):
+        m = _WithLists.from_dict({"id": "1", "tags": ["a", "b"]})
+        assert m.tags == ["a", "b"]
+
+    def test_null_optional_stays_none(self):
+        # An Optional[...] = None field: null is the correct value, unchanged.
+        a = _Agent.from_dict({"agent_id": "a1", "name": None})
+        assert a.name is None
 
 
 class TestFromList:


### PR DESCRIPTION
First **C1 — Reads** namespace, and the reference the other five C1 namespaces copy. Built entirely on the merged C0 transport (typed errors, cursor pagination, `APIModel`).

## Surface
- `client.agents.list()` → lazy iterator of `Agent` (cursor-paginated, backend newest-first); `list_page()` for a single `CursorPage`.
- `client.agents.get(id)` → `Agent`; 404 → `NotFoundError`.
- `client.agents.tool_catalog(id)` → `AgentToolCatalog` with a typed `CatalogTool` list (nested-model conversion) + the raw resource union.
- All async siblings (`alist`/`aget`/`atool_catalog`/…).

**Convention set here (copied by C1):** read resources are *data-bearing*, so they do **not** swallow errors in production (unlike telemetry writes) — a failure surfaces the typed transport error.

## Review-driven hardening (code-skeptic pass)
- **Central null-normalization in `APIModel.from_dict`:** a backend `null` for a field that has a default now falls back to the default (`[]` / `{}`) instead of sticking as `None`. Dormant for agents, but this reference `from_dict`/nested-conversion idiom is copied by sessions/experiments/etc. where nullable nested collections are common — so the fix lands centrally, once.
- **Softened the bootstrap docstrings.** `agents.list()` was sold as "the first way to discover an `agent_id`," but `LucidicAI` still *requires* an `agent_id` to construct — so a true zero-state user can't reach it without a placeholder. Docstrings now say so; the construction fix is filed as a follow-up (see below).

## Follow-up (not in this PR)
The zero-state bootstrap needs a **read-only client construction mode** (make `agent_id` optional at init). That's a core-init change affecting all users, so it's filed separately rather than bundled here.

## Files
- `lucidicai/api/models/agent.py` (new) — `Agent`, `CatalogTool`, `AgentToolCatalog`
- `lucidicai/api/models/base.py` — central null-normalization
- `lucidicai/api/resources/agents.py` (new) — `AgentsResource`
- `lucidicai/client.py` — wire the `agents` namespace
- `tests/api/resources/test_agents.py` + `tests/api/test_models.py` — 275 hermetic tests pass