### PR TITLE
LUC-915: client.experiments write (delete + evaluators attach/detach/list)

### DIFF
--- a/lucidicai/api/client.py
+++ b/lucidicai/api/client.py
@@ -334,17 +334,21 @@ class HttpClient:
         data = self._add_timestamp(data)
         return self.request("PATCH", endpoint, json=data)
 
-    def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None,
+               data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a synchronous DELETE request.
-        
+
         Args:
             endpoint: API endpoint (without base URL)
             params: Query parameters
-            
+            data: Optional JSON body. Most deletes carry none; a few endpoints
+                take a small flag in the DELETE body (e.g. the experiments
+                delete's ``delete_sessions``).
+
         Returns:
             Response data as dictionary
         """
-        return self.request("DELETE", endpoint, params=params)
+        return self.request("DELETE", endpoint, params=params, json=data)
 
     def head(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
         """Make a synchronous HEAD request and return the response headers (LUC-903).
@@ -455,17 +459,19 @@ class HttpClient:
         data = self._add_timestamp(data)
         return await self.arequest("PATCH", endpoint, json=data)
 
-    async def adelete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    async def adelete(self, endpoint: str, params: Optional[Dict[str, Any]] = None,
+                      data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make an asynchronous DELETE request.
-        
+
         Args:
             endpoint: API endpoint (without base URL)
             params: Query parameters
-            
+            data: Optional JSON body (see ``delete``).
+
         Returns:
             Response data as dictionary
         """
-        return await self.arequest("DELETE", endpoint, params=params)
+        return await self.arequest("DELETE", endpoint, params=params, json=data)
 
     async def ahead(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
         """Async sibling of ``head`` (LUC-903)."""

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
 from ..models.base import CursorPage
+from ..models.evaluator import Evaluator
 from ..models.experiment import Experiment
 from ..pagination import apaginate, paginate
 from ...core.errors import require_agent_id
@@ -30,6 +31,17 @@ class ExperimentResource:
         self.http = http
         self._agent_id = agent_id
         self._production = production
+        # client.experiments.evaluators — attach/detach/list evaluators on an
+        # experiment. Stateless (experiment id is passed per call), so one instance
+        # is reused across calls.
+        self._evaluators = ExperimentEvaluatorsResource(http)
+
+    @property
+    def evaluators(self) -> "ExperimentEvaluatorsResource":
+        """Wire evaluators onto experiments — e.g.
+        ``client.experiments.evaluators.attach(experiment_id, ["accuracy"])`` /
+        ``.list(experiment_id)`` / ``.detach(experiment_id, evaluator_id)``."""
+        return self._evaluators
 
     def create(
         self,
@@ -177,6 +189,28 @@ class ExperimentResource:
         """Async sibling of ``get``."""
         return Experiment.from_dict(await self.http.aget(f"sdk/v2/experiments/{experiment_id}"))
 
+    # ==================== v2 writes (LUC-915) ====================
+    #
+    # Data-bearing (destructive) write → no production swallow, unlike the gen-3
+    # create/acreate above. Each has an async sibling.
+
+    def delete(self, experiment_id: str, delete_sessions: bool = False) -> None:
+        """Delete an experiment (DELETE /sdk/v2/experiments/{id}; needs
+        ``experiment:delete``). The experiment row is hard-deleted and its
+        surviving sessions are detached (their ``experiment`` is set to null).
+        ``delete_sessions=True`` instead SOFT-deletes those sessions — hidden but
+        recoverable via the retention sweep — and is sent as a JSON body flag.
+        An unknown / cross-org / out-of-binding id → ``NotFoundError``."""
+        self.http.delete(
+            f"sdk/v2/experiments/{experiment_id}", data={"delete_sessions": delete_sessions}
+        )
+
+    async def adelete(self, experiment_id: str, delete_sessions: bool = False) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(
+            f"sdk/v2/experiments/{experiment_id}", data={"delete_sessions": delete_sessions}
+        )
+
     # ---- internals ----
 
     def _list_params(
@@ -202,3 +236,90 @@ class ExperimentResource:
         if cursor:
             params["cursor"] = cursor
         return await self.http.aget("sdk/v2/experiments", params)
+
+
+class ExperimentEvaluatorsResource:
+    """``client.experiments.evaluators`` — wire evaluators onto an experiment (LUC-915).
+
+    Attach / detach / list the evaluator definitions bound to an experiment. Attach
+    is **config-only**: it links evaluators so FUTURE sessions in the experiment
+    inherit them at session-init — it does NOT re-score existing sessions or
+    recompute metrics. The experiment id is passed per call. Data-bearing writes →
+    no production swallow. Each method has an async sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def list(self, experiment_id: str, *, page_size: Optional[int] = None) -> Iterator[Evaluator]:
+        """Lazily iterate the evaluators attached to an experiment (the endpoint is
+        cursor-paginated, so this transparently walks every page)."""
+        base = self._page_params(page_size)
+        return paginate(lambda c: self._page_get(self._path(experiment_id), base, c), model=Evaluator)
+
+    def alist(self, experiment_id: str, *, page_size: Optional[int] = None) -> AsyncIterator[Evaluator]:
+        """Async sibling of ``list``."""
+        base = self._page_params(page_size)
+        return apaginate(lambda c: self._apage_get(self._path(experiment_id), base, c), model=Evaluator)
+
+    def list_page(
+        self, experiment_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of an experiment's attached evaluators."""
+        body = self._page_get(self._path(experiment_id), self._page_params(page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    async def alist_page(
+        self, experiment_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._path(experiment_id), self._page_params(page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    def attach(self, experiment_id: str, names: List[str]) -> List[Evaluator]:
+        """Attach evaluators to an experiment by NAME (POST; needs
+        ``experiment:write``). Config-only — future sessions inherit; existing
+        sessions are not re-scored. Idempotent (re-attaching is a no-op). If ANY
+        name is unknown for the experiment's agent the whole call fails
+        (``ValidationError``) and nothing is attached. Returns the experiment's
+        full current attached evaluator set."""
+        resp = self.http.post(self._path(experiment_id), {"evaluator_names": names})
+        return Evaluator.from_list(resp.get("evaluators", []))
+
+    async def aattach(self, experiment_id: str, names: List[str]) -> List[Evaluator]:
+        """Async sibling of ``attach``."""
+        resp = await self.http.apost(self._path(experiment_id), {"evaluator_names": names})
+        return Evaluator.from_list(resp.get("evaluators", []))
+
+    def detach(self, experiment_id: str, evaluator_id: str) -> None:
+        """Detach one evaluator (by its UUID) from an experiment (DELETE; needs
+        ``experiment:write``). Removes only the link — the evaluator definition and
+        any already-recorded metrics are untouched. An evaluator that isn't
+        attached (or an unknown id) → ``NotFoundError``."""
+        self.http.delete(f"{self._path(experiment_id)}/{evaluator_id}")
+
+    async def adetach(self, experiment_id: str, evaluator_id: str) -> None:
+        """Async sibling of ``detach``."""
+        await self.http.adelete(f"{self._path(experiment_id)}/{evaluator_id}")
+
+    # ---- internals ----
+
+    @staticmethod
+    def _path(experiment_id: str) -> str:
+        return f"sdk/v2/experiments/{experiment_id}/evaluators"
+
+    @staticmethod
+    def _page_params(page_size: Optional[int]) -> Dict[str, Any]:
+        return {"page_size": page_size} if page_size is not None else {}
+
+    def _page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params or None)
+
+    async def _apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params or None)

--- a/tests/api/resources/test_experiments_v2.py
+++ b/tests/api/resources/test_experiments_v2.py
@@ -1,14 +1,22 @@
-"""LUC-908 — client.experiments reads (list / count / get)."""
+"""LUC-908 — client.experiments reads (list / count / get).
+LUC-915 — client.experiments writes (delete + evaluators attach/detach/list)."""
+import json
+
 import httpx
 import pytest
 import respx
 
+from lucidicai.api.models.evaluator import Evaluator
 from lucidicai.api.models.experiment import Experiment
 from lucidicai.api.resources.experiment import ExperimentResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
 
 _BASE = "https://stub.lucidic.test"
 _EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
+
+
+def _evals_url(xid):
+    return f"{_EXPERIMENTS}/{xid}/evaluators"
 
 
 @pytest.fixture
@@ -23,6 +31,13 @@ def _exp(i, **over):
         "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
         "num_sessions": 3, "tags": ["prod"], "eval_metrics": [],
     }
+    d.update(over)
+    return d
+
+
+def _ev(i, **over):
+    d = {"evaluator_id": f"e{i}", "name": f"eval-{i}", "type": "LLM",
+         "result_type": "boolean", "is_default": False}
     d.update(over)
     return d
 
@@ -121,3 +136,127 @@ class TestAsync:
         respx.get(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(200, json=_exp(1)))
         e = await experiments.aget("x1")
         assert e.experiment_id == "x1"
+
+
+# ==================== LUC-915 writes ====================
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_default_no_cascade(self, experiments):
+        # delete_sessions is a JSON BODY flag, default False (not a query param).
+        route = respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(204))
+        assert experiments.delete("x1") is None
+        assert json.loads(route.calls.last.request.read()) == {"delete_sessions": False}
+
+    @respx.mock
+    def test_delete_sessions_true_sends_body_flag(self, experiments):
+        route = respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(204))
+        experiments.delete("x1", delete_sessions=True)
+        assert json.loads(route.calls.last.request.read()) == {"delete_sessions": True}
+
+    @respx.mock
+    def test_delete_forbidden_403(self, experiments):
+        # experiment:delete is a full-key-only scope; an ingest key → 403.
+        respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(
+            403, json={"error": "This API key is not authorized for this action."}))
+        with pytest.raises(InsufficientScopeError):
+            experiments.delete("x1")
+
+    @respx.mock
+    def test_delete_missing_404(self, experiments):
+        respx.delete(f"{_EXPERIMENTS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified Experiment not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.delete("missing")
+
+
+class TestEvaluatorsList:
+    @respx.mock
+    def test_follows_pages_typed(self, experiments):
+        url = _evals_url("x1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_ev(1), _ev(2)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_ev(3)], "next": None}),
+        ])
+        got = list(experiments.evaluators.list("x1"))
+        assert [e.evaluator_id for e in got] == ["e1", "e2", "e3"]
+        assert all(isinstance(e, Evaluator) for e in got)
+
+    @respx.mock
+    def test_list_page_and_page_size(self, experiments):
+        route = respx.get(_evals_url("x1")).mock(return_value=httpx.Response(
+            200, json={"results": [_ev(1)], "next": None}))
+        page = experiments.evaluators.list_page("x1", page_size=50)
+        assert isinstance(page.results[0], Evaluator)
+        assert route.calls.last.request.url.params["page_size"] == "50"
+
+
+class TestEvaluatorsAttach:
+    @respx.mock
+    def test_attach_posts_names_returns_full_set(self, experiments):
+        route = respx.post(_evals_url("x1")).mock(return_value=httpx.Response(
+            200, json={"experiment_id": "x1", "evaluators": [_ev(1), _ev(2)]}))
+        got = experiments.evaluators.attach("x1", ["eval-1", "eval-2"])
+        assert [e.evaluator_id for e in got] == ["e1", "e2"]
+        assert all(isinstance(e, Evaluator) for e in got)
+        # backend field is evaluator_names (names, not ids); current_time is auto-injected.
+        assert json.loads(route.calls.last.request.read())["evaluator_names"] == ["eval-1", "eval-2"]
+
+    @respx.mock
+    def test_attach_unknown_name_400(self, experiments):
+        respx.post(_evals_url("x1")).mock(return_value=httpx.Response(
+            400, json={"error": "Validation failed",
+                       "details": {"evaluator_names": ["Unknown evaluators for this experiment's agent: ['nope']"]}}))
+        with pytest.raises(ValidationError):
+            experiments.evaluators.attach("x1", ["nope"])
+
+
+class TestEvaluatorsDetach:
+    @respx.mock
+    def test_detach_returns_none_204(self, experiments):
+        route = respx.delete(f"{_evals_url('x1')}/e1").mock(return_value=httpx.Response(204))
+        assert experiments.evaluators.detach("x1", "e1") is None
+        assert route.called
+
+    @respx.mock
+    def test_detach_not_attached_404(self, experiments):
+        respx.delete(f"{_evals_url('x1')}/e9").mock(return_value=httpx.Response(
+            404, json={"error": "Specified evaluator not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.evaluators.detach("x1", "e9")
+
+
+class TestWriteAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete_sends_body(self, experiments):
+        route = respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(204))
+        assert await experiments.adelete("x1", delete_sessions=True) is None
+        assert json.loads(route.calls.last.request.read()) == {"delete_sessions": True}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aattach(self, experiments):
+        respx.post(_evals_url("x1")).mock(return_value=httpx.Response(
+            200, json={"experiment_id": "x1", "evaluators": [_ev(1)]}))
+        got = await experiments.evaluators.aattach("x1", ["eval-1"])
+        assert [e.evaluator_id for e in got] == ["e1"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adetach(self, experiments):
+        route = respx.delete(f"{_evals_url('x1')}/e1").mock(return_value=httpx.Response(204))
+        assert await experiments.evaluators.adetach("x1", "e1") is None
+        assert route.called
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, experiments):
+        url = _evals_url("x1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_ev(1)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_ev(2)], "next": None}),
+        ])
+        got = [e.evaluator_id async for e in experiments.evaluators.alist("x1")]
+        assert got == ["e1", "e2"]


### PR DESCRIPTION
Adds the experiment lifecycle + evaluator-wiring writes to `ExperimentResource`.

## Surface
- `experiments.delete(id, delete_sessions=False)` → `None` (DELETE `/sdk/v2/experiments/{id}`; needs `experiment:delete`). The experiment row is **hard-deleted**; its surviving sessions are detached (`experiment` → NULL). `delete_sessions=True` instead **soft-deletes** those sessions (hidden but recoverable via retention). Unknown / cross-org / out-of-binding id → `NotFoundError`.
- `experiments.evaluators` sub-namespace (`client.experiments.evaluators.…`):
  - `list(id)` / `list_page(id)` → cursor-paginated `Evaluator`s attached to the experiment (reuses the LUC-910 `Evaluator` model).
  - `attach(id, names)` → `List[Evaluator]` (POST; `experiment:write`). Attaches by **name**; config-only (future sessions inherit — existing sessions aren't re-scored); idempotent; an unknown name fails the whole call (`ValidationError`) and attaches nothing. Returns the full current attached set.
  - `detach(id, evaluator_id)` → `None` (DELETE `…/evaluators/{uuid}`; `experiment:write`). Not-attached / unknown id → `NotFoundError`.
- All with async siblings. Data-bearing writes → no production swallow.

## Transport change
`delete_sessions` is a **JSON body** flag on the DELETE (not a query param), so `HttpClient.delete/adelete` now accept an optional `data=` body. Backward-compatible — every existing caller passes only `params`, so the body defaults to `None` (no body sent). The DELETE body is exactly `{"delete_sessions": bool}` (no auto-injected `current_time`, unlike POST/PUT).

## Verification (two-lens: skeptic + backend-contract)
- **Contract: conforms exactly** — re-verified against a freshly-fetched `origin/sdk-first-platform-parity` (all four routes, scopes, the `delete_sessions` body flag + strict `is True` cascade, `evaluator_names` field, 200-not-201 attach response `{experiment_id, evaluators:[…]}`, UUID detach path).
- **Skeptic:** no correctness bugs. It flagged (medium) that DELETE is auto-retried on 429/503, so a commit-then-503 on a destructive delete can surface a spurious `NotFoundError` on the retry. This is a **pre-existing, uniform property** of the C0 idempotent-retry design (affects every SDK delete), with **no data damage** (UUIDs aren't reused). Left unchanged here — a proper fix ("treat 404-after-retry as success") is a holistic transport decision, not an experiments-only special-case. Worth a C0 follow-up.

## Files
- `lucidicai/api/client.py` — `delete`/`adelete` accept an optional JSON body.
- `lucidicai/api/resources/experiment.py` — `delete`/`adelete` + new `ExperimentEvaluatorsResource` (+ `evaluators` property).
- `tests/api/resources/test_experiments_v2.py` — 13 new write tests (delete body flag / cascade / 403 / 404, evaluators list+pagination, attach names→full-set / unknown-name 400, detach 204 / not-attached 404, async). 409 hermetic total pass.