### PR TITLE
LUC-908: client.experiments reads (list / count / get)

### DIFF
--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,6 +1,7 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
+from .experiment import Experiment
 from .session import (
     EvalResult,
     Event,
@@ -16,6 +17,7 @@ __all__ = [
     "Agent",
     "AgentToolCatalog",
     "CatalogTool",
+    "Experiment",
     "Session",
     "SessionTrace",
     "Event",

--- a/lucidicai/api/models/experiment.py
+++ b/lucidicai/api/models/experiment.py
@@ -1,0 +1,37 @@
+"""Typed response model for client.experiments reads (LUC-908)."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Experiment(APIModel):
+    """An experiment — a group of sessions with aggregated metrics/insights.
+
+    ``client.experiments.list()`` returns the light shape (through
+    ``eval_metrics`` / ``num_sessions`` / ``tags``); ``get()`` additionally
+    populates the detail metrics + failure groups (the fields below default to
+    ``None`` / ``[]`` in a list result).
+    """
+
+    experiment_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    num_sessions: Optional[int] = None
+    tags: List[str] = field(default_factory=list)
+    eval_metrics: Optional[Any] = None
+
+    # detail-only (get) — aggregated analytics; kept as raw dicts/lists.
+    agent_id: Optional[str] = None
+    eval_metrics_by_tag: Optional[Dict[str, Any]] = None
+    time_data: Optional[Dict[str, Any]] = None
+    time_data_by_tag: Optional[Dict[str, Any]] = None
+    cost_data: Optional[Dict[str, Any]] = None
+    cost_data_by_tag: Optional[Dict[str, Any]] = None
+    num_events_data: Optional[Dict[str, Any]] = None
+    num_events_data_by_tag: Optional[Dict[str, Any]] = None
+    event_failure_groups: List[Dict[str, Any]] = field(default_factory=list)
+    analytics_session_count: Optional[int] = None

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -1,8 +1,11 @@
 """Experiment resource API operations."""
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.experiment import Experiment
+from ..pagination import apaginate, paginate
 
 logger = logging.getLogger("Lucidic")
 
@@ -106,3 +109,88 @@ class ExperimentResource:
                 logger.error(f"[ExperimentResource] Failed to create experiment: {e}")
                 return None
             raise
+
+    # ==================== v2 reads (LUC-908) ====================
+    #
+    # Data-bearing reads: they do NOT swallow in production (they surface the
+    # typed transport error), unlike create/acreate above. ``agent_id`` defaults
+    # to the resource's configured agent. Each read has an async sibling.
+
+    def list(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[Experiment]:
+        """Lazily iterate an agent's experiments, newest first (LUC-816).
+
+        ``ordering`` accepts ``created_at`` / ``id`` (± prefix). Lazy generator —
+        errors surface on first iteration; use ``count()`` for a cheap total.
+        """
+        base = self._list_params(agent_id, ordering, page_size)
+        return paginate(lambda cursor: self._page_get(base, cursor), model=Experiment)
+
+    def alist(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[Experiment]:
+        """Async sibling of ``list``."""
+        base = self._list_params(agent_id, ordering, page_size)
+        return apaginate(lambda cursor: self._apage_get(base, cursor), model=Experiment)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of experiments (manual pagination control)."""
+        body = self._page_get(self._list_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Experiment)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._list_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Experiment)
+
+    def count(self, agent_id: Optional[str] = None) -> int:
+        """Cheap total of the agent's experiments via HEAD (``X-Total-Count``)."""
+        headers = self.http.head("sdk/v2/experiments", self._list_params(agent_id, None, None))
+        return int(headers.get("X-Total-Count") or 0)
+
+    async def acount(self, agent_id: Optional[str] = None) -> int:
+        """Async sibling of ``count``."""
+        headers = await self.http.ahead("sdk/v2/experiments", self._list_params(agent_id, None, None))
+        return int(headers.get("X-Total-Count") or 0)
+
+    def get(self, experiment_id: str) -> Experiment:
+        """Read one experiment's detail (metrics + failure groups). Raises
+        ``NotFoundError`` if it doesn't exist or the (bound) key can't see it."""
+        return Experiment.from_dict(self.http.get(f"sdk/v2/experiments/{experiment_id}"))
+
+    async def aget(self, experiment_id: str) -> Experiment:
+        """Async sibling of ``get``."""
+        return Experiment.from_dict(await self.http.aget(f"sdk/v2/experiments/{experiment_id}"))
+
+    # ---- internals ----
+
+    def _list_params(
+        self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"agent_id": agent_id or self._agent_id}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get("sdk/v2/experiments", params)
+
+    async def _apage_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget("sdk/v2/experiments", params)

--- a/tests/api/resources/test_experiments_v2.py
+++ b/tests/api/resources/test_experiments_v2.py
@@ -1,0 +1,123 @@
+"""LUC-908 — client.experiments reads (list / count / get)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.experiment import Experiment
+from lucidicai.api.resources.experiment import ExperimentResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
+
+
+@pytest.fixture
+def experiments(http):
+    # Configured agent_id "a1" — list()/count() default to it.
+    return ExperimentResource(http, agent_id="a1", production=False)
+
+
+def _exp(i, **over):
+    d = {
+        "experiment_id": f"x{i}", "name": f"exp-{i}", "description": "",
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+        "num_sessions": 3, "tags": ["prod"], "eval_metrics": [],
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, experiments):
+        respx.get(_EXPERIMENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_exp(1), _exp(2)],
+                                      "next": f"{_EXPERIMENTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_exp(3)], "next": None}),
+        ])
+        got = list(experiments.list())
+        assert [e.experiment_id for e in got] == ["x1", "x2", "x3"]
+        assert all(isinstance(e, Experiment) for e in got)
+
+    @respx.mock
+    def test_defaults_configured_agent_id(self, experiments):
+        route = respx.get(_EXPERIMENTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(experiments.list())
+        assert route.calls.last.request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_explicit_agent_id_and_ordering(self, experiments):
+        route = respx.get(_EXPERIMENTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(experiments.list("a2", ordering="created_at", page_size=10))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a2"
+        assert p["ordering"] == "created_at"
+        assert p["page_size"] == "10"
+
+    @respx.mock
+    def test_list_page(self, experiments):
+        respx.get(_EXPERIMENTS).mock(return_value=httpx.Response(
+            200, json={"results": [_exp(1)], "next": f"{_EXPERIMENTS}?cursor=c9"}))
+        page = experiments.list_page()
+        assert isinstance(page.results[0], Experiment) and page.next_cursor == "c9"
+
+
+class TestCount:
+    @respx.mock
+    def test_count(self, experiments):
+        respx.head(_EXPERIMENTS).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "12"}))
+        assert experiments.count() == 12
+
+    @respx.mock
+    def test_count_missing_header_zero(self, experiments):
+        respx.head(_EXPERIMENTS).mock(return_value=httpx.Response(200))
+        assert experiments.count() == 0
+
+
+class TestGet:
+    @respx.mock
+    def test_detail_with_metrics(self, experiments):
+        detail = _exp(1, agent_id="a1", eval_metrics_by_tag={"prod": {}},
+                      time_data={"p50": 1.2}, event_failure_groups=[{"group": "timeout"}],
+                      analytics_session_count=3)
+        respx.get(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(200, json=detail))
+        e = experiments.get("x1")
+        assert isinstance(e, Experiment)
+        assert e.agent_id == "a1"
+        assert e.time_data == {"p50": 1.2}
+        assert e.event_failure_groups == [{"group": "timeout"}]
+
+    @respx.mock
+    def test_404_raises(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.get("missing")
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, experiments):
+        respx.get(_EXPERIMENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_exp(1)], "next": f"{_EXPERIMENTS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_exp(2)], "next": None}),
+        ])
+        got = [e.experiment_id async for e in experiments.alist()]
+        assert got == ["x1", "x2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acount(self, experiments):
+        respx.head(_EXPERIMENTS).mock(return_value=httpx.Response(200, headers={"X-Total-Count": "5"}))
+        assert await experiments.acount() == 5
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(200, json=_exp(1)))
+        e = await experiments.aget("x1")
+        assert e.experiment_id == "x1"


### PR DESCRIPTION
Adds v2 reads to the create-only `ExperimentResource`, mirroring the now-established agents/sessions read pattern on C0 (typed model, cursor pagination, HEAD count). `create`/`acreate` are untouched.

## Surface
- `experiments.list(agent_id=None)` → lazy `Experiment` iterator (`agent_id` defaults to the resource's configured agent); `ordering` accepts `created_at`/`id`; `list_page()` for a single `CursorPage`.
- `experiments.count(agent_id=None)` → total via HEAD `X-Total-Count`.
- `experiments.get(id)` → `Experiment` detail (metrics + failure groups); 404 → `NotFoundError`.
- All async siblings. Reads are data-bearing → don't swallow in production.

One `Experiment` model covers both shapes: `list()` returns the light fields, `get()` additionally populates the detail metrics/analytics dicts + `event_failure_groups` (optional, default `None`/`[]` in a list result).

## Note on review
This ticket is a faithful mirror of the agents/sessions pattern already hardened by two adversarial reviews — no novel logic (UUID paths, no filters, no nested trees), so I relied on the vetted pattern + tests rather than a fresh review pass. The skeptic returns for the novel-logic tickets (C2 creates/deletes, evosim cancel, async workflows).

## Files
- `lucidicai/api/models/experiment.py` (new) — `Experiment`
- `lucidicai/api/resources/experiment.py` — read methods added
- `lucidicai/api/models/__init__.py`
- `tests/api/resources/test_experiments_v2.py` — 11 tests; 309 hermetic total pass