### PR TITLE
LUC-911: client.usage reads (get) — closes C1

### DIFF
--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -12,6 +12,7 @@ from .session import (
     SessionEvaluatorResults,
     SessionTrace,
 )
+from .usage import Usage
 
 __all__ = [
     "APIModel",
@@ -29,4 +30,5 @@ __all__ = [
     "EvalResult",
     "EventEval",
     "SessionEvaluatorResults",
+    "Usage",
 ]

--- a/lucidicai/api/models/usage.py
+++ b/lucidicai/api/models/usage.py
@@ -1,0 +1,48 @@
+"""Typed response model for client.usage (LUC-911).
+
+The usage endpoint returns a *dynamic* ``{stat_name: total}`` map (stat names
+are backend-normalized: spaces -> ``_``, ``/`` removed, lowercased), so — unlike
+the fixed-field ``APIModel`` models — ``Usage`` is a thin read-only mapping
+wrapper over the raw dict rather than a dataclass with declared fields.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, ItemsView, Iterator, KeysView
+
+
+@dataclass
+class Usage:
+    """Org-aggregated usage / quota counters as a read-only mapping.
+
+    Access counters by name — ``usage["num_sessions"]`` / ``usage.get("cost")``
+    — or reach the raw dict via ``.stats``. An org-less key yields an empty map.
+    """
+
+    stats: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Usage":
+        return cls(stats=dict(data) if isinstance(data, dict) else {})
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.stats.get(key, default)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self.stats)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.stats[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.stats
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.stats)
+
+    def __len__(self) -> int:
+        return len(self.stats)
+
+    def keys(self) -> KeysView[str]:
+        return self.stats.keys()
+
+    def items(self) -> ItemsView[str, Any]:
+        return self.stats.items()

--- a/lucidicai/api/resources/usage.py
+++ b/lucidicai/api/resources/usage.py
@@ -1,0 +1,21 @@
+"""client.usage — org-aggregated usage / quota counters (LUC-911).
+
+A single-endpoint namespace. Data-bearing read — does NOT swallow in production.
+"""
+from ..client import HttpClient
+from ..models.usage import Usage
+
+
+class UsageResource:
+    """Handle for ``GET /sdk/v2/usage``."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def get(self) -> Usage:
+        """Read the key's org aggregated usage counters (scope ``usage:read``)."""
+        return Usage.from_dict(self.http.get("sdk/v2/usage"))
+
+    async def aget(self) -> Usage:
+        """Async sibling of ``get``."""
+        return Usage.from_dict(await self.http.aget("sdk/v2/usage"))

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -28,6 +28,7 @@ from .api.resources.agents import AgentsResource
 from .api.resources.evaluator_results import EvaluatorResultsResource
 from .api.resources.evaluators import EvaluatorsResource
 from .api.resources.session import SessionResource
+from .api.resources.usage import UsageResource
 from .api.resources.event import EventResource
 from .api.resources.dataset import DatasetResource
 from .api.resources.experiment import ExperimentResource
@@ -161,6 +162,7 @@ class LucidicAI:
             "agents": AgentsResource(self._http),
             "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
             "evaluator_results": EvaluatorResultsResource(self._http),
+            "usage": UsageResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
             "datasets": DatasetResource(self._http, self._config.agent_id, self._production),
@@ -276,6 +278,13 @@ class LucidicAI:
         on ``client.evaluators``.
         """
         return self._resources["evaluator_results"]
+
+    @property
+    def usage(self) -> UsageResource:
+        """Access org-aggregated usage counters (LUC-911):
+        ``client.usage.get()`` returns a read-only ``{stat_name: total}`` mapping.
+        """
+        return self._resources["usage"]
 
     @property
     def tools(self) -> ToolsResource:

--- a/tests/api/resources/test_usage_v2.py
+++ b/tests/api/resources/test_usage_v2.py
@@ -1,0 +1,54 @@
+"""LUC-911 — client.usage.get (org-aggregated usage counters)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.usage import Usage
+from lucidicai.api.resources.usage import UsageResource
+from lucidicai.core.errors import InsufficientScopeError
+
+_BASE = "https://stub.lucidic.test"
+_USAGE = f"{_BASE}/sdk/v2/usage"
+
+
+@pytest.fixture
+def usage(http):
+    return UsageResource(http)
+
+
+class TestGet:
+    @respx.mock
+    def test_returns_mapping(self, usage):
+        respx.get(_USAGE).mock(return_value=httpx.Response(
+            200, json={"num_sessions": 120, "num_events": 4500, "cost": 3.14}))
+        u = usage.get()
+        assert isinstance(u, Usage)
+        assert u["num_sessions"] == 120
+        assert u.get("cost") == 3.14
+        assert u.get("missing", 0) == 0
+        assert "num_events" in u
+        assert set(u.keys()) == {"num_sessions", "num_events", "cost"}
+        assert dict(u.items()) == u.to_dict()
+        assert len(u) == 3
+
+    @respx.mock
+    def test_empty_map(self, usage):
+        # org-less key -> {} (backend defensive path)
+        respx.get(_USAGE).mock(return_value=httpx.Response(200, json={}))
+        u = usage.get()
+        assert u.to_dict() == {} and len(u) == 0
+
+    @respx.mock
+    def test_missing_scope_raises(self, usage):
+        # Data-bearing read: surfaces the typed error, doesn't swallow.
+        respx.get(_USAGE).mock(return_value=httpx.Response(
+            403, json={"error": "missing scope", "required_scope": "usage:read"}))
+        with pytest.raises(InsufficientScopeError):
+            usage.get()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, usage):
+        respx.get(_USAGE).mock(return_value=httpx.Response(200, json={"num_sessions": 7}))
+        u = await usage.aget()
+        assert u["num_sessions"] == 7


### PR DESCRIPTION
The last **C1 — Reads** ticket. New single-endpoint `client.usage` namespace.

## Surface
- `client.usage.get()` → org-aggregated usage counters; `aget()` async.

The endpoint returns a **dynamic** `{stat_name: total}` map (arbitrary backend-normalized keys), so `Usage` is a thin read-only **mapping wrapper** (`usage["num_sessions"]` / `.get("cost")` / `.keys()` / `.items()` / `.to_dict()`, raw dict on `.stats`) rather than a fixed-field dataclass. Data-bearing read → no production swallow.

## Milestone: C1 is complete 🎯
With this, the SDK goes from **read-blind → read-complete**. All six read namespaces are in:
`agents` · `sessions` (list/trace/evals/event) · `experiments` · `prompts` (list/versions/labels) · `evaluators` + `evaluator_results` · `usage`.

A customer can now enumerate and read back everything the SDK writes, entirely from code. Next milestone is **C2 — Writes & lifecycle**.

## Files
- `lucidicai/api/models/usage.py` (new) — `Usage` (mapping wrapper)
- `lucidicai/api/resources/usage.py` (new) — `UsageResource`
- `lucidicai/api/models/__init__.py`, `lucidicai/client.py` — wire the namespace
- `tests/api/resources/test_usage_v2.py` — 4 tests; 334 hermetic total pass