### PR TITLE
LUC-914: client.prompts write (create / rename / set_labels / delete)

### DIFF
--- a/lucidicai/api/resources/prompt.py
+++ b/lucidicai/api/resources/prompt.py
@@ -482,6 +482,106 @@ class PromptResource:
         resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent})
         return resp.get("labels", [])
 
+    # ==================== v2 writes (LUC-914) ====================
+    #
+    # rename / set_labels / delete operate on EXISTING prompts. There is no SDK
+    # endpoint to create a brand-new prompt (dashboard-only today); ``update()``
+    # above (gen-3 PUT /sdk/prompts) adds a *version* to an existing prompt.
+    # Data-bearing writes → no production swallow. Each has an async sibling.
+
+    def rename(
+        self, prompt_name: str, *, new_name: Optional[str] = None,
+        icon: Optional[str] = None, agent_id: Optional[str] = None,
+    ) -> PromptInfo:
+        """Rename and/or re-icon a prompt (PATCH /sdk/v2/prompts/detail). Pass
+        ``new_name`` and/or ``icon``. A name collision with another prompt →
+        ``ConflictError``. When the renamed prompt has shipped versions, the
+        result carries a ``warning`` (on ``.extra``): clients still fetching the
+        old name will 404 until updated."""
+        result = PromptInfo.from_dict(
+            self.http.patch("sdk/v2/prompts/detail", self._rename_body(prompt_name, new_name, icon, agent_id))
+        )
+        self._invalidate_cache(prompt_name)  # old (agent, name) fetches are now stale
+        return result
+
+    async def arename(
+        self, prompt_name: str, *, new_name: Optional[str] = None,
+        icon: Optional[str] = None, agent_id: Optional[str] = None,
+    ) -> PromptInfo:
+        """Async sibling of ``rename``."""
+        body = self._rename_body(prompt_name, new_name, icon, agent_id)
+        result = PromptInfo.from_dict(await self.http.apatch("sdk/v2/prompts/detail", body))
+        self._invalidate_cache(prompt_name)
+        return result
+
+    def set_labels(
+        self, prompt_name: str, version_number: int, labels: List[str], *,
+        agent_id: Optional[str] = None,
+    ) -> PromptVersion:
+        """Set which labels point at a specific version — promote / roll back
+        (PUT /sdk/v2/prompts/labels). This is a **replace**: ``labels`` becomes
+        that version's entire label set (any other label on it is removed), and
+        each label is **moved off** whatever version currently holds it — e.g.
+        ``set_labels("greeting", 5, ["production"])`` points ``production`` at
+        v5 and removes it from wherever it was. Not additive. ``"latest"`` is
+        auto-managed and can't be moved (→ ``ValidationError``); an unknown
+        ``version_number`` → ``NotFoundError``. Returns the updated version (a
+        promote onto a previously-unlabeled version carries a ``warning`` on
+        ``.extra``)."""
+        result = PromptVersion.from_dict(
+            self.http.put("sdk/v2/prompts/labels", self._label_body(prompt_name, version_number, labels, agent_id))
+        )
+        self._invalidate_cache(prompt_name)  # label pointers moved -> label fetches stale
+        return result
+
+    async def aset_labels(
+        self, prompt_name: str, version_number: int, labels: List[str], *,
+        agent_id: Optional[str] = None,
+    ) -> PromptVersion:
+        """Async sibling of ``set_labels``."""
+        body = self._label_body(prompt_name, version_number, labels, agent_id)
+        result = PromptVersion.from_dict(await self.http.aput("sdk/v2/prompts/labels", body))
+        self._invalidate_cache(prompt_name)
+        return result
+
+    def delete(self, prompt_name: str, *, agent_id: Optional[str] = None) -> None:
+        """Hard-delete a prompt and all its versions (DELETE /sdk/v2/prompts/detail;
+        needs ``prompt:delete``). A version bound to a checkpoint is protected →
+        ``ConflictError``."""
+        self.http.delete("sdk/v2/prompts/detail", self._name_params(prompt_name, agent_id))
+        self._invalidate_cache(prompt_name)
+
+    async def adelete(self, prompt_name: str, *, agent_id: Optional[str] = None) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete("sdk/v2/prompts/detail", self._name_params(prompt_name, agent_id))
+        self._invalidate_cache(prompt_name)
+
+    # ---- write internals ----
+
+    def _rename_body(
+        self, prompt_name: str, new_name: Optional[str], icon: Optional[str], agent_id: Optional[str]
+    ) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.rename")
+        body: Dict[str, Any] = {"agent_id": agent, "prompt_name": prompt_name}
+        if new_name is not None:
+            body["name"] = new_name  # backend field is "name" (the new name)
+        if icon is not None:
+            body["icon"] = icon
+        return body
+
+    def _label_body(
+        self, prompt_name: str, version_number: int, labels: List[str], agent_id: Optional[str]
+    ) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.set_labels")
+        return {
+            "agent_id": agent, "prompt_name": prompt_name,
+            "version_number": version_number, "labels": labels,
+        }
+
+    def _name_params(self, prompt_name: str, agent_id: Optional[str]) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.delete")
+        return {"agent_id": agent, "prompt_name": prompt_name}
+
     # ---- read internals ----
 
     def _agent_params(

--- a/lucidicai/api/resources/prompt.py
+++ b/lucidicai/api/resources/prompt.py
@@ -484,10 +484,44 @@ class PromptResource:
 
     # ==================== v2 writes (LUC-914) ====================
     #
-    # rename / set_labels / delete operate on EXISTING prompts. There is no SDK
-    # endpoint to create a brand-new prompt (dashboard-only today); ``update()``
-    # above (gen-3 PUT /sdk/prompts) adds a *version* to an existing prompt.
+    # create makes a brand-new prompt (+ its first version, via POST /sdk/v2/prompts,
+    # LUC-931); rename / set_labels / delete operate on EXISTING prompts. (``update()``
+    # above, the gen-3 PUT /sdk/prompts, adds a *version* to an existing prompt.)
     # Data-bearing writes → no production swallow. Each has an async sibling.
+
+    def create(
+        self, name: str, prompt_content: str, *,
+        icon: Optional[str] = None, description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None, labels: Optional[List[str]] = None,
+        agent_id: Optional[str] = None,
+    ) -> Tuple[PromptInfo, Optional[PromptVersion]]:
+        """Create a brand-new prompt and its first version (POST /sdk/v2/prompts;
+        needs ``prompt:write``). ``name`` is unique per agent — a duplicate →
+        ``ConflictError`` (use ``update()`` to add a version to an existing prompt).
+        The first version auto-gets the ``latest`` + ``production`` labels; any
+        ``labels`` you pass are added on top. Returns ``(prompt, first_version)``
+        as typed models — ``first_version`` is ``None`` only if a future backend
+        omits the version subobject from the response."""
+        response = self.http.post(
+            "sdk/v2/prompts",
+            self._create_body(name, prompt_content, icon, description, metadata, labels, agent_id),
+        )
+        self._invalidate_cache(name)  # a same-name entry (deleted elsewhere, recreated) is now stale
+        return self._created(response)
+
+    async def acreate(
+        self, name: str, prompt_content: str, *,
+        icon: Optional[str] = None, description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None, labels: Optional[List[str]] = None,
+        agent_id: Optional[str] = None,
+    ) -> Tuple[PromptInfo, Optional[PromptVersion]]:
+        """Async sibling of ``create``."""
+        response = await self.http.apost(
+            "sdk/v2/prompts",
+            self._create_body(name, prompt_content, icon, description, metadata, labels, agent_id),
+        )
+        self._invalidate_cache(name)
+        return self._created(response)
 
     def rename(
         self, prompt_name: str, *, new_name: Optional[str] = None,
@@ -557,6 +591,37 @@ class PromptResource:
         self._invalidate_cache(prompt_name)
 
     # ---- write internals ----
+
+    def _create_body(
+        self, name: str, prompt_content: str, icon: Optional[str],
+        description: Optional[str], metadata: Optional[Dict[str, Any]],
+        labels: Optional[List[str]], agent_id: Optional[str],
+    ) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.create")
+        body: Dict[str, Any] = {
+            "agent_id": agent, "name": name, "prompt_content": prompt_content,
+        }
+        # omit-None: let the backend apply its defaults (icon="compass",
+        # description="", metadata={}, labels=[]) rather than sending explicit nulls.
+        if icon is not None:
+            body["icon"] = icon
+        if description is not None:
+            body["description"] = description
+        if metadata is not None:
+            body["metadata"] = metadata
+        if labels is not None:
+            body["labels"] = labels
+        return body
+
+    @staticmethod
+    def _created(response: Dict[str, Any]) -> Tuple[PromptInfo, Optional[PromptVersion]]:
+        """Split the create response into the created ``PromptInfo`` and its first
+        ``PromptVersion``. The backend returns the prompt payload plus a ``version``
+        subobject; ``version`` is ``None`` only if a future backend omits it."""
+        info = PromptInfo.from_dict(response)
+        raw_version = response.get("version")
+        version = PromptVersion.from_dict(raw_version) if isinstance(raw_version, dict) else None
+        return info, version
 
     def _rename_body(
         self, prompt_name: str, new_name: Optional[str], icon: Optional[str], agent_id: Optional[str]

--- a/tests/api/resources/test_prompts_v2.py
+++ b/tests/api/resources/test_prompts_v2.py
@@ -1,4 +1,6 @@
-"""LUC-909 — client.prompts reads (list / versions / labels)."""
+"""LUC-909 / LUC-914 — client.prompts reads + writes."""
+import json
+
 import httpx
 import pytest
 import respx
@@ -6,9 +8,12 @@ import respx
 from lucidicai.api.models.prompt import PromptInfo, PromptVersion
 from lucidicai.api.resources.prompt import PromptResource
 from lucidicai.core.config import NetworkConfig, SDKConfig
+from lucidicai.core.errors import ConflictError, ValidationError
 
 _BASE = "https://stub.lucidic.test"
 _PROMPTS = f"{_BASE}/sdk/v2/prompts"
+_DETAIL = f"{_PROMPTS}/detail"
+_LABELS = f"{_PROMPTS}/labels"
 
 
 @pytest.fixture
@@ -122,3 +127,136 @@ class TestAsync:
         respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(
             200, json={"labels": ["latest"]}))
         assert await prompts.alabels() == ["latest"]
+
+
+def _ct(body):
+    # PATCH/PUT bodies carry an auto-injected current_time; ignore in equality.
+    return {"current_time": body["current_time"]} if "current_time" in body else {}
+
+
+class TestRename:
+    @respx.mock
+    def test_rename_and_reicon(self, prompts):
+        route = respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        p = prompts.rename("greeting", new_name="salutation", icon="wave")
+        assert isinstance(p, PromptInfo)
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1" and body["prompt_name"] == "greeting"
+        assert body["name"] == "salutation" and body["icon"] == "wave"
+
+    @respx.mock
+    def test_rename_only_provided(self, prompts):
+        route = respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        prompts.rename("greeting", icon="wave")
+        body = json.loads(route.calls.last.request.read())
+        assert "name" not in body and body["icon"] == "wave"
+
+    @respx.mock
+    def test_warning_on_extra(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(
+            200, json=dict(_prompt(1), warning="clients fetching the old name will 404")))
+        p = prompts.rename("greeting", new_name="salutation")
+        assert "404" in p.extra["warning"]
+
+    @respx.mock
+    def test_collision_409(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(
+            409, json={"error": "A prompt named 'x' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            prompts.rename("greeting", new_name="x")
+
+
+class TestSetLabels:
+    @respx.mock
+    def test_promote(self, prompts):
+        route = respx.put(_LABELS).mock(return_value=httpx.Response(
+            200, json=_version(3, labels=["production"])))
+        v = prompts.set_labels("greeting", 3, ["production"])
+        assert isinstance(v, PromptVersion) and v.labels == ["production"]
+        body = json.loads(route.calls.last.request.read())
+        assert body == {"agent_id": "a1", "prompt_name": "greeting",
+                        "version_number": 3, "labels": ["production"], **_ct(body)}
+
+    @respx.mock
+    def test_warning_on_extra(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(
+            200, json=dict(_version(3), warning="version 3 previously had no labels")))
+        v = prompts.set_labels("greeting", 3, ["production"])
+        assert "no labels" in v.extra["warning"]
+
+    @respx.mock
+    def test_move_latest_400(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(
+            400, json={"error": "'latest' is auto-managed"}))
+        with pytest.raises(ValidationError):
+            prompts.set_labels("greeting", 3, ["latest"])
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_204_sends_query(self, prompts):
+        route = respx.delete(_DETAIL).mock(return_value=httpx.Response(204))
+        assert prompts.delete("greeting") is None
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a1" and p["prompt_name"] == "greeting"
+
+    @respx.mock
+    def test_checkpoint_bound_409(self, prompts):
+        respx.delete(_DETAIL).mock(return_value=httpx.Response(
+            409, json={"error": "This prompt has a version bound to a checkpoint and cannot be deleted."}))
+        with pytest.raises(ConflictError):
+            prompts.delete("greeting")
+
+
+class TestAsyncWrite:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_arename(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        p = await prompts.arename("greeting", new_name="salutation")
+        assert isinstance(p, PromptInfo)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aset_labels(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(200, json=_version(3)))
+        v = await prompts.aset_labels("greeting", 3, ["production"])
+        assert v.prompt_version_number == 3
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, prompts):
+        route = respx.delete(_DETAIL).mock(return_value=httpx.Response(204))
+        assert await prompts.adelete("greeting") is None
+        assert route.called
+
+
+class TestCacheInvalidation:
+    """The writes must clear the local get() cache (keyed by prompt_name) —
+    like update()/update_metadata() do — else a promoted/renamed/deleted prompt
+    keeps serving stale cached content."""
+
+    @staticmethod
+    def _seed(prompts):
+        prompts._cache[("greeting", "production", None, None)] = {"content": "old", "timestamp": 0}
+
+    @respx.mock
+    def test_rename_invalidates(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        self._seed(prompts)
+        prompts.rename("greeting", new_name="salutation")
+        assert not any(k[0] == "greeting" for k in prompts._cache)
+
+    @respx.mock
+    def test_set_labels_invalidates(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(200, json=_version(3)))
+        self._seed(prompts)
+        prompts.set_labels("greeting", 3, ["production"])
+        assert not any(k[0] == "greeting" for k in prompts._cache)
+
+    @respx.mock
+    def test_delete_invalidates(self, prompts):
+        respx.delete(_DETAIL).mock(return_value=httpx.Response(204))
+        self._seed(prompts)
+        prompts.delete("greeting")
+        assert not any(k[0] == "greeting" for k in prompts._cache)

--- a/tests/api/resources/test_prompts_v2.py
+++ b/tests/api/resources/test_prompts_v2.py
@@ -8,7 +8,12 @@ import respx
 from lucidicai.api.models.prompt import PromptInfo, PromptVersion
 from lucidicai.api.resources.prompt import PromptResource
 from lucidicai.core.config import NetworkConfig, SDKConfig
-from lucidicai.core.errors import ConflictError, ValidationError
+from lucidicai.core.errors import (
+    AgentIdRequiredError,
+    ConflictError,
+    InsufficientScopeError,
+    ValidationError,
+)
 
 _BASE = "https://stub.lucidic.test"
 _PROMPTS = f"{_BASE}/sdk/v2/prompts"
@@ -132,6 +137,91 @@ class TestAsync:
 def _ct(body):
     # PATCH/PUT bodies carry an auto-injected current_time; ignore in equality.
     return {"current_time": body["current_time"]} if "current_time" in body else {}
+
+
+class TestCreate:
+    """LUC-914 follow-up (unblocked by backend LUC-931): POST /sdk/v2/prompts —
+    create a brand-new prompt + its first version."""
+
+    @respx.mock
+    def test_create_prompt_and_typed_first_version(self, prompts):
+        route = respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            201, json={**_prompt(1), "version": _version(1, labels=["latest", "production"])}))
+        info, v = prompts.create("prompt-1", "content 1")
+        assert isinstance(info, PromptInfo) and info.prompt_id == "p1" and info.name == "prompt-1"
+        assert isinstance(v, PromptVersion) and v.prompt_version_number == 1
+        assert set(v.labels) == {"latest", "production"}
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1"  # defaulted from config
+        assert body["name"] == "prompt-1" and body["prompt_content"] == "content 1"
+        # omit-None: unspecified optionals are NOT sent (backend applies its defaults)
+        assert not any(k in body for k in ("icon", "description", "metadata", "labels"))
+
+    @respx.mock
+    def test_create_all_fields_sent(self, prompts):
+        route = respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        prompts.create("prompt-1", "c", icon="star", description="d",
+                       metadata={"k": "v"}, labels=["staging"])
+        body = json.loads(route.calls.last.request.read())
+        assert body["icon"] == "star" and body["description"] == "d"
+        assert body["metadata"] == {"k": "v"} and body["labels"] == ["staging"]
+
+    @respx.mock
+    def test_create_explicit_agent_id_overrides_config(self, prompts):
+        route = respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        prompts.create("prompt-1", "c", agent_id="a2")
+        assert json.loads(route.calls.last.request.read())["agent_id"] == "a2"
+
+    @respx.mock
+    def test_create_without_version_subobject(self, prompts):
+        # Forward-compat: a response missing the version subobject yields (PromptInfo, None).
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        info, v = prompts.create("prompt-1", "c")
+        assert isinstance(info, PromptInfo) and v is None
+
+    @respx.mock
+    def test_create_duplicate_name_409(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            409, json={"error": "A prompt named 'prompt-1' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            prompts.create("prompt-1", "c")
+
+    @respx.mock
+    def test_create_missing_content_400(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            400, json={"error": "This field may not be blank."}))
+        with pytest.raises(ValidationError):
+            prompts.create("prompt-1", "")
+
+    @respx.mock
+    def test_create_without_write_scope_403(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            403, json={"error": "requires prompt:write"}))
+        with pytest.raises(InsufficientScopeError):
+            prompts.create("prompt-1", "c")
+
+    @respx.mock
+    def test_create_invalidates_stale_same_name_cache(self, prompts):
+        # A name deleted elsewhere then recreated must not keep serving old cached content.
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        prompts._cache[("prompt-1", "production", None, None)] = {"content": "old", "timestamp": 0}
+        prompts.create("prompt-1", "c")
+        assert not any(k[0] == "prompt-1" for k in prompts._cache)
+
+    def test_create_without_agent_id_raises(self, http):
+        # No HTTP call: the guard fires client-side before the request.
+        res = PromptResource(http, SDKConfig(
+            api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE)))
+        with pytest.raises(AgentIdRequiredError):
+            res.create("prompt-1", "c")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            201, json={**_prompt(1), "version": _version(1)}))
+        info, v = await prompts.acreate("prompt-1", "c")
+        assert isinstance(info, PromptInfo) and isinstance(v, PromptVersion)
 
 
 class TestRename:


### PR DESCRIPTION
Adds the prompt-ops write loop to `PromptResource`.

## Surface
- `prompts.create(name, prompt_content, *, icon=None, description=None, metadata=None, labels=None, agent_id=None)` → `(PromptInfo, Optional[PromptVersion])` (POST `/sdk/v2/prompts`). Creates a brand-new prompt **and its first version**. `name` is unique per agent — a duplicate → `ConflictError` (use `update()` to add a version to an existing prompt). The first version auto-gets `latest` + `production`; any `labels` you pass are added on top. Omit-None body building defers to the backend serializer defaults (`icon="compass"`, …).
- `prompts.rename(prompt_name, *, new_name=None, icon=None)` → `PromptInfo` (PATCH `/sdk/v2/prompts/detail`). Name collision → `ConflictError`; a rename with shipped versions carries a `warning` on `.extra` (old-name fetches will 404).
- `prompts.set_labels(prompt_name, version_number, labels)` → `PromptVersion` (PUT `/sdk/v2/prompts/labels`) — promote / roll back. **Replace semantics**: `labels` becomes the version's entire set, and each label is *moved off* its prior version. Moving `"latest"` → `ValidationError`; unknown version → `NotFoundError`.
- `prompts.delete(prompt_name)` → `None` (DELETE `/sdk/v2/prompts/detail` via query params). A checkpoint-bound version → `ConflictError`.
- All async siblings. Data-bearing writes → no production swallow.

## `create` — now buildable (backend LUC-931 / #645)
The ticket called for a `create`, but there was no backend endpoint at the time: `SDKPromptView` had no `post()`, its `PUT` requires an *existing* prompt, and `Prompt.objects.create` was dashboard-only. That gap is now filled — backend PR #645 (LUC-931) shipped `POST /sdk/v2/prompts` (create prompt + first version, `prompt:write`-scoped, atomic, with a 409 on duplicate name), and this PR wires the SDK to it. Verified conformant against the merged endpoint (request field names, serializer defaults, response shape, and 409/403/400/404 error mapping).

## Review-driven fixes (code-skeptic)
- **Staleness bug** (rename / set_labels / delete): the new writes didn't invalidate `PromptResource`'s local `get()` cache the way the sibling `update()`/`update_metadata()` do — so after `set_labels`/`rename`/`delete`, a `get(cache_ttl>0)` would keep serving stale content (a promote that `get(label=...)` never reflects). Fixed: all three now `_invalidate_cache(prompt_name)`, with tests. Also renamed the kwarg `name`→`new_name` and spelled out `set_labels`' replace/move semantics.
- **`create` return shape** (two-lens verify — skeptic + backend-contract): the created first version was initially exposed through the untyped forward-compat `.extra["version"]` bag (undiscoverable, no IDE/mypy typing, `KeyError` when the backend omits it). Changed to return a typed `(PromptInfo, Optional[PromptVersion])` tuple. `create` also `require_agent_id`-guards before any network call and invalidates any stale same-name cache entry.

## Files
- `lucidicai/api/resources/prompt.py`
- `tests/api/resources/test_prompts_v2.py` — 35 tests (reads + writes + create + cache); 395 hermetic total pass