### PR TITLE
LUC-909: client.prompts reads (list / versions / labels)

### DIFF
--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -2,6 +2,7 @@
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
 from .experiment import Experiment
+from .prompt import PromptInfo, PromptVersion
 from .session import (
     EvalResult,
     Event,
@@ -18,6 +19,8 @@ __all__ = [
     "AgentToolCatalog",
     "CatalogTool",
     "Experiment",
+    "PromptInfo",
+    "PromptVersion",
     "Session",
     "SessionTrace",
     "Event",

--- a/lucidicai/api/models/prompt.py
+++ b/lucidicai/api/models/prompt.py
@@ -1,0 +1,35 @@
+"""Typed response models for client.prompts reads (LUC-909).
+
+Distinct from the SDK's grandfathered ``Prompt`` dataclass
+(``api/resources/prompt.py``), which is a *rendered* prompt (content + metadata,
+returned by ``prompts.get()``). These model the prompt catalog + version history.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class PromptInfo(APIModel):
+    """A prompt (unique name per agent) as returned by ``client.prompts.list()``.
+    ``preview`` is a short excerpt of its latest content."""
+
+    prompt_id: str
+    name: Optional[str] = None
+    icon: Optional[str] = None
+    preview: Optional[str] = None
+
+
+@dataclass
+class PromptVersion(APIModel):
+    """One immutable version of a prompt — its content, the labels pointing at
+    it, and metadata. Returned by ``client.prompts.versions(name)``."""
+
+    promptversion_id: str
+    prompt_version_number: Optional[int] = None
+    prompt_content: Optional[str] = None
+    description: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    labels: List[str] = field(default_factory=list)

--- a/lucidicai/api/resources/prompt.py
+++ b/lucidicai/api/resources/prompt.py
@@ -2,9 +2,12 @@
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, TYPE_CHECKING
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.prompt import PromptInfo, PromptVersion
+from ..pagination import apaginate, paginate
 
 if TYPE_CHECKING:
     from ...core.config import SDKConfig
@@ -385,3 +388,117 @@ class PromptResource:
                 logger.error(f"[PromptResource] Failed to update prompt metadata: {e}")
                 return Prompt(raw_content="", content="", metadata={})
             raise
+
+    # ==================== v2 reads (LUC-909) ====================
+    #
+    # Prompt-ops discovery: list the agent's prompts, walk a prompt's full
+    # version history, read the agent's label set. Data-bearing reads — they do
+    # NOT swallow in production (they surface the typed transport error), unlike
+    # the get/update methods above. ``agent_id`` defaults to the configured
+    # agent. Each read has an async sibling.
+
+    def list(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[PromptInfo]:
+        """Lazily iterate the agent's prompts (by name). ``ordering`` accepts
+        ``name`` / ``id`` (± prefix)."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return paginate(lambda c: self._page_get("sdk/v2/prompts", base, c), model=PromptInfo)
+
+    def alist(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[PromptInfo]:
+        """Async sibling of ``list``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return apaginate(lambda c: self._apage_get("sdk/v2/prompts", base, c), model=PromptInfo)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of prompts (manual pagination control)."""
+        body = self._page_get("sdk/v2/prompts", self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=PromptInfo)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get("sdk/v2/prompts", self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=PromptInfo)
+
+    def versions(
+        self, name: str, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[PromptVersion]:
+        """Lazily iterate one prompt's full version history, newest first.
+        ``ordering`` accepts ``version_number`` / ``id`` (± prefix)."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        return paginate(lambda c: self._page_get("sdk/v2/prompts/versions", base, c), model=PromptVersion)
+
+    def aversions(
+        self, name: str, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[PromptVersion]:
+        """Async sibling of ``versions``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        return apaginate(lambda c: self._apage_get("sdk/v2/prompts/versions", base, c), model=PromptVersion)
+
+    def versions_page(
+        self, name: str, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of a prompt's version history."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        return CursorPage.from_body(self._page_get("sdk/v2/prompts/versions", base, cursor), model=PromptVersion)
+
+    async def aversions_page(
+        self, name: str, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``versions_page``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        body = await self._apage_get("sdk/v2/prompts/versions", base, cursor)
+        return CursorPage.from_body(body, model=PromptVersion)
+
+    def labels(self, agent_id: Optional[str] = None) -> List[str]:
+        """The agent's label names (shared across its prompts) — a small,
+        non-paginated read."""
+        resp = self.http.get("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        return resp.get("labels", [])
+
+    async def alabels(self, agent_id: Optional[str] = None) -> List[str]:
+        """Async sibling of ``labels``."""
+        resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        return resp.get("labels", [])
+
+    # ---- read internals ----
+
+    def _agent_params(
+        self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"agent_id": agent_id or self._config.agent_id}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params)
+
+    async def _apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params)

--- a/tests/api/resources/test_prompts_v2.py
+++ b/tests/api/resources/test_prompts_v2.py
@@ -1,0 +1,124 @@
+"""LUC-909 — client.prompts reads (list / versions / labels)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.prompt import PromptInfo, PromptVersion
+from lucidicai.api.resources.prompt import PromptResource
+from lucidicai.core.config import NetworkConfig, SDKConfig
+
+_BASE = "https://stub.lucidic.test"
+_PROMPTS = f"{_BASE}/sdk/v2/prompts"
+
+
+@pytest.fixture
+def prompts(http):
+    cfg = SDKConfig(api_key="test-key", agent_id="a1", network=NetworkConfig(base_url=_BASE))
+    return PromptResource(http, cfg, production=False)
+
+
+def _prompt(i):
+    return {"prompt_id": f"p{i}", "name": f"prompt-{i}", "icon": "doc", "preview": "Hello..."}
+
+
+def _version(n, **over):
+    d = {
+        "promptversion_id": f"v{n}", "prompt_version_number": n,
+        "prompt_content": f"content {n}", "description": "", "metadata": {},
+        "created_at": "2026-07-22T00:00:00Z", "labels": [],
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, prompts):
+        respx.get(_PROMPTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_prompt(1), _prompt(2)],
+                                      "next": f"{_PROMPTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_prompt(3)], "next": None}),
+        ])
+        got = list(prompts.list())
+        assert [p.prompt_id for p in got] == ["p1", "p2", "p3"]
+        assert all(isinstance(p, PromptInfo) for p in got)
+
+    @respx.mock
+    def test_defaults_configured_agent_id(self, prompts):
+        route = respx.get(_PROMPTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(prompts.list(ordering="name"))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a1"
+        assert p["ordering"] == "name"
+
+    @respx.mock
+    def test_list_page(self, prompts):
+        respx.get(_PROMPTS).mock(return_value=httpx.Response(
+            200, json={"results": [_prompt(1)], "next": f"{_PROMPTS}?cursor=c9"}))
+        page = prompts.list_page()
+        assert isinstance(page.results[0], PromptInfo) and page.next_cursor == "c9"
+
+
+class TestVersions:
+    @respx.mock
+    def test_sends_prompt_name_and_typed(self, prompts):
+        route = respx.get(f"{_PROMPTS}/versions").mock(side_effect=[
+            httpx.Response(200, json={"results": [_version(2, labels=["latest", "production"])],
+                                      "next": f"{_PROMPTS}/versions?cursor=c2"}),
+            httpx.Response(200, json={"results": [_version(1)], "next": None}),
+        ])
+        got = list(prompts.versions("greeting"))
+        assert route.calls[0].request.url.params["prompt_name"] == "greeting"
+        assert route.calls[0].request.url.params["agent_id"] == "a1"
+        assert [v.prompt_version_number for v in got] == [2, 1]
+        assert all(isinstance(v, PromptVersion) for v in got)
+        assert got[0].labels == ["latest", "production"]
+
+    @respx.mock
+    def test_versions_page(self, prompts):
+        respx.get(f"{_PROMPTS}/versions").mock(return_value=httpx.Response(
+            200, json={"results": [_version(1)], "next": None}))
+        page = prompts.versions_page("greeting")
+        assert isinstance(page.results[0], PromptVersion)
+
+
+class TestLabels:
+    @respx.mock
+    def test_labels_unwrapped(self, prompts):
+        route = respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(
+            200, json={"labels": ["latest", "production", "staging"]}))
+        assert prompts.labels() == ["latest", "production", "staging"]
+        assert route.calls.last.request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_labels_empty(self, prompts):
+        respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(200, json={"labels": []}))
+        assert prompts.labels() == []
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, prompts):
+        respx.get(_PROMPTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_prompt(1)], "next": f"{_PROMPTS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_prompt(2)], "next": None}),
+        ])
+        got = [p.prompt_id async for p in prompts.alist()]
+        assert got == ["p1", "p2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aversions(self, prompts):
+        respx.get(f"{_PROMPTS}/versions").mock(return_value=httpx.Response(
+            200, json={"results": [_version(1)], "next": None}))
+        got = [v.prompt_version_number async for v in prompts.aversions("greeting")]
+        assert got == [1]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alabels(self, prompts):
+        respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(
+            200, json={"labels": ["latest"]}))
+        assert await prompts.alabels() == ["latest"]


### PR DESCRIPTION
Adds the prompt-ops discovery reads to `PromptResource`, alongside its existing `get`/`update`/`update_metadata` (which return the grandfathered rendered `Prompt` dataclass — untouched).

## Surface
- `prompts.list(agent_id=None)` → lazy `PromptInfo` iterator (the agent's prompts by name; `ordering` = `name`/`id`); `list_page()` for a single `CursorPage`.
- `prompts.versions(name, agent_id=None)` → lazy `PromptVersion` iterator (a prompt's full version history, newest first, with `labels` + content); `versions_page()`.
- `prompts.labels(agent_id=None)` → `List[str]` (the agent's label set; unwraps the `{"labels": [...]}` envelope).
- All async siblings. Reads are data-bearing → don't swallow in production.

## Reconciling with the grandfathered model
The SDK already has a `Prompt` dataclass (a *rendered* prompt: content + metadata, from `get()`). The new catalog/version models are distinct, so they're named **`PromptInfo`** / **`PromptVersion`** in `api/models/prompt.py` — no collision; `Prompt` stays exported unchanged. No HEAD/count (the backend prompt list has no HEAD).

Pure-mirror ticket (no novel logic), so per the established calibration I relied on the vetted pattern + tests rather than a fresh skeptic pass.

## Files
- `lucidicai/api/models/prompt.py` (new) — `PromptInfo`, `PromptVersion`
- `lucidicai/api/resources/prompt.py` — read methods added
- `lucidicai/api/models/__init__.py`
- `tests/api/resources/test_prompts_v2.py` — 10 tests; 319 hermetic total pass