### PR TITLE
LUC-912: client.agents create / update (first C2 write)

### DIFF
--- a/lucidicai/api/resources/agents.py
+++ b/lucidicai/api/resources/agents.py
@@ -1,17 +1,16 @@
-"""client.agents — agent reads (LUC-906).
+"""client.agents — agent reads + writes (LUC-906 / LUC-912).
 
-Read the org's agents: ``list`` them (discover / enumerate ``agent_id`` s),
-``get`` one back, or inspect an agent's ``tool_catalog``.
+Read the org's agents (``list`` / ``get`` / ``tool_catalog``) and provision them
+(``create`` / ``update``). ``create`` is the SDK-first bootstrap — since LUC-926
+a client needs only an api_key to construct, so ``client.agents.create(...)``
+can mint an org's first agent purely from code. There is no ``delete`` (that
+cascades to every session/event/tool/prompt under the agent — dashboard-only).
 
-(A brand-new caller with *no* ``agent_id`` at all still can't construct the
-client to reach ``list`` — ``LucidicAI`` requires one today; a read-only /
-bootstrap construction mode is a planned follow-up. With any existing key +
-``agent_id`` you can enumerate the rest.)
-
-Reads are data-bearing, so — unlike the telemetry-write resources — they do
-NOT swallow errors in production: a failure raises the typed ``LucidicError``
-subclass the transport decoded (``NotFoundError``, ``InsufficientScopeError``,
-…). Every method has an ``a``-prefixed async sibling.
+Both reads and writes are data-bearing, so — unlike the telemetry resources —
+they do NOT swallow errors in production: a failure raises the typed
+``LucidicError`` subclass the transport decoded (``NotFoundError``,
+``InsufficientScopeError``, ``ValidationError``, …). Every method has an
+``a``-prefixed async sibling.
 """
 from typing import Any, AsyncIterator, Dict, Iterator, Optional
 
@@ -88,6 +87,74 @@ class AgentsResource:
     async def aget(self, agent_id: str) -> Agent:
         """Async sibling of ``get``."""
         return Agent.from_dict(await self.http.aget(f"{_AGENTS}/{agent_id}"))
+
+    # ==================== write (LUC-912) ====================
+
+    def create(
+        self, name: str, *, icon: Optional[str] = None, project_id: Optional[str] = None,
+    ) -> Agent:
+        """Create an agent in the key's org — the SDK-first bootstrap.
+
+        Needs ``agent:write``. An agent-**bound** key can't create agents (it
+        could only ever see its one agent) → the backend returns 403 →
+        ``InsufficientScopeError`` (a binding restriction, not a missing scope;
+        see that error's docs). ``icon`` defaults backend-side ("compass") when
+        omitted; ``project_id`` optionally files the new agent under a project.
+        """
+        return Agent.from_dict(self.http.post(_AGENTS, self._create_body(name, icon, project_id)))
+
+    async def acreate(
+        self, name: str, *, icon: Optional[str] = None, project_id: Optional[str] = None,
+    ) -> Agent:
+        """Async sibling of ``create``."""
+        body = self._create_body(name, icon, project_id)
+        return Agent.from_dict(await self.http.apost(_AGENTS, body))
+
+    def update(
+        self, agent_id: str, *, name: Optional[str] = None, icon: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> Agent:
+        """Update an agent's name / icon / project (e.g. move it between
+        projects). Only the fields you pass change; ``None`` leaves a field
+        untouched. An over-length name/icon → ``ValidationError``."""
+        return Agent.from_dict(
+            self.http.put(f"{_AGENTS}/{agent_id}", self._update_body(name, icon, project_id))
+        )
+
+    async def aupdate(
+        self, agent_id: str, *, name: Optional[str] = None, icon: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> Agent:
+        """Async sibling of ``update``."""
+        return Agent.from_dict(
+            await self.http.aput(f"{_AGENTS}/{agent_id}", self._update_body(name, icon, project_id))
+        )
+
+    @staticmethod
+    def _create_body(
+        name: str, icon: Optional[str], project_id: Optional[str]
+    ) -> Dict[str, Any]:
+        # Omit unset optional fields uniformly (like _update_body) so the backend
+        # owns their defaults — don't hardcode "compass" here.
+        body: Dict[str, Any] = {"name": name}
+        if icon is not None:
+            body["icon"] = icon
+        if project_id is not None:
+            body["project_id"] = project_id
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], icon: Optional[str], project_id: Optional[str]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if icon is not None:
+            body["icon"] = icon
+        if project_id is not None:
+            body["project_id"] = project_id
+        return body
 
     # ==================== tool catalog ====================
 

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -78,10 +78,13 @@ class APIKeyVerificationError(AuthError):
 
 
 class InsufficientScopeError(LucidicAPIError):
-    """403 — the API key lacks the required capability scope.
+    """403 — the API key is not authorized for this action.
 
-    ``required_scope`` names the missing ``resource:verb`` when the backend
-    reports it, so the message can tell the user which preset/key to mint.
+    Usually a missing capability scope: ``required_scope`` names the missing
+    ``resource:verb`` when the backend reports it. When ``required_scope`` is
+    ``None`` the key HAS the scope but a narrower rule blocked the action (e.g.
+    an agent-bound key can't create new agents) — read the message rather than
+    assuming a scope is missing.
     """
     status_code = 403
 

--- a/tests/api/resources/test_agents.py
+++ b/tests/api/resources/test_agents.py
@@ -1,15 +1,17 @@
-"""LUC-906 — client.agents reads (list / get / tool_catalog).
+"""LUC-906 / LUC-912 — client.agents reads + writes.
 
 Uses the hermetic ``http`` fixture from tests/api/conftest.py (stub URL,
 retry sleeps irrelevant here). Backend mocked at the HTTP boundary via respx.
 """
+import json
+
 import httpx
 import pytest
 import respx
 
 from lucidicai.api.models.agent import Agent, AgentToolCatalog, CatalogTool
 from lucidicai.api.resources.agents import AgentsResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
 
 _BASE = "https://stub.lucidic.test"
 _AGENTS = f"{_BASE}/sdk/v2/agents"
@@ -157,3 +159,70 @@ class TestAsync:
             200, json={"agent_id": "a1", "agent_name": "n", "tools": [], "resources": []}))
         c = await agents.atool_catalog("a1")
         assert c.agent_id == "a1" and c.tools == []
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_omits_unset_optionals(self, agents):
+        route = respx.post(_AGENTS).mock(return_value=httpx.Response(201, json=_agent(1)))
+        a = agents.create("agent-1")
+        assert isinstance(a, Agent) and a.agent_id == "a1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "agent-1"
+        assert "icon" not in body            # omitted -> backend defaults ("compass")
+        assert "project_id" not in body
+
+    @respx.mock
+    def test_with_icon_and_project(self, agents):
+        route = respx.post(_AGENTS).mock(return_value=httpx.Response(201, json=_agent(1)))
+        agents.create("a", icon="rocket", project_id="p1")
+        body = json.loads(route.calls.last.request.read())
+        assert body["icon"] == "rocket" and body["project_id"] == "p1"
+
+    @respx.mock
+    def test_bound_key_403_is_insufficient_scope(self, agents):
+        respx.post(_AGENTS).mock(return_value=httpx.Response(
+            403, json={"error": "An agent-bound API key cannot create new agents."}))
+        with pytest.raises(InsufficientScopeError):
+            agents.create("x")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_sends_only_provided_fields(self, agents):
+        route = respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = agents.update("a1", name="renamed")
+        assert isinstance(a, Agent)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed"
+        assert "icon" not in body and "project_id" not in body
+
+    @respx.mock
+    def test_all_fields(self, agents):
+        route = respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        agents.update("a1", name="n", icon="i", project_id="p1")
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "n" and body["icon"] == "i" and body["project_id"] == "p1"
+
+    @respx.mock
+    def test_over_length_400_is_validation_error(self, agents):
+        respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(
+            400, json={"error": "A field exceeds its maximum length."}))
+        with pytest.raises(ValidationError):
+            agents.update("a1", name="x" * 999)
+
+
+class TestAsyncWrite:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, agents):
+        respx.post(_AGENTS).mock(return_value=httpx.Response(201, json=_agent(1)))
+        a = await agents.acreate("agent-1")
+        assert a.agent_id == "a1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, agents):
+        respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = await agents.aupdate("a1", icon="star")
+        assert a.agent_id == "a1"


### PR DESCRIPTION
First **C2 — Writes & lifecycle** ticket. Adds provisioning writes to `AgentsResource`.

## Surface
- `agents.create(name, *, icon=None, project_id=None)` → `Agent` (POST `/sdk/v2/agents`). The SDK-first bootstrap — since LUC-926 a client needs only an api_key, so this can mint an org's first agent purely from code.
- `agents.update(id, *, name=None, icon=None, project_id=None)` → `Agent` (PUT; only the fields you pass change). No `delete` (cascades to every session/event/tool/prompt — dashboard-only).
- All async siblings. Writes are data-bearing → they do **not** swallow in production; typed transport errors (`InsufficientScopeError`/`ValidationError`/…) propagate.

## C2-write conventions established here (the 7 sibling writes copy this)
The code-skeptic pass confirmed the spine is sound and refined two conventions before they propagate:
- **Omit-None body building, uniformly** — don't hardcode backend defaults (the old `_create_body` always sent `icon="compass"`). The backend owns defaults; `create`/`update` now build bodies identically.
- **Retry/idempotency** (from C0) is correct for writes: POST `create` is **not** auto-retried (no double-create); PUT `update` **is** retried and **is** idempotent (re-applies the same only-provided fields).
- **403 semantics** — a bound key (which *has* `agent:write`, but binding forbids create) surfaces as `InsufficientScopeError`. Its docstring is broadened **centrally** so `required_scope is None` reads as "a non-scope authorization restriction," not "you're missing a scope."
- **Null-clearing** a field isn't expressible (the backend also refuses null via `if x is not None`). If a future write needs set-to-null, we add an `UNSET` sentinel then — flagged now so it's a deliberate decision, not per-ticket drift.

## Files
- `lucidicai/api/resources/agents.py` — create/update + async + body builders
- `lucidicai/core/errors.py` — `InsufficientScopeError` docstring broadened
- `tests/api/resources/test_agents.py` — write tests; 356 hermetic total pass