### PR TITLE
LUC-926: agent_id optional at construction + AgentIdRequiredError guard

### DIFF
--- a/lucidicai/api/resources/evaluators.py
+++ b/lucidicai/api/resources/evaluators.py
@@ -15,6 +15,7 @@ from ..models.base import CursorPage
 from ..models.evaluator import Evaluator
 from ..models.session import EvalResult
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 _EVALUATORS = "sdk/v2/evaluators"
 
@@ -120,10 +121,9 @@ class EvaluatorsResource:
     def _agent_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
     ) -> Dict[str, Any]:
-        resolved = agent_id or self._agent_id
-        params: Dict[str, Any] = {}
-        if resolved is not None:
-            params["agent_id"] = resolved
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "evaluators.list"),
+        }
         if ordering is not None:
             params["ordering"] = ordering
         if page_size is not None:

--- a/lucidicai/api/resources/evosim.py
+++ b/lucidicai/api/resources/evosim.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from ..client import HttpClient
-from ...core.errors import LucidicError
+from ...core.errors import LucidicError, require_agent_id
 
 logger = logging.getLogger("Lucidic")
 
@@ -43,10 +43,11 @@ class EvoSimResource:
         Returns:
             Backend response describing the run (successful or failed)
         """
+        # LUC-926: a training run needs an agent; raise before the swallow.
+        require_agent_id(self._agent_id, "evosim.train")
         try:
             payload = _load_training_config(config_json_file)
-            if self._agent_id:
-                payload.setdefault("agent_id", self._agent_id)
+            payload.setdefault("agent_id", self._agent_id)
             return self.http.post("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:
@@ -56,10 +57,10 @@ class EvoSimResource:
 
     async def atrain(self, config_json_file: Union[str, Path]) -> Dict[str, Any]:
         """Async sibling of ``train``."""
+        require_agent_id(self._agent_id, "evosim.train")
         try:
             payload = _load_training_config(config_json_file)
-            if self._agent_id:
-                payload.setdefault("agent_id", self._agent_id)
+            payload.setdefault("agent_id", self._agent_id)
             return await self.http.apost("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -6,6 +6,7 @@ from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.experiment import Experiment
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 logger = logging.getLogger("Lucidic")
 
@@ -56,6 +57,9 @@ class ExperimentResource:
         if LLM_numeric_evaluators:
             evaluator_names.extend(LLM_numeric_evaluators)
 
+        # LUC-926: an experiment must belong to an agent — raise before the
+        # swallow rather than POST a null agent_id.
+        require_agent_id(self._agent_id, "experiments.create")
         try:
             response = self.http.post(
                 "createexperiment",
@@ -92,6 +96,8 @@ class ExperimentResource:
         if LLM_numeric_evaluators:
             evaluator_names.extend(LLM_numeric_evaluators)
 
+        # LUC-926: same guard as create() — raise before the swallow.
+        require_agent_id(self._agent_id, "experiments.create")
         try:
             response = await self.http.apost(
                 "createexperiment",
@@ -176,7 +182,9 @@ class ExperimentResource:
     def _list_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
     ) -> Dict[str, Any]:
-        params: Dict[str, Any] = {"agent_id": agent_id or self._agent_id}
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "experiments.list"),
+        }
         if ordering is not None:
             params["ordering"] = ordering
         if page_size is not None:

--- a/lucidicai/api/resources/prompt.py
+++ b/lucidicai/api/resources/prompt.py
@@ -8,6 +8,7 @@ from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.prompt import PromptInfo, PromptVersion
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 if TYPE_CHECKING:
     from ...core.config import SDKConfig
@@ -471,12 +472,14 @@ class PromptResource:
     def labels(self, agent_id: Optional[str] = None) -> List[str]:
         """The agent's label names (shared across its prompts) — a small,
         non-paginated read."""
-        resp = self.http.get("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.labels")
+        resp = self.http.get("sdk/v2/prompts/labels", {"agent_id": agent})
         return resp.get("labels", [])
 
     async def alabels(self, agent_id: Optional[str] = None) -> List[str]:
         """Async sibling of ``labels``."""
-        resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.labels")
+        resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent})
         return resp.get("labels", [])
 
     # ---- read internals ----
@@ -484,7 +487,9 @@ class PromptResource:
     def _agent_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
     ) -> Dict[str, Any]:
-        params: Dict[str, Any] = {"agent_id": agent_id or self._config.agent_id}
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._config.agent_id, "prompts.list"),
+        }
         if ordering is not None:
             params["ordering"] = ordering
         if page_size is not None:

--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -9,6 +9,7 @@ from ..client import HttpClient
 from ..models import session as session_models
 from ..models.base import CursorPage
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 if TYPE_CHECKING:
     from ...client import LucidicAI
@@ -102,6 +103,11 @@ class SessionResource:
                     auto_end=False,
                 )
             raise LucidicError("Client is not properly configured")
+
+        # LUC-926: a session must attach to an agent. Raise loudly (even in
+        # production) BEFORE the swallow below, rather than POST a null agent_id
+        # and silently drop this session + all its events.
+        require_agent_id(self._config.agent_id, "sessions.create")
 
         # Use client's auto_end by default
         if auto_end is None:
@@ -209,6 +215,9 @@ class SessionResource:
                     auto_end=False,
                 )
             raise LucidicError("Client is not properly configured")
+
+        # LUC-926: same guard as create() — raise before the swallow.
+        require_agent_id(self._config.agent_id, "sessions.create")
 
         if auto_end is None:
             auto_end = self._config.auto_end

--- a/lucidicai/core/config.py
+++ b/lucidicai/core/config.py
@@ -223,10 +223,13 @@ class SDKConfig:
         
         if not self.api_key:
             errors.append("API key is required (LUCIDIC_API_KEY)")
-        
-        if not self.agent_id:
-            errors.append("Agent ID is required (LUCIDIC_AGENT_ID)")
-        
+
+        # agent_id is intentionally NOT required (LUC-926): a client may be
+        # constructed with just an api_key to run org-/id-scoped operations
+        # (agents/projects/usage, get-by-id). Agent-scoped operations (telemetry
+        # ingestion, prompt fetch, list-by-agent) guard with require_agent_id and
+        # raise AgentIdRequiredError when it's actually needed but absent.
+
         if self.blob_threshold < 1024:
             errors.append("Blob threshold must be at least 1024 bytes")
         

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -148,6 +148,39 @@ class FeatureFlagError(LucidicError):
         super().__init__(f"Failed to fetch feature flag: {message}")
 
 
+class AgentIdRequiredError(LucidicError):
+    """Raised when an operation needs an ``agent_id`` but the client was created
+    without one (LUC-926).
+
+    ``agent_id`` is optional at construction so org-/id-scoped work (agents,
+    projects, usage, and any get-by-id) can run without one. Operations that are
+    inherently agent-scoped — telemetry ingestion, prompt fetch, and the
+    list-by-agent reads — raise this instead. It is raised **even in production**
+    (not routed through the telemetry error-swallow): a missing agent_id is a
+    deterministic setup mistake, so silently no-op'ing would just lose data.
+    """
+
+    def __init__(self, operation: str):
+        super().__init__(
+            f"{operation} requires an agent_id, but this client was created "
+            f"without one. Provide it via LucidicAI(agent_id=...), the "
+            f"LUCIDIC_AGENT_ID env var, or (where the method accepts it) pass "
+            f"agent_id=... to the call."
+        )
+
+
+def require_agent_id(agent_id: Optional[str], operation: str) -> str:
+    """Return ``agent_id`` if present, else raise ``AgentIdRequiredError``.
+
+    The single guard for every agent-scoped operation. Call at the top of the
+    operation, before any HTTP request or error-swallowing, so the failure is
+    immediate and loud.
+    """
+    if not agent_id:
+        raise AgentIdRequiredError(operation)
+    return agent_id
+
+
 # ---------------------------------------------------------------------------
 # mock_call dispatch errors (LUC-607)
 # ---------------------------------------------------------------------------

--- a/lucidicai/sdk/session.py
+++ b/lucidicai/sdk/session.py
@@ -75,7 +75,7 @@ def _ensure_http_and_resources_initialized(config: SDKConfig) -> None:
 def _build_session_params(
     session_id: Optional[str],
     session_name: Optional[str],
-    agent_id: str,
+    agent_id: Optional[str],
     task: Optional[str],
     tags: Optional[List],
     experiment_id: Optional[str],
@@ -84,10 +84,16 @@ def _build_session_params(
     production_monitoring: bool,
 ) -> tuple[str, dict]:
     """Build session parameters for API call.
-    
+
     Returns:
         Tuple of (real_session_id, session_params)
     """
+    # LUC-926: a session must attach to an agent. Raise loudly (even in
+    # production) if there's no agent_id, rather than POST a null one or let a
+    # swallow silently drop the session. Shared by create_session + acreate.
+    from ..core.errors import require_agent_id
+    require_agent_id(agent_id, "create_session")
+
     # Create or retrieve session
     if session_id:
         real_session_id = session_id
@@ -330,7 +336,12 @@ def emit_session(
         Session ID - returned immediately
     """
     from .init import _sdk_state
-    
+
+    # NOTE (LUC-926): emit_session is pre-existing-broken — the import above
+    # (`_sdk_state`) doesn't exist in sdk/init.py, so this fire-and-forget path
+    # raises ImportError on first use and is effectively dead (not in __all__).
+    # It is therefore NOT a silent-loss risk; no agent_id guard is added here.
+
     # Pre-generate session ID for instant return
     real_session_id = session_id or str(uuid.uuid4())
     

--- a/tests/api/resources/test_evaluators_v2.py
+++ b/tests/api/resources/test_evaluators_v2.py
@@ -88,14 +88,13 @@ class TestEvalsDistribution:
 
 
 class TestAgentIdGuard:
-    @respx.mock
-    def test_list_omits_agent_id_when_none(self, http):
-        # No configured agent + none passed -> agent_id is omitted (not sent as
-        # an empty string), matching the sibling-resource convention.
-        route = respx.get(_EVALUATORS).mock(
-            return_value=httpx.Response(200, json={"results": [], "next": None}))
-        list(EvaluatorsResource(http, agent_id=None).list())
-        assert "agent_id" not in route.calls.last.request.url.params
+    def test_list_without_agent_id_raises(self, http):
+        # No configured agent + none passed -> a clear AgentIdRequiredError
+        # (raised eagerly at the .list() call, before any HTTP), not a backend
+        # 400 or an empty-string param (LUC-926).
+        from lucidicai.core.errors import AgentIdRequiredError
+        with pytest.raises(AgentIdRequiredError):
+            EvaluatorsResource(http, agent_id=None).list()
 
 
 class TestAsync:

--- a/tests/api/test_agent_id_guard.py
+++ b/tests/api/test_agent_id_guard.py
@@ -1,0 +1,109 @@
+"""LUC-926 — agent_id optional at construction + AgentIdRequiredError guard.
+
+agent_id is no longer required to build a client (org-/id-scoped work runs
+without one); agent-scoped operations raise a clear, typed error — even in
+production — when it's actually needed but absent.
+"""
+import pytest
+
+from lucidicai.api.resources.evaluators import EvaluatorsResource
+from lucidicai.api.resources.evosim import EvoSimResource
+from lucidicai.api.resources.experiment import ExperimentResource
+from lucidicai.api.resources.prompt import PromptResource
+from lucidicai.api.resources.session import SessionResource
+from lucidicai.core.config import NetworkConfig, SDKConfig
+from lucidicai.core.errors import AgentIdRequiredError, require_agent_id
+from lucidicai.sdk.session import _build_session_params
+
+_BASE = "https://stub.lucidic.test"
+
+
+class _FakeClient:
+    """Minimal stand-in: the write guard fires before any real client use."""
+    is_valid = True
+
+
+class TestValidateRelaxed:
+    def test_no_agent_id_is_valid(self):
+        # api_key alone is a valid config now (LUC-926).
+        assert SDKConfig(api_key="k", agent_id=None).validate() == []
+
+    def test_api_key_still_required(self):
+        errors = SDKConfig(api_key=None, agent_id=None).validate()
+        assert any("API key" in e for e in errors)
+
+
+class TestHelper:
+    def test_returns_when_present(self):
+        assert require_agent_id("a1", "op") == "a1"
+
+    def test_raises_when_absent(self):
+        with pytest.raises(AgentIdRequiredError) as ei:
+            require_agent_id(None, "create_session")
+        assert "create_session" in str(ei.value)
+        assert "agent_id" in str(ei.value)
+
+
+class TestIngestionGuard:
+    def test_build_session_params_requires_agent(self):
+        # Telemetry chokepoint: a session must attach to an agent. This helper
+        # has no production branch, so it raises unconditionally.
+        with pytest.raises(AgentIdRequiredError):
+            _build_session_params(None, "run", None, None, None, None, None, None, False)
+
+    def test_build_session_params_ok_with_agent(self):
+        real_id, params = _build_session_params(
+            None, "run", "a1", None, None, None, None, None, False)
+        assert params["agent_id"] == "a1"
+
+    def test_evosim_train_raises_even_in_production(self, http):
+        # Guard is before the try/except swallow, so production doesn't eat it.
+        res = EvoSimResource(http, agent_id=None, production=True)
+        with pytest.raises(AgentIdRequiredError):
+            res.train("does-not-matter.json")  # raises before reading the file
+
+
+class TestListReadGuards:
+    def test_experiments_list_raises(self, http):
+        with pytest.raises(AgentIdRequiredError):
+            ExperimentResource(http, agent_id=None).list()
+
+    def test_evaluators_list_raises(self, http):
+        with pytest.raises(AgentIdRequiredError):
+            EvaluatorsResource(http, agent_id=None).list()
+
+    def test_prompts_list_raises(self, http):
+        cfg = SDKConfig(api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE))
+        with pytest.raises(AgentIdRequiredError):
+            PromptResource(http, cfg).list()
+
+    def test_prompts_labels_raises(self, http):
+        cfg = SDKConfig(api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE))
+        with pytest.raises(AgentIdRequiredError):
+            PromptResource(http, cfg).labels()
+
+    def test_explicit_agent_id_bypasses_guard(self, http):
+        # Passing agent_id explicitly is fine even with no configured agent —
+        # the resolver never reaches the guard (no HTTP asserted; just no raise).
+        import respx
+        import httpx
+        with respx.mock:
+            respx.get(f"{_BASE}/sdk/v2/experiments").mock(
+                return_value=httpx.Response(200, json={"results": [], "next": None}))
+            assert list(ExperimentResource(http, agent_id=None).list("a2")) == []
+
+
+class TestWriteGuards:
+    """The write chokepoints (the live public telemetry / provisioning paths)
+    must raise BEFORE their production error-swallow, not silently no-op."""
+
+    def test_session_create_raises_even_in_production(self, http):
+        cfg = SDKConfig(api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE))
+        res = SessionResource(http, client=_FakeClient(), config=cfg, production=True)
+        with pytest.raises(AgentIdRequiredError):
+            res.create(session_name="x")
+
+    def test_experiment_create_raises_even_in_production(self, http):
+        res = ExperimentResource(http, agent_id=None, production=True)
+        with pytest.raises(AgentIdRequiredError):
+            res.create("my-exp")


### PR DESCRIPTION
Makes `agent_id` **optional at construction** (one client, no second type) so a client built with just an `api_key` can run org-/id-scoped work — `agents`/`projects`/`usage`, and any get-by-id — without one. Agent-scoped operations raise a clear, typed `AgentIdRequiredError` when it's actually needed but absent.

Per the design discussion: **the guard raises even in production** (not routed through the telemetry error-swallow), which is safe because a missing agent_id is a *deterministic* setup mistake — it can never intermittently break a correctly-configured deployment, only surface an already-broken one.

## Changes
- `core/config.py` — `validate()` no longer requires `agent_id` (api_key still required).
- `core/errors.py` — `AgentIdRequiredError` + `require_agent_id(agent_id, operation)` helper.
- **Guards, each placed *before* the production error-swallow:**
  - `SessionResource.create`/`acreate` — the **live public telemetry path** (`client.sessions.create`).
  - `ExperimentResource.create`/`acreate`.
  - `EvoSimResource.train`/`atrain`.
  - C1 list reads: `experiments`/`prompts`(list+labels)/`evaluators` `.list()` — eager (raise at the `.list()` call, before HTTP).
  - `_build_session_params` (legacy module-level path).

## Review caught a critical miss (fixed)
The code-skeptic pass found that my *first* attempt guarded only the **legacy module-level** `create_session` (`_build_session_params`), **not** the live `client.sessions.create` → `SessionResource.create` path — which builds `agent_id` from config inline inside a production swallow. Relaxing `validate()` removed the `is_valid` gate that used to protect it, so a no-agent client would have **silently dropped sessions in production** — the exact trap this ticket exists to prevent. Fixed by guarding the real chokepoints (`SessionResource.create`/`acreate`, `ExperimentResource.create`) and adding a test for the precise scenario (no-agent client + `production=True` → raises).

## Deliberately NOT guarded (documented)
- **Prompt fetch** (`PromptResource.get`) — resolves via session/checkpoint context, so requiring agent_id would over-reject valid calls.
- **`DatasetResource.create` + dataset-gen features + feature flags** — legacy / lower-frequency; same one-line helper applies as a small follow-up.
- **`emit_session`** is pre-existing-**broken** (`ImportError` on `_sdk_state`, not defined in `sdk/init.py`; not in `__all__`) — dead code, so it's a loud-fail, not a silent-loss path. Noted, not guarded.

## Files
`core/config.py`, `core/errors.py`, `sdk/session.py`, `api/resources/{session,experiment,evosim,prompt,evaluators}.py`; `tests/api/test_agent_id_guard.py` (14 tests). 348 hermetic total pass.