### PR TITLE
LUC-910: client.evaluators + evaluator_results reads

### DIFF
--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,6 +1,7 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
+from .evaluator import Evaluator
 from .experiment import Experiment
 from .prompt import PromptInfo, PromptVersion
 from .session import (
@@ -18,6 +19,7 @@ __all__ = [
     "Agent",
     "AgentToolCatalog",
     "CatalogTool",
+    "Evaluator",
     "Experiment",
     "PromptInfo",
     "PromptVersion",

--- a/lucidicai/api/models/evaluator.py
+++ b/lucidicai/api/models/evaluator.py
@@ -1,0 +1,33 @@
+"""Typed response model for client.evaluators reads (LUC-910).
+
+The per-result rows (``evaluators.evals()`` distribution and
+``evaluators.result()``) reuse the ``EvalResult`` model from ``models.session``
+— both endpoints serialize with the backend's ``EvaluatorResultSerializer``.
+"""
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Evaluator(APIModel):
+    """An evaluator (LLM / CODE / HUMAN / RUNTIME) — the definition of a scoring
+    criterion. ``list()`` returns the light shape; ``get()`` additionally
+    populates ``rubric_json`` + ``config`` (default ``None`` in a list result).
+    """
+
+    evaluator_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    icon: Optional[str] = None
+    type: Optional[str] = None
+    result_type: Optional[str] = None
+    is_default: bool = False
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    criteria: Optional[Any] = None
+
+    # detail-only (get)
+    rubric_json: Optional[Any] = None
+    config: Optional[Dict[str, Any]] = None

--- a/lucidicai/api/resources/evaluator_results.py
+++ b/lucidicai/api/resources/evaluator_results.py
@@ -1,0 +1,28 @@
+"""client.evaluator_results — a single evaluator result by id (LUC-910).
+
+A small namespace keyed by an ``EvaluatorResult`` id (distinct from an evaluator
+id), so ``evaluator_results.get(eval_id)`` can't be confused with the
+evaluator-keyed reads on ``client.evaluators``. Reuses the ``EvalResult`` model
+(the ``EvaluatorResultSerializer`` shape). Data-bearing read — does NOT swallow
+in production.
+"""
+from ..client import HttpClient
+from ..models.session import EvalResult
+
+_EVAL_RESULTS = "sdk/v2/evaluator-results"
+
+
+class EvaluatorResultsResource:
+    """Handle for the ``/sdk/v2/evaluator-results`` read endpoint."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def get(self, eval_id: str) -> EvalResult:
+        """Read one evaluator result by its id (a CODE result is synced from S3
+        on read). ``eval_id`` is an ``EvalResult.eval_id``."""
+        return EvalResult.from_dict(self.http.get(f"{_EVAL_RESULTS}/{eval_id}"))
+
+    async def aget(self, eval_id: str) -> EvalResult:
+        """Async sibling of ``get``."""
+        return EvalResult.from_dict(await self.http.aget(f"{_EVAL_RESULTS}/{eval_id}"))

--- a/lucidicai/api/resources/evaluators.py
+++ b/lucidicai/api/resources/evaluators.py
@@ -1,0 +1,152 @@
+"""client.evaluators — evaluator reads (LUC-910).
+
+A new namespace (today only ``client.evals.emit`` — a different concept, ad-hoc
+score submission — exists). Reads the agent's evaluator definitions, one
+evaluator's eval distribution across runs, and a single evaluator result by id.
+
+The per-result reads reuse the ``EvalResult`` model (both endpoints serialize
+with the backend's ``EvaluatorResultSerializer``). Data-bearing reads — they do
+NOT swallow in production. Each has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.evaluator import Evaluator
+from ..models.session import EvalResult
+from ..pagination import apaginate, paginate
+
+_EVALUATORS = "sdk/v2/evaluators"
+
+
+class EvaluatorsResource:
+    """Handle for the ``/sdk/v2/evaluators`` read endpoints."""
+
+    def __init__(self, http: HttpClient, agent_id: Optional[str] = None):
+        self.http = http
+        self._agent_id = agent_id
+
+    # ==================== evaluators (definitions) ====================
+
+    def list(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[Evaluator]:
+        """Lazily iterate the agent's evaluators, newest first. ``agent_id``
+        defaults to the configured agent; ``ordering`` accepts ``id`` (± prefix)."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return paginate(lambda c: self._page_get(_EVALUATORS, base, c), model=Evaluator)
+
+    def alist(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[Evaluator]:
+        """Async sibling of ``list``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return apaginate(lambda c: self._apage_get(_EVALUATORS, base, c), model=Evaluator)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of evaluators."""
+        body = self._page_get(_EVALUATORS, self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(_EVALUATORS, self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    def get(self, evaluator_id: str) -> Evaluator:
+        """Read one evaluator's detail (incl. ``rubric_json`` / ``config``)."""
+        return Evaluator.from_dict(self.http.get(f"{_EVALUATORS}/{evaluator_id}"))
+
+    async def aget(self, evaluator_id: str) -> Evaluator:
+        """Async sibling of ``get``."""
+        return Evaluator.from_dict(await self.http.aget(f"{_EVALUATORS}/{evaluator_id}"))
+
+    # ==================== one evaluator's eval distribution ====================
+
+    def evals(
+        self, evaluator_id: str, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[EvalResult]:
+        """Lazily iterate one evaluator's results across runs (the metric's
+        distribution). Returns ``EvalResult`` items."""
+        base = self._page_params(ordering, page_size)
+        return paginate(
+            lambda c: self._page_get(f"{_EVALUATORS}/{evaluator_id}/evals", base, c),
+            model=EvalResult,
+        )
+
+    def aevals(
+        self, evaluator_id: str, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[EvalResult]:
+        """Async sibling of ``evals``."""
+        base = self._page_params(ordering, page_size)
+        return apaginate(
+            lambda c: self._apage_get(f"{_EVALUATORS}/{evaluator_id}/evals", base, c),
+            model=EvalResult,
+        )
+
+    def evals_page(
+        self, evaluator_id: str, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of one evaluator's results."""
+        body = self._page_get(f"{_EVALUATORS}/{evaluator_id}/evals", self._page_params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=EvalResult)
+
+    async def aevals_page(
+        self, evaluator_id: str, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``evals_page``."""
+        body = await self._apage_get(f"{_EVALUATORS}/{evaluator_id}/evals", self._page_params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=EvalResult)
+
+    # NOTE: a *single* evaluator result by its own id lives on the separate
+    # ``client.evaluator_results`` namespace (get(eval_id)) — keying it off an
+    # EvalResult id, not an evaluator id, so it isn't confused with the
+    # evaluator-keyed reads above.
+
+    # ==================== internals ====================
+
+    def _agent_params(
+        self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
+    ) -> Dict[str, Any]:
+        resolved = agent_id or self._agent_id
+        params: Dict[str, Any] = {}
+        if resolved is not None:
+            params["agent_id"] = resolved
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    @staticmethod
+    def _page_params(ordering: Optional[str], page_size: Optional[int]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params or None)
+
+    async def _apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params or None)

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -25,6 +25,8 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 from .api.client import HttpClient
 from .api.resources.agents import AgentsResource
+from .api.resources.evaluator_results import EvaluatorResultsResource
+from .api.resources.evaluators import EvaluatorsResource
 from .api.resources.session import SessionResource
 from .api.resources.event import EventResource
 from .api.resources.dataset import DatasetResource
@@ -157,6 +159,8 @@ class LucidicAI:
         # Initialize API resources
         self._resources: Dict[str, Any] = {
             "agents": AgentsResource(self._http),
+            "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
+            "evaluator_results": EvaluatorResultsResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
             "datasets": DatasetResource(self._http, self._config.agent_id, self._production),
@@ -252,6 +256,26 @@ class LucidicAI:
         follow-up.)
         """
         return self._resources["agents"]
+
+    @property
+    def evaluators(self) -> EvaluatorsResource:
+        """Access evaluator reads (LUC-910): ``list()`` / ``get(id)``,
+        ``evals(id)`` (one evaluator's result distribution), and ``result(id)``
+        (a single evaluator result by id).
+
+        Distinct from ``client.evals`` (ad-hoc score ``emit``).
+        """
+        return self._resources["evaluators"]
+
+    @property
+    def evaluator_results(self) -> EvaluatorResultsResource:
+        """Read a single evaluator result by its id (LUC-910):
+        ``client.evaluator_results.get(eval_id)``.
+
+        Keyed by an ``EvalResult`` id — distinct from the evaluator-keyed reads
+        on ``client.evaluators``.
+        """
+        return self._resources["evaluator_results"]
 
     @property
     def tools(self) -> ToolsResource:

--- a/tests/api/resources/test_evaluator_results_v2.py
+++ b/tests/api/resources/test_evaluator_results_v2.py
@@ -1,0 +1,47 @@
+"""LUC-910 — client.evaluator_results.get (single evaluator result by id)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.session import EvalResult
+from lucidicai.api.resources.evaluator_results import EvaluatorResultsResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_EVAL_RESULTS = f"{_BASE}/sdk/v2/evaluator-results"
+
+
+@pytest.fixture
+def results(http):
+    return EvaluatorResultsResource(http)
+
+
+def _result(i, **over):
+    d = {"eval_id": f"r{i}", "evaluator_name": "eval-1", "result": True,
+         "result_type": "boolean", "is_pending": False}
+    d.update(over)
+    return d
+
+
+class TestGet:
+    @respx.mock
+    def test_single_result_typed(self, results):
+        respx.get(f"{_EVAL_RESULTS}/r1").mock(return_value=httpx.Response(
+            200, json=_result(1, result=0.9, result_type="number")))
+        r = results.get("r1")
+        assert isinstance(r, EvalResult)
+        assert r.eval_id == "r1" and r.result == 0.9
+
+    @respx.mock
+    def test_404_raises(self, results):
+        respx.get(f"{_EVAL_RESULTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            results.get("missing")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, results):
+        respx.get(f"{_EVAL_RESULTS}/r1").mock(return_value=httpx.Response(200, json=_result(1)))
+        r = await results.aget("r1")
+        assert r.eval_id == "r1"

--- a/tests/api/resources/test_evaluators_v2.py
+++ b/tests/api/resources/test_evaluators_v2.py
@@ -1,0 +1,119 @@
+"""LUC-910 — client.evaluators reads (list / get / evals / result)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.evaluator import Evaluator
+from lucidicai.api.models.session import EvalResult
+from lucidicai.api.resources.evaluators import EvaluatorsResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_EVALUATORS = f"{_BASE}/sdk/v2/evaluators"
+
+
+@pytest.fixture
+def evaluators(http):
+    return EvaluatorsResource(http, agent_id="a1")
+
+
+def _evaluator(i, **over):
+    d = {
+        "evaluator_id": f"e{i}", "name": f"eval-{i}", "description": "", "icon": "star",
+        "type": "LLM", "result_type": "boolean", "is_default": False,
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+        "criteria": [],
+    }
+    d.update(over)
+    return d
+
+
+def _result(i, **over):
+    d = {"eval_id": f"r{i}", "evaluator_name": "eval-1", "result": True,
+         "result_type": "boolean", "is_pending": False}
+    d.update(over)
+    return d
+
+
+class TestListGet:
+    @respx.mock
+    def test_list_typed_and_defaults_agent(self, evaluators):
+        route = respx.get(_EVALUATORS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evaluator(1), _evaluator(2)],
+                                      "next": f"{_EVALUATORS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evaluator(3)], "next": None}),
+        ])
+        got = list(evaluators.list())
+        assert [e.evaluator_id for e in got] == ["e1", "e2", "e3"]
+        assert all(isinstance(e, Evaluator) for e in got)
+        assert route.calls[0].request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_get_detail(self, evaluators):
+        respx.get(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(
+            200, json=_evaluator(1, rubric_json={"q": "is it good?"}, config={"model": "gpt"})))
+        e = evaluators.get("e1")
+        assert isinstance(e, Evaluator)
+        assert e.rubric_json == {"q": "is it good?"}
+        assert e.config == {"model": "gpt"}
+
+    @respx.mock
+    def test_get_404(self, evaluators):
+        respx.get(f"{_EVALUATORS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            evaluators.get("missing")
+
+
+class TestEvalsDistribution:
+    @respx.mock
+    def test_evals_typed_and_no_agent_param(self, evaluators):
+        route = respx.get(f"{_EVALUATORS}/e1/evals").mock(side_effect=[
+            httpx.Response(200, json={"results": [_result(1), _result(2)],
+                                      "next": f"{_EVALUATORS}/e1/evals?cursor=c2"}),
+            httpx.Response(200, json={"results": [_result(3)], "next": None}),
+        ])
+        got = list(evaluators.evals("e1"))
+        assert [r.eval_id for r in got] == ["r1", "r2", "r3"]
+        assert all(isinstance(r, EvalResult) for r in got)
+        # path-keyed: no agent_id forwarded on the distribution read
+        assert "agent_id" not in route.calls[0].request.url.params
+
+    @respx.mock
+    def test_evals_page(self, evaluators):
+        respx.get(f"{_EVALUATORS}/e1/evals").mock(return_value=httpx.Response(
+            200, json={"results": [_result(1)], "next": None}))
+        page = evaluators.evals_page("e1")
+        assert isinstance(page.results[0], EvalResult)
+
+
+class TestAgentIdGuard:
+    @respx.mock
+    def test_list_omits_agent_id_when_none(self, http):
+        # No configured agent + none passed -> agent_id is omitted (not sent as
+        # an empty string), matching the sibling-resource convention.
+        route = respx.get(_EVALUATORS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(EvaluatorsResource(http, agent_id=None).list())
+        assert "agent_id" not in route.calls.last.request.url.params
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, evaluators):
+        respx.get(_EVALUATORS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evaluator(1)], "next": f"{_EVALUATORS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evaluator(2)], "next": None}),
+        ])
+        got = [e.evaluator_id async for e in evaluators.alist()]
+        assert got == ["e1", "e2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aevals(self, evaluators):
+        respx.get(f"{_EVALUATORS}/e1/evals").mock(return_value=httpx.Response(
+            200, json={"results": [_result(1)], "next": None}))
+        got = [r.eval_id async for r in evaluators.aevals("e1")]
+        assert got == ["r1"]
+


### PR DESCRIPTION
New evaluator read surface (distinct from the pre-existing emit-only `client.evals`). Two namespaces on C0:

## Surface
- **`client.evaluators`** — `list()`/`get(id)` (evaluator definitions; one `Evaluator` model spans list-light + detail-superset with `rubric_json`/`config`), and `evals(evaluator_id)` → one evaluator's result distribution across runs (`EvalResult` items). Plus `list_page`/`evals_page` and all async siblings.
- **`client.evaluator_results`** — `get(eval_id)` → a single evaluator result by its own id.

Both eval-result reads reuse the existing `EvalResult` model (shared `EvaluatorResultSerializer`). Reads are data-bearing → no production swallow. No HEAD/count (evaluator list has none).

## Review-driven (code-skeptic pass)
Field-parity verified exact — `EvalResult` matches the 16-field `EvaluatorResultSerializer` for both endpoints (nothing lost to `.extra`), and `Evaluator` matches the list/detail serializers. Two changes from the review:
- **Moved the single-result read into its own `client.evaluator_results` namespace** (as originally specced). On `evaluators` it was `result(eval_id)` — an *EvalResult* id — sitting next to `evals(evaluator_id)`/`get(evaluator_id)`, a real id-type footgun. The dedicated namespace makes the keying unambiguous.
- **`_agent_params` omits `agent_id` when it resolves to `None`** instead of sending an empty `agent_id=`, matching the sibling-resource convention.

## Files
- `lucidicai/api/models/evaluator.py` (new) — `Evaluator`
- `lucidicai/api/resources/evaluators.py` (new) — `EvaluatorsResource`
- `lucidicai/api/resources/evaluator_results.py` (new) — `EvaluatorResultsResource`
- `lucidicai/client.py` — wire both namespaces
- `tests/api/resources/test_evaluators_v2.py` + `test_evaluator_results_v2.py` — 14 tests; 330 hermetic total pass