### PR TITLE
LUC-913: client.projects CRUD (new namespace)

### DIFF
--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -3,6 +3,7 @@ from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
 from .evaluator import Evaluator
 from .experiment import Experiment
+from .project import Project
 from .prompt import PromptInfo, PromptVersion
 from .session import (
     EvalResult,
@@ -22,6 +23,7 @@ __all__ = [
     "CatalogTool",
     "Evaluator",
     "Experiment",
+    "Project",
     "PromptInfo",
     "PromptVersion",
     "Session",

--- a/lucidicai/api/models/project.py
+++ b/lucidicai/api/models/project.py
@@ -1,0 +1,16 @@
+"""Typed response model for client.projects (LUC-913)."""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Project(APIModel):
+    """A project — an org-level grouping that agents can be filed under
+    (``Agent.project``). Org-scoped: a bound key still sees all of them."""
+
+    project_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    icon: Optional[str] = None

--- a/lucidicai/api/resources/projects.py
+++ b/lucidicai/api/resources/projects.py
@@ -1,0 +1,159 @@
+"""client.projects — project CRUD (LUC-913).
+
+A new namespace. Projects are org-level groupings agents can be filed under
+(``Agent.project``). Org-scoped: a bound key still reaches them all (agent
+binding is a no-op here). ``delete`` is low-risk — ``Agent.project`` is
+SET_NULL, so deleting a project un-projects its agents rather than destroying
+them.
+
+Reads and writes are data-bearing — they do NOT swallow in production; typed
+transport errors propagate. Every method has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.project import Project
+from ..pagination import apaginate, paginate
+
+_PROJECTS = "sdk/v2/projects"
+
+
+class ProjectsResource:
+    """Handle for the ``/sdk/v2/projects`` endpoints."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    # ==================== list ====================
+
+    def list(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> Iterator[Project]:
+        """Lazily iterate the org's projects, newest first. ``ordering`` accepts
+        ``id`` (± prefix). Handy for resolving a ``project_id`` by name."""
+        base = self._params(ordering, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=Project)
+
+    def alist(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> AsyncIterator[Project]:
+        """Async sibling of ``list``."""
+        base = self._params(ordering, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=Project)
+
+    def list_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of projects."""
+        return CursorPage.from_body(
+            self._page_get(self._params(ordering, page_size), cursor), model=Project
+        )
+
+    async def alist_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Project)
+
+    # ==================== get ====================
+
+    def get(self, project_id: str) -> Project:
+        """Read one project by id (raises ``NotFoundError`` if absent)."""
+        return Project.from_dict(self.http.get(f"{_PROJECTS}/{project_id}"))
+
+    async def aget(self, project_id: str) -> Project:
+        """Async sibling of ``get``."""
+        return Project.from_dict(await self.http.aget(f"{_PROJECTS}/{project_id}"))
+
+    # ==================== create ====================
+
+    def create(self, name: str, icon: str, description: Optional[str] = None) -> Project:
+        """Create a project in the key's org. ``name`` and ``icon`` are required
+        by the backend; an over-length field → ``ValidationError``."""
+        return Project.from_dict(self.http.post(_PROJECTS, self._create_body(name, icon, description)))
+
+    async def acreate(self, name: str, icon: str, description: Optional[str] = None) -> Project:
+        """Async sibling of ``create``."""
+        body = self._create_body(name, icon, description)
+        return Project.from_dict(await self.http.apost(_PROJECTS, body))
+
+    # ==================== update ====================
+
+    def update(
+        self, project_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+    ) -> Project:
+        """Rename / re-describe / re-icon a project. Only the fields you pass
+        change; ``None`` leaves a field untouched."""
+        return Project.from_dict(
+            self.http.put(f"{_PROJECTS}/{project_id}", self._update_body(name, description, icon))
+        )
+
+    async def aupdate(
+        self, project_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+    ) -> Project:
+        """Async sibling of ``update``."""
+        return Project.from_dict(
+            await self.http.aput(f"{_PROJECTS}/{project_id}", self._update_body(name, description, icon))
+        )
+
+    # ==================== delete ====================
+
+    def delete(self, project_id: str) -> None:
+        """Delete a project (needs ``project:delete``). Its agents survive,
+        un-projected (``Agent.project`` is SET_NULL). A missing project →
+        ``NotFoundError``."""
+        self.http.delete(f"{_PROJECTS}/{project_id}")
+
+    async def adelete(self, project_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_PROJECTS}/{project_id}")
+
+    # ==================== internals ====================
+
+    @staticmethod
+    def _params(ordering: Optional[str], page_size: Optional[int]) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params or None
+
+    def _page_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_PROJECTS, params or None)
+
+    async def _apage_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_PROJECTS, params or None)
+
+    @staticmethod
+    def _create_body(name: str, icon: str, description: Optional[str]) -> Dict[str, Any]:
+        # name + icon are required by the backend; description is optional.
+        body: Dict[str, Any] = {"name": name, "icon": icon}
+        if description is not None:
+            body["description"] = description
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], description: Optional[str], icon: Optional[str]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if icon is not None:
+            body["icon"] = icon
+        return body

--- a/lucidicai/api/resources/projects.py
+++ b/lucidicai/api/resources/projects.py
@@ -71,12 +71,13 @@ class ProjectsResource:
 
     # ==================== create ====================
 
-    def create(self, name: str, icon: str, description: Optional[str] = None) -> Project:
+    def create(self, name: str, *, icon: str, description: Optional[str] = None) -> Project:
         """Create a project in the key's org. ``name`` and ``icon`` are required
-        by the backend; an over-length field → ``ValidationError``."""
+        by the backend (``icon`` is a required keyword, matching the write
+        surface's keyword-only style); an over-length field → ``ValidationError``."""
         return Project.from_dict(self.http.post(_PROJECTS, self._create_body(name, icon, description)))
 
-    async def acreate(self, name: str, icon: str, description: Optional[str] = None) -> Project:
+    async def acreate(self, name: str, *, icon: str, description: Optional[str] = None) -> Project:
         """Async sibling of ``create``."""
         body = self._create_body(name, icon, description)
         return Project.from_dict(await self.http.apost(_PROJECTS, body))

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -27,6 +27,7 @@ from .api.client import HttpClient
 from .api.resources.agents import AgentsResource
 from .api.resources.evaluator_results import EvaluatorResultsResource
 from .api.resources.evaluators import EvaluatorsResource
+from .api.resources.projects import ProjectsResource
 from .api.resources.session import SessionResource
 from .api.resources.usage import UsageResource
 from .api.resources.event import EventResource
@@ -162,6 +163,7 @@ class LucidicAI:
             "agents": AgentsResource(self._http),
             "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
             "evaluator_results": EvaluatorResultsResource(self._http),
+            "projects": ProjectsResource(self._http),
             "usage": UsageResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
@@ -278,6 +280,14 @@ class LucidicAI:
         on ``client.evaluators``.
         """
         return self._resources["evaluator_results"]
+
+    @property
+    def projects(self) -> ProjectsResource:
+        """Access project CRUD (LUC-913): ``list`` / ``create`` / ``get`` /
+        ``update`` / ``delete``. Org-scoped; ``delete`` un-projects agents
+        (SET_NULL) rather than destroying them.
+        """
+        return self._resources["projects"]
 
     @property
     def usage(self) -> UsageResource:

--- a/tests/api/resources/test_projects_v2.py
+++ b/tests/api/resources/test_projects_v2.py
@@ -1,0 +1,147 @@
+"""LUC-913 — client.projects CRUD (list / create / get / update / delete)."""
+import json
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.project import Project
+from lucidicai.api.resources.projects import ProjectsResource
+from lucidicai.core.errors import NotFoundError, ValidationError
+
+_BASE = "https://stub.lucidic.test"
+_PROJECTS = f"{_BASE}/sdk/v2/projects"
+
+
+@pytest.fixture
+def projects(http):
+    return ProjectsResource(http)
+
+
+def _project(i, **over):
+    d = {"project_id": f"p{i}", "name": f"proj-{i}", "description": "", "icon": "folder"}
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, projects):
+        respx.get(_PROJECTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_project(1), _project(2)],
+                                      "next": f"{_PROJECTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_project(3)], "next": None}),
+        ])
+        got = list(projects.list())
+        assert [p.project_id for p in got] == ["p1", "p2", "p3"]
+        assert all(isinstance(p, Project) for p in got)
+
+    @respx.mock
+    def test_no_agent_id_param(self, projects):
+        # Projects are org-scoped: no agent_id is sent.
+        route = respx.get(_PROJECTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(projects.list(ordering="id"))
+        p = route.calls.last.request.url.params
+        assert "agent_id" not in p and p["ordering"] == "id"
+
+
+class TestGet:
+    @respx.mock
+    def test_get(self, projects):
+        respx.get(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        p = projects.get("p1")
+        assert isinstance(p, Project) and p.project_id == "p1" and p.icon == "folder"
+
+    @respx.mock
+    def test_404(self, projects):
+        respx.get(f"{_PROJECTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            projects.get("missing")
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_requires_name_and_icon(self, projects):
+        route = respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
+        p = projects.create("proj-1", "rocket")
+        assert isinstance(p, Project) and p.project_id == "p1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "proj-1" and body["icon"] == "rocket"
+        assert "description" not in body
+
+    @respx.mock
+    def test_create_with_description(self, projects):
+        route = respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
+        projects.create("proj-1", "rocket", description="my project")
+        body = json.loads(route.calls.last.request.read())
+        assert body["description"] == "my project"
+
+    @respx.mock
+    def test_create_over_length_400(self, projects):
+        respx.post(_PROJECTS).mock(return_value=httpx.Response(
+            400, json={"error": "A field exceeds its maximum length."}))
+        with pytest.raises(ValidationError):
+            projects.create("x" * 999, "i")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_only_provided_fields(self, projects):
+        route = respx.put(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        p = projects.update("p1", name="renamed")
+        assert isinstance(p, Project)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed"
+        assert "icon" not in body and "description" not in body
+
+    @respx.mock
+    def test_all_fields(self, projects):
+        route = respx.put(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        projects.update("p1", name="n", description="d", icon="i")
+        body = json.loads(route.calls.last.request.read())
+        assert body == {"name": "n", "description": "d", "icon": "i", **_current_time(body)}
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_returns_none_on_204(self, projects):
+        route = respx.delete(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(204))
+        assert projects.delete("p1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_404_raises(self, projects):
+        respx.delete(f"{_PROJECTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            projects.delete("missing")
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, projects):
+        respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
+        p = await projects.acreate("proj-1", "rocket")
+        assert p.project_id == "p1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, projects):
+        respx.put(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        p = await projects.aupdate("p1", icon="star")
+        assert p.project_id == "p1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, projects):
+        route = respx.delete(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(204))
+        assert await projects.adelete("p1") is None
+        assert route.called
+
+
+def _current_time(body):
+    # PUT/POST bodies carry an auto-injected current_time; ignore it in equality.
+    return {"current_time": body["current_time"]} if "current_time" in body else {}

--- a/tests/api/resources/test_projects_v2.py
+++ b/tests/api/resources/test_projects_v2.py
@@ -65,7 +65,7 @@ class TestCreate:
     @respx.mock
     def test_create_requires_name_and_icon(self, projects):
         route = respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
-        p = projects.create("proj-1", "rocket")
+        p = projects.create("proj-1", icon="rocket")
         assert isinstance(p, Project) and p.project_id == "p1"
         body = json.loads(route.calls.last.request.read())
         assert body["name"] == "proj-1" and body["icon"] == "rocket"
@@ -74,7 +74,7 @@ class TestCreate:
     @respx.mock
     def test_create_with_description(self, projects):
         route = respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
-        projects.create("proj-1", "rocket", description="my project")
+        projects.create("proj-1", icon="rocket", description="my project")
         body = json.loads(route.calls.last.request.read())
         assert body["description"] == "my project"
 
@@ -83,7 +83,7 @@ class TestCreate:
         respx.post(_PROJECTS).mock(return_value=httpx.Response(
             400, json={"error": "A field exceeds its maximum length."}))
         with pytest.raises(ValidationError):
-            projects.create("x" * 999, "i")
+            projects.create("x" * 999, icon="i")
 
 
 class TestUpdate:
@@ -124,7 +124,7 @@ class TestAsync:
     @pytest.mark.asyncio
     async def test_acreate(self, projects):
         respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
-        p = await projects.acreate("proj-1", "rocket")
+        p = await projects.acreate("proj-1", icon="rocket")
         assert p.project_id == "p1"
 
     @respx.mock


### PR DESCRIPTION
New `client.projects` namespace — full CRUD — so an SDK-first customer can resolve a `project_id` by name and organize agents into projects from a script. Pairs with LUC-912 agents-write for the provisioning story.

## Surface
- `projects.list()` / `list_page()` → `Project` iterator (org-scoped — **no** agent_id; a bound key still sees all projects, binding is a no-op).
- `projects.get(id)` → `Project`.
- `projects.create(name, icon, description=None)` → `Project`. `name` + `icon` are **required by the backend** (no client-side default — per the convention).
- `projects.update(id, *, name=None, description=None, icon=None)` → `Project` (only-provided fields).
- `projects.delete(id)` → `None` (204). `Agent.project` is `SET_NULL`, so deleting a project **un-projects** its agents rather than destroying them.
- All async siblings. Reads + writes are data-bearing → don't swallow in production.

## Conventions
Follows the C2-write conventions from LUC-912 (omit-None bodies, no-swallow, typed return, POST-not-retried / PUT-idempotent). **Establishes the delete convention** the sibling deletes (experiments/evaluators/prompts) copy: `http.delete` → return `None` on 204, raise the typed error otherwise; delete is always explicit (you name the id).

## Files
- `lucidicai/api/models/project.py` (new) — `Project`
- `lucidicai/api/resources/projects.py` (new) — `ProjectsResource`
- `lucidicai/api/models/__init__.py`, `lucidicai/client.py` — wire the namespace
- `tests/api/resources/test_projects_v2.py` — 14 tests; 370 hermetic total pass