### PR TITLE
LUC-907: client.sessions v2 reads (list, trace, evals, event raw)

### DIFF
--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,5 +1,25 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
+from .session import (
+    EvalResult,
+    Event,
+    EventEval,
+    Session,
+    SessionEvaluatorResults,
+    SessionTrace,
+)
 
-__all__ = ["APIModel", "CursorPage", "Agent", "AgentToolCatalog", "CatalogTool"]
+__all__ = [
+    "APIModel",
+    "CursorPage",
+    "Agent",
+    "AgentToolCatalog",
+    "CatalogTool",
+    "Session",
+    "SessionTrace",
+    "Event",
+    "EvalResult",
+    "EventEval",
+    "SessionEvaluatorResults",
+]

--- a/lucidicai/api/models/session.py
+++ b/lucidicai/api/models/session.py
@@ -1,0 +1,167 @@
+"""Typed response models for client.sessions v2 reads (LUC-907)."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Event(APIModel):
+    """One event in a session's trace.
+
+    The list/trace (preview) shape omits ``payload``; the single-event detail
+    (``client.sessions.event``) includes ``payload`` and, for an offloaded
+    payload requested with ``raw=True``, a short-lived presigned ``blob_url``.
+    ``children`` is populated by ``SessionTrace.tree()`` — not sent by the
+    backend.
+    """
+
+    event_id: str
+    session_id: Optional[str] = None
+    parent_event_id: Optional[str] = None
+    type: Optional[str] = None
+    created_at: Optional[str] = None
+    occurred_at: Optional[str] = None
+    duration: Optional[float] = None
+    cost: Optional[float] = None
+    summary: Optional[str] = None
+    function_name: Optional[str] = None
+    model_name: Optional[str] = None
+    provider: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = None
+    num_time_travels: Optional[int] = None
+    has_blob: bool = False
+    payload: Optional[Any] = None       # detail only
+    blob_url: Optional[str] = None      # raw=True + offloaded payload
+    children: List["Event"] = field(default_factory=list, repr=False)  # from tree()
+
+
+@dataclass
+class Session(APIModel):
+    """A session — a full run/trace of an agent execution. Returned by
+    ``client.sessions.list()`` and as the ``.session`` of a detail (``get``)."""
+
+    session_id: str
+    custom_session_id: Optional[str] = None
+    name: Optional[str] = None
+    start_time: Optional[str] = None
+    duration: Optional[float] = None
+    is_finished: bool = False
+    production_monitoring: bool = False
+    task: Optional[str] = None
+    cost: Optional[float] = None
+    tags: List[str] = field(default_factory=list)
+    eval_previews: List[Dict[str, Any]] = field(default_factory=list)
+    num_events: Optional[int] = None
+    status: Optional[str] = None
+    datasetitem_id: Optional[str] = None
+
+
+@dataclass
+class SessionTrace(APIModel):
+    """A session detail: session meta + its flat, ``occurred_at``-ordered event
+    trace. Rebuild the parent/child tree with ``tree()`` (or group with
+    ``children_by_parent()``)."""
+
+    session: Session
+    events: List[Event] = field(default_factory=list)
+    num_events: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SessionTrace":
+        data = data if isinstance(data, dict) else {}
+        obj = cls(
+            session=Session.from_dict(data.get("session") or {}),
+            events=Event.from_list(data.get("events") or []),
+            num_events=data.get("num_events"),
+        )
+        object.__setattr__(obj, "_extra", {
+            k: v for k, v in data.items()
+            if k not in ("session", "events", "num_events")
+        })
+        return obj
+
+    def children_by_parent(self) -> Dict[Optional[str], List[Event]]:
+        """Group events by parent. Root events — no parent, a parent absent from
+        this event set (e.g. a purged or truncated-out parent), or a
+        self-reference — are bucketed under the ``None`` key so nothing is
+        silently dropped. Preserves the backend's ``occurred_at`` ordering.
+        """
+        known = {ev.event_id for ev in self.events}
+        by_parent: Dict[Optional[str], List[Event]] = {}
+        for ev in self.events:
+            pid = ev.parent_event_id
+            if pid is None or pid == ev.event_id or pid not in known:
+                pid = None  # true root, orphan, or self-cycle -> treat as root
+            by_parent.setdefault(pid, []).append(ev)
+        return by_parent
+
+    def tree(self) -> List[Event]:
+        """Rebuild the trace tree from ``parent_event_id``: returns the root
+        events, each with its ``children`` linked. Orphan events (parent not in
+        the returned set) surface as roots rather than vanishing."""
+        by_parent = self.children_by_parent()
+        for ev in self.events:
+            ev.children = by_parent.get(ev.event_id, [])
+        return by_parent.get(None, [])
+
+
+@dataclass
+class EvalResult(APIModel):
+    """One session-level evaluator result."""
+
+    eval_id: str
+    evaluator_id: Optional[str] = None
+    evaluator_name: Optional[str] = None
+    evaluator_type: Optional[str] = None
+    result: Optional[Any] = None
+    result_type: Optional[str] = None
+    description: Optional[str] = None
+    is_pending: bool = False
+    error_message: Optional[str] = None
+    execution_time_ms: Optional[int] = None
+    submitted_by: Optional[str] = None
+    evaluated_at: Optional[str] = None
+    last_updated: Optional[str] = None
+    created_at: Optional[str] = None
+    session_id: Optional[str] = None
+    criteria_results: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class EventEval(APIModel):
+    """One event-level eval mapping (``NewEventEval``)."""
+
+    eval_id: str
+    event_id: Optional[str] = None
+    session_id: Optional[str] = None
+    criteria_name: Optional[str] = None
+    result: Optional[Any] = None
+    description: Optional[str] = None
+    lucidic_created: bool = False
+    evaluator_failed: bool = False
+    criteria_failed: bool = False
+    last_updated: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class SessionEvaluatorResults(APIModel):
+    """A session's eval scores: session-level ``evals`` + event-level
+    ``event_evals``. Returned by ``client.sessions.evaluator_results``."""
+
+    evals: List[EvalResult] = field(default_factory=list)
+    event_evals: List[EventEval] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SessionEvaluatorResults":
+        data = data if isinstance(data, dict) else {}
+        obj = cls(
+            evals=EvalResult.from_list(data.get("evals") or []),
+            event_evals=EventEval.from_list(data.get("event_evals") or []),
+        )
+        object.__setattr__(obj, "_extra", {
+            k: v for k, v in data.items() if k not in ("evals", "event_evals")
+        })
+        return obj

--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -2,9 +2,13 @@
 import logging
 import threading
 import uuid
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, TYPE_CHECKING
+from urllib.parse import quote
 
 from ..client import HttpClient
+from ..models import session as session_models
+from ..models.base import CursorPage
+from ..pagination import apaginate, paginate
 
 if TYPE_CHECKING:
     from ...client import LucidicAI
@@ -403,16 +407,58 @@ class SessionResource:
         )
         return response
 
-    def get(self, session_id: str) -> Dict[str, Any]:
-        """Get a session by ID.
+    # ==================== v2 reads (LUC-907) ====================
+    #
+    # These reads are data-bearing, so — unlike the telemetry lifecycle methods
+    # above — they do NOT swallow errors in production: a failure raises the
+    # typed LucidicError the transport decoded. Each has an async sibling.
 
-        Args:
-            session_id: Session ID
+    def get(self, session_id: str) -> "session_models.SessionTrace":
+        """Read a session's detail + trace (LUC-817).
 
-        Returns:
-            Session data
+        Accepts the session UUID or the client-supplied ``custom_session_id``.
+        Returns a ``SessionTrace`` (session meta + flat ``occurred_at``-ordered
+        events); use ``.tree()`` to rebuild the parent/child tree.
         """
-        return self.http.get(f"sessions/{session_id}")
+        return session_models.SessionTrace.from_dict(
+            self.http.get(f"sdk/v2/sessions/{quote(session_id, safe='')}")
+        )
+
+    async def aget(self, session_id: str) -> "session_models.SessionTrace":
+        """Async sibling of ``get``."""
+        return session_models.SessionTrace.from_dict(
+            await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}")
+        )
+
+    def evaluator_results(self, session_id: str) -> "session_models.SessionEvaluatorResults":
+        """A session's eval scores: session-level ``evals`` + event-level
+        ``event_evals`` (accepts a UUID or ``custom_session_id``)."""
+        return session_models.SessionEvaluatorResults.from_dict(
+            self.http.get(f"sdk/v2/sessions/{quote(session_id, safe='')}/evaluator-results")
+        )
+
+    async def aevaluator_results(self, session_id: str) -> "session_models.SessionEvaluatorResults":
+        """Async sibling of ``evaluator_results``."""
+        return session_models.SessionEvaluatorResults.from_dict(
+            await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}/evaluator-results")
+        )
+
+    def event(self, session_id: str, event_id: str, *, raw: bool = False) -> "session_models.Event":
+        """Read one event of a session. ``raw=True`` returns the complete
+        payload — inline in ``.payload`` (<2 MB) or a short-lived presigned
+        ``.blob_url`` for an offloaded payload (fetch the bytes with
+        ``lucidicai.api.downloads.fetch_presigned``)."""
+        params = {"raw": "true"} if raw else None
+        return session_models.Event.from_dict(
+            self.http.get(f"sdk/v2/sessions/{quote(session_id, safe='')}/events/{event_id}", params)
+        )
+
+    async def aevent(self, session_id: str, event_id: str, *, raw: bool = False) -> "session_models.Event":
+        """Async sibling of ``event``."""
+        params = {"raw": "true"} if raw else None
+        return session_models.Event.from_dict(
+            await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}/events/{event_id}", params)
+        )
 
     def update(self, session_id: str, **updates) -> Dict[str, Any]:
         """Update an existing session.
@@ -485,34 +531,133 @@ class SessionResource:
 
     def list(
         self,
-        agent_id: Optional[str] = None,
+        agent_id: str,
+        *,
         experiment_id: Optional[str] = None,
-        limit: int = 100,
-        offset: int = 0
-    ) -> Dict[str, Any]:
-        """List sessions with optional filters.
+        production: Optional[bool] = None,
+        cost: Optional[str] = None,
+        duration: Optional[str] = None,
+        num_events: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        status: Optional[str] = None,
+        eval_bool: Optional[Any] = None,
+        eval_number: Optional[Any] = None,
+        eval_string: Optional[Any] = None,
+        ordering: Optional[str] = None,
+        page_size: Optional[int] = None,
+    ) -> Iterator["session_models.Session"]:
+        """Lazily iterate an agent's sessions, following pages (LUC-816).
 
-        Args:
-            agent_id: Filter by agent ID
-            experiment_id: Filter by experiment ID
-            limit: Maximum number of sessions
-            offset: Pagination offset
+        Filters (all optional): ``experiment_id``; ``production`` (bool);
+        ``cost`` / ``duration`` / ``num_events`` as ``"min:max"`` range strings
+        (either side may be blank); ``tags`` (list, AND-matched); ``status``;
+        and the repeatable eval filters ``eval_bool`` (``"name:true"`` /
+        ``"name:false"``), ``eval_number`` (``"name:min:max"``), ``eval_string``
+        (``"name:value"``) — each takes a single string or a list of them.
+        ``ordering`` accepts ``start_time`` / ``id`` (± prefix); backend default
+        is newest-first.
 
-        Returns:
-            List of sessions and pagination info
+        Lazy generator: request errors surface on first iteration. Use
+        ``count()`` for a cheap total, ``list_page()`` for eager single-page.
         """
-        params: Dict[str, Any] = {
-            "limit": limit,
-            "offset": offset
-        }
+        base = self._filter_params(agent_id, {
+            "experiment_id": experiment_id, "production": production, "cost": cost,
+            "duration": duration, "num_events": num_events, "tags": tags,
+            "status": status, "eval_bool": eval_bool, "eval_number": eval_number,
+            "eval_string": eval_string, "ordering": ordering, "page_size": page_size,
+        })
+        return paginate(
+            lambda cursor: self._page_get(base, cursor), model=session_models.Session
+        )
 
-        if agent_id:
-            params["agent_id"] = agent_id
+    def alist(self, agent_id: str, **filters: Any) -> AsyncIterator["session_models.Session"]:
+        """Async sibling of ``list`` (same filter kwargs)."""
+        base = self._filter_params(agent_id, filters)
+        return apaginate(
+            lambda cursor: self._apage_get(base, cursor), model=session_models.Session
+        )
 
-        if experiment_id:
-            params["experiment_id"] = experiment_id
+    def list_page(
+        self, agent_id: str, *, cursor: Optional[str] = None, **filters: Any
+    ) -> CursorPage:
+        """Fetch a single page of sessions (manual pagination control)."""
+        return CursorPage.from_body(
+            self._page_get(self._filter_params(agent_id, filters), cursor),
+            model=session_models.Session,
+        )
 
-        return self.http.get("sessions", params)
+    async def alist_page(
+        self, agent_id: str, *, cursor: Optional[str] = None, **filters: Any
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._filter_params(agent_id, filters), cursor)
+        return CursorPage.from_body(body, model=session_models.Session)
+
+    def count(self, agent_id: str, **filters: Any) -> int:
+        """Cheap total for the filtered set via HEAD (``X-Total-Count``), no
+        paging. Same filter kwargs as ``list``."""
+        headers = self.http.head("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return int(headers.get("X-Total-Count") or 0)
+
+    async def acount(self, agent_id: str, **filters: Any) -> int:
+        """Async sibling of ``count``."""
+        headers = await self.http.ahead("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return int(headers.get("X-Total-Count") or 0)
+
+    def tags(self, agent_id: str, **filters: Any) -> List[str]:
+        """The tag set for the filtered query via HEAD (``X-Tags``), no paging."""
+        headers = self.http.head("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return [t for t in headers.get("X-Tags", "").split(",") if t]
+
+    async def atags(self, agent_id: str, **filters: Any) -> List[str]:
+        """Async sibling of ``tags``."""
+        headers = await self.http.ahead("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return [t for t in headers.get("X-Tags", "").split(",") if t]
+
+    # ---- list internals ----
+
+    _FILTER_KEYS = frozenset({
+        "experiment_id", "production", "cost", "duration", "num_events", "tags",
+        "status", "eval_bool", "eval_number", "eval_string", "ordering", "page_size",
+    })
+
+    @classmethod
+    def _filter_params(cls, agent_id: str, f: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the /sdk/v2/sessions query params from the filter kwargs,
+        omitting unset ones. Shared by list / list_page / count / tags.
+
+        An unknown filter name raises TypeError: the ``**filters`` methods
+        (count/tags/list_page) would otherwise silently ignore a typo like
+        ``experiment=`` and return the *unfiltered* result — a wrong number
+        with no error."""
+        unknown = set(f) - cls._FILTER_KEYS
+        if unknown:
+            raise TypeError(f"unknown session filter(s): {sorted(unknown)}")
+        params: Dict[str, Any] = {"agent_id": agent_id}
+        for key in ("experiment_id", "status", "cost", "duration", "num_events",
+                    "ordering", "page_size", "eval_bool", "eval_number", "eval_string"):
+            value = f.get(key)
+            if value is not None:
+                params[key] = value
+        production = f.get("production")
+        if production is not None:
+            params["production"] = "true" if production else "false"
+        tags = f.get("tags")
+        if tags:
+            params["tags"] = ",".join(tags) if isinstance(tags, (list, tuple)) else tags
+        return params
+
+    def _page_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get("sdk/v2/sessions", params)
+
+    async def _apage_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget("sdk/v2/sessions", params)
 
     # ==================== Asynchronous HTTP Methods ====================
 
@@ -541,17 +686,6 @@ class SessionResource:
             f"session_id={_truncate_id(resp_session_id)}, response_keys={list(response.keys()) if response else 'None'}"
         )
         return response
-
-    async def aget(self, session_id: str) -> Dict[str, Any]:
-        """Get a session by ID (asynchronous).
-
-        Args:
-            session_id: Session ID
-
-        Returns:
-            Session data
-        """
-        return await self.http.aget(f"sessions/{session_id}")
 
     async def aupdate(self, session_id: str, **updates) -> Dict[str, Any]:
         """Update an existing session (asynchronous).
@@ -620,34 +754,3 @@ class SessionResource:
             updates["is_successful_reason"] = is_successful_reason
 
         return await self.aupdate(session_id, **updates)
-
-    async def alist(
-        self,
-        agent_id: Optional[str] = None,
-        experiment_id: Optional[str] = None,
-        limit: int = 100,
-        offset: int = 0
-    ) -> Dict[str, Any]:
-        """List sessions with optional filters (asynchronous).
-
-        Args:
-            agent_id: Filter by agent ID
-            experiment_id: Filter by experiment ID
-            limit: Maximum number of sessions
-            offset: Pagination offset
-
-        Returns:
-            List of sessions and pagination info
-        """
-        params: Dict[str, Any] = {
-            "limit": limit,
-            "offset": offset
-        }
-
-        if agent_id:
-            params["agent_id"] = agent_id
-
-        if experiment_id:
-            params["experiment_id"] = experiment_id
-
-        return await self.http.aget("sessions", params)

--- a/tests/api/resources/test_sessions_v2.py
+++ b/tests/api/resources/test_sessions_v2.py
@@ -1,0 +1,266 @@
+"""LUC-907 — client.sessions v2 reads (list/count/tags, detail+trace,
+evaluator-results, event raw)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.session import (
+    EvalResult,
+    Event,
+    EventEval,
+    Session,
+    SessionEvaluatorResults,
+    SessionTrace,
+)
+from lucidicai.api.resources.session import SessionResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_SESSIONS = f"{_BASE}/sdk/v2/sessions"
+
+
+@pytest.fixture
+def sessions(http):
+    # v2 reads only use self.http; client/config/production are irrelevant here.
+    return SessionResource(http, client=None, config=None, production=False)
+
+
+def _session(i, **over):
+    d = {
+        "session_id": f"s{i}", "custom_session_id": None, "name": f"run-{i}",
+        "start_time": "2026-07-22T00:00:00Z", "duration": 1.5, "is_finished": True,
+        "production_monitoring": False, "task": None, "cost": 0.01, "tags": ["prod"],
+        "eval_previews": [], "num_events": 3, "status": "finished", "datasetitem_id": None,
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, sessions):
+        respx.get(_SESSIONS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_session(1), _session(2)],
+                                      "next": f"{_SESSIONS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_session(3)], "next": None}),
+        ])
+        got = list(sessions.list("a1"))
+        assert [s.session_id for s in got] == ["s1", "s2", "s3"]
+        assert all(isinstance(s, Session) for s in got)
+
+    @respx.mock
+    def test_filters_are_normalized(self, sessions):
+        route = respx.get(_SESSIONS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(sessions.list(
+            "a1", experiment_id="e1", production=True, cost="0:10", duration=":5",
+            num_events="1:", tags=["prod", "canary"], status="finished",
+            eval_bool="quality:true", ordering="-start_time", page_size=25,
+        ))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a1"
+        assert p["experiment_id"] == "e1"
+        assert p["production"] == "true"       # bool -> "true"
+        assert p["cost"] == "0:10"
+        assert p["duration"] == ":5"
+        assert p["num_events"] == "1:"
+        assert p["tags"] == "prod,canary"      # list -> comma
+        assert p["status"] == "finished"
+        assert p["eval_bool"] == "quality:true"
+        assert p["ordering"] == "-start_time"
+        assert p["page_size"] == "25"
+
+    @respx.mock
+    def test_production_false_serialized(self, sessions):
+        route = respx.get(_SESSIONS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(sessions.list("a1", production=False))
+        assert route.calls.last.request.url.params["production"] == "false"
+
+    @respx.mock
+    def test_list_page(self, sessions):
+        respx.get(_SESSIONS).mock(return_value=httpx.Response(
+            200, json={"results": [_session(1)], "next": f"{_SESSIONS}?cursor=c9"}))
+        page = sessions.list_page("a1")
+        assert isinstance(page.results[0], Session) and page.next_cursor == "c9"
+
+
+class TestCountTags:
+    @respx.mock
+    def test_count(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "42"}))
+        assert sessions.count("a1", production=True) == 42
+
+    @respx.mock
+    def test_tags(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(
+            200, headers={"X-Tags": "prod,canary"}))
+        assert sessions.tags("a1") == ["prod", "canary"]
+
+    @respx.mock
+    def test_tags_empty(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(200, headers={"X-Tags": ""}))
+        assert sessions.tags("a1") == []
+
+
+class TestGetTrace:
+    @respx.mock
+    def test_detail_and_tree(self, sessions):
+        body = {
+            "session": _session(1),
+            "events": [
+                {"event_id": "e1", "parent_event_id": None, "occurred_at": "1", "type": "llm"},
+                {"event_id": "e2", "parent_event_id": "e1", "occurred_at": "2", "type": "tool"},
+                {"event_id": "e3", "parent_event_id": "e1", "occurred_at": "3", "type": "tool"},
+            ],
+            "num_events": 3,
+        }
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(200, json=body))
+        trace = sessions.get("s1")
+        assert isinstance(trace, SessionTrace)
+        assert isinstance(trace.session, Session) and trace.session.session_id == "s1"
+        assert trace.num_events == 3
+        assert all(isinstance(e, Event) for e in trace.events)
+        roots = trace.tree()
+        assert [r.event_id for r in roots] == ["e1"]
+        assert [c.event_id for c in roots[0].children] == ["e2", "e3"]
+
+    @respx.mock
+    def test_accepts_custom_session_id(self, sessions):
+        respx.get(f"{_SESSIONS}/my-custom-id").mock(return_value=httpx.Response(
+            200, json={"session": _session(1), "events": [], "num_events": 0}))
+        trace = sessions.get("my-custom-id")
+        assert trace.events == []
+
+    @respx.mock
+    def test_404_raises(self, sessions):
+        respx.get(f"{_SESSIONS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            sessions.get("missing")
+
+    @respx.mock
+    def test_orphan_event_surfaces_as_root(self, sessions):
+        # e2's parent e1 is absent from the returned set (purged/truncated) —
+        # it must surface as a root, not silently vanish from tree().
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(200, json={
+            "session": _session(1),
+            "events": [{"event_id": "e2", "parent_event_id": "e1", "occurred_at": "1"}],
+            "num_events": 1,
+        }))
+        roots = sessions.get("s1").tree()
+        assert [r.event_id for r in roots] == ["e2"]
+
+    @respx.mock
+    def test_self_cycle_event_is_root(self, sessions):
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(200, json={
+            "session": _session(1),
+            "events": [{"event_id": "e1", "parent_event_id": "e1", "occurred_at": "1"}],
+        }))
+        roots = sessions.get("s1").tree()
+        assert [r.event_id for r in roots] == ["e1"]
+        assert roots[0].children == []  # not its own child
+
+    @respx.mock
+    def test_custom_session_id_path_encoded(self, sessions):
+        # A client-supplied custom_session_id with URL-significant chars must be
+        # percent-encoded so it doesn't break routing (false NotFound otherwise).
+        route = respx.route(method="GET").mock(return_value=httpx.Response(
+            200, json={"session": _session(1), "events": [], "num_events": 0}))
+        sessions.get("a/b c")
+        raw = route.calls.last.request.url.raw_path.decode()
+        assert "/sessions/a/b" not in raw   # the raw '/' did not leak
+        assert "a%2Fb" in raw
+
+
+class TestFilterValidation:
+    def test_unknown_filter_raises(self, sessions):
+        # A typo in a **filters method must fail loudly, not silently return the
+        # unfiltered count/tags.
+        with pytest.raises(TypeError):
+            sessions.count("a1", experiment="e1")  # should be experiment_id
+
+
+class TestEvaluatorResults:
+    @respx.mock
+    def test_typed_results(self, sessions):
+        body = {
+            "evals": [{"eval_id": "ev1", "evaluator_name": "quality", "result": 0.9,
+                       "result_type": "number", "is_pending": False}],
+            "event_evals": [{"eval_id": "ee1", "event_id": "e1", "criteria_name": "grounded",
+                             "result": True}],
+        }
+        respx.get(f"{_SESSIONS}/s1/evaluator-results").mock(
+            return_value=httpx.Response(200, json=body))
+        res = sessions.evaluator_results("s1")
+        assert isinstance(res, SessionEvaluatorResults)
+        assert isinstance(res.evals[0], EvalResult) and res.evals[0].evaluator_name == "quality"
+        assert isinstance(res.event_evals[0], EventEval) and res.event_evals[0].event_id == "e1"
+
+    @respx.mock
+    def test_empty_results(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/evaluator-results").mock(return_value=httpx.Response(
+            200, json={"evals": [], "event_evals": []}))
+        res = sessions.evaluator_results("s1")
+        assert res.evals == [] and res.event_evals == []
+
+
+class TestEvent:
+    @respx.mock
+    def test_non_raw_returns_typed_event(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1", "type": "llm", "has_blob": True,
+                       "payload": {"preview": "..."}}))
+        ev = sessions.event("s1", "e1")
+        assert isinstance(ev, Event) and ev.event_id == "e1" and ev.has_blob is True
+
+    @respx.mock
+    def test_raw_true_sends_param_and_returns_blob_url(self, sessions):
+        route = respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1", "type": "llm", "has_blob": True,
+                       "blob_url": "https://s3/presigned?sig=x"}))
+        ev = sessions.event("s1", "e1", raw=True)
+        assert route.calls.last.request.url.params["raw"] == "true"
+        assert ev.blob_url == "https://s3/presigned?sig=x"
+
+    @respx.mock
+    def test_raw_true_inline_payload(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1", "payload": {"full": [1, 2, 3]}}))
+        ev = sessions.event("s1", "e1", raw=True)
+        assert ev.payload == {"full": [1, 2, 3]}
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, sessions):
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(
+            200, json={"session": _session(1), "events": [], "num_events": 0}))
+        trace = await sessions.aget("s1")
+        assert trace.session.session_id == "s1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, sessions):
+        respx.get(_SESSIONS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_session(1)], "next": f"{_SESSIONS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_session(2)], "next": None}),
+        ])
+        got = [s.session_id async for s in sessions.alist("a1")]
+        assert got == ["s1", "s2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acount(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(200, headers={"X-Total-Count": "7"}))
+        assert await sessions.acount("a1") == 7
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aevent(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1"}))
+        ev = await sessions.aevent("s1", "e1")
+        assert ev.event_id == "e1"


### PR DESCRIPTION
The highest-value C1 read — closes the SDK's biggest write-then-observe gap. Added onto the existing `SessionResource`; the old offset/limit `get`/`list` (+ async `aget`/`alist`) are replaced with v2 typed reads, and the telemetry lifecycle methods (`create`/`end`/`update`/`end_session`/`create_session`) are untouched. Builds on C0 (typed errors, cursor pagination, HEAD, presigned, `APIModel`).

## Surface
- `sessions.list(agent_id, **filters)` → lazy `Session` iterator. Filters: `experiment_id`, `production` (bool), `cost`/`duration`/`num_events` (`"min:max"` ranges), `tags` (list, AND), `status`, repeatable `eval_bool`/`eval_number`/`eval_string`, `ordering`. `count()`/`tags()` via HEAD (`X-Total-Count`/`X-Tags`); `list_page()` for a single `CursorPage`.
- `sessions.get(id)` → `SessionTrace` (session meta + flat `occurred_at`-ordered events); **`.tree()`** rebuilds the parent/child tree. Accepts a UUID or `custom_session_id`.
- `sessions.evaluator_results(id)` → `SessionEvaluatorResults` (typed `evals` + `event_evals`).
- `sessions.event(id, event_id, raw=False)` → `Event`; `raw=True` inlines `.payload` or returns a presigned `.blob_url` (fetch bytes with `api.downloads.fetch_presigned`).
- All async siblings. Reads are data-bearing → they do **not** swallow in production.

## Review-driven hardening (code-skeptic pass)
The reviewer confirmed the get/list replacement is regression-clean (no remaining consumers of the old shape, lifecycle intact, no obscured methods), and caught three silent-wrong-result bugs — all fixed:
- **URL-encode the client-supplied `session_id`** in the path. A `custom_session_id` containing `/`, `?`, or a space would otherwise break routing into a false `NotFound`. (Sessions is the first read to accept a client-supplied path id — the reference must get this right.)
- **`tree()` no longer drops orphans.** An event whose `parent_event_id` is absent from the returned set (purged/truncated parent) — or a self-cycle — now surfaces as a root instead of silently vanishing or infinite-recursing.
- **Filter-name typos raise.** `_filter_params` validates keys, so `count(agent_id, experiment=...)` (should be `experiment_id`) fails loudly instead of silently returning the *unfiltered* total.

## Files
- `lucidicai/api/models/session.py` (new) — `Session`, `Event` (+ `tree()`), `SessionTrace`, `EvalResult`, `EventEval`, `SessionEvaluatorResults`
- `lucidicai/api/resources/session.py` — v2 reads replace the old `get`/`list`
- `lucidicai/api/models/__init__.py`
- `tests/api/resources/test_sessions_v2.py` — 23 tests; 298 hermetic total pass