### PR TITLE
LUC-916: client.evaluators write (create LLM / update / delete)

### DIFF
--- a/lucidicai/api/resources/evaluators.py
+++ b/lucidicai/api/resources/evaluators.py
@@ -1,21 +1,22 @@
-"""client.evaluators — evaluator reads (LUC-910).
+"""client.evaluators — evaluator reads (LUC-910) + writes (LUC-916).
 
 A new namespace (today only ``client.evals.emit`` — a different concept, ad-hoc
 score submission — exists). Reads the agent's evaluator definitions, one
 evaluator's eval distribution across runs, and a single evaluator result by id.
+Writes create / update / delete evaluator definitions.
 
 The per-result reads reuse the ``EvalResult`` model (both endpoints serialize
-with the backend's ``EvaluatorResultSerializer``). Data-bearing reads — they do
-NOT swallow in production. Each has an ``a``-prefixed async sibling.
+with the backend's ``EvaluatorResultSerializer``). Data-bearing reads + writes —
+they do NOT swallow in production. Each has an ``a``-prefixed async sibling.
 """
-from typing import Any, AsyncIterator, Dict, Iterator, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.evaluator import Evaluator
 from ..models.session import EvalResult
 from ..pagination import apaginate, paginate
-from ...core.errors import require_agent_id
+from ...core.errors import InvalidOperationError, require_agent_id
 
 _EVALUATORS = "sdk/v2/evaluators"
 
@@ -70,6 +71,92 @@ class EvaluatorsResource:
         """Async sibling of ``get``."""
         return Evaluator.from_dict(await self.http.aget(f"{_EVALUATORS}/{evaluator_id}"))
 
+    # ==================== writes (LUC-916) ====================
+    #
+    # create / update / delete evaluator definitions. Data-bearing writes → no
+    # production swallow. Each has an async sibling. ``create`` is LLM/rubric only
+    # (CODE creation is deferred backend-side, LUC-829) and rejects a non-LLM
+    # ``type`` client-side, since the backend silently coerces every create to LLM.
+
+    def create(
+        self, name: str, *, criteria: List[Dict[str, Any]], result_type: str,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: bool = False, type: str = "llm", agent_id: Optional[str] = None,
+    ) -> Evaluator:
+        """Create an LLM (rubric) evaluator (POST /sdk/v2/evaluators; needs
+        ``evaluator:write``). ``result_type`` is ``"boolean"`` (pass/fail) or
+        ``"number"`` (score); ``criteria`` is a non-empty list whose per-item shape
+        depends on ``result_type`` — boolean: ``{name, pass_definition,
+        fail_definition, pass_definition_details?, fail_definition_details?}``;
+        number: ``{name, weight?, score_definitions:[{score, definition}]}``. The
+        backend builds the rubric from ``criteria`` (don't pass ``rubric_json``). A
+        duplicate ``name`` for the agent → ``ConflictError``; a malformed criterion
+        or unsupported ``result_type`` → ``ValidationError``. Returns the created
+        evaluator in **list shape** — ``criteria`` is populated, but ``rubric_json``
+        / ``config`` are not (call ``get(id)`` for the full built rubric).
+
+        Only LLM/rubric evaluators can be created from the SDK — CODE creation is
+        deferred (LUC-829). Passing any ``type`` other than ``"llm"`` raises
+        ``InvalidOperationError`` (create CODE evaluators in the dashboard)."""
+        self._reject_non_llm(type)
+        return Evaluator.from_dict(self.http.post(
+            _EVALUATORS,
+            self._create_body(name, criteria, result_type, description, icon, is_default, agent_id),
+        ))
+
+    async def acreate(
+        self, name: str, *, criteria: List[Dict[str, Any]], result_type: str,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: bool = False, type: str = "llm", agent_id: Optional[str] = None,
+    ) -> Evaluator:
+        """Async sibling of ``create``."""
+        self._reject_non_llm(type)
+        return Evaluator.from_dict(await self.http.apost(
+            _EVALUATORS,
+            self._create_body(name, criteria, result_type, description, icon, is_default, agent_id),
+        ))
+
+    def update(
+        self, evaluator_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: Optional[bool] = None, criteria: Optional[List[Dict[str, Any]]] = None,
+        result_type: Optional[str] = None, config: Optional[Dict[str, Any]] = None,
+    ) -> Evaluator:
+        """Partially update an evaluator (PUT /sdk/v2/evaluators/{id}; needs
+        ``evaluator:write``). Send only the fields to change: ``name`` /
+        ``description`` / ``icon`` / ``is_default`` apply to any type; ``criteria``
+        applies to LLM evaluators; ``result_type`` / ``config`` (incl.
+        ``config["user_code"]``) apply to CODE evaluators — fields inapplicable to
+        the evaluator's type are ignored, so a round-tripped detail body is safe.
+        A rename collision → ``ConflictError``. Returns the updated evaluator
+        (detail shape, incl. ``rubric_json`` / ``config``)."""
+        return Evaluator.from_dict(self.http.put(
+            f"{_EVALUATORS}/{evaluator_id}",
+            self._update_body(name, description, icon, is_default, criteria, result_type, config),
+        ))
+
+    async def aupdate(
+        self, evaluator_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: Optional[bool] = None, criteria: Optional[List[Dict[str, Any]]] = None,
+        result_type: Optional[str] = None, config: Optional[Dict[str, Any]] = None,
+    ) -> Evaluator:
+        """Async sibling of ``update``."""
+        return Evaluator.from_dict(await self.http.aput(
+            f"{_EVALUATORS}/{evaluator_id}",
+            self._update_body(name, description, icon, is_default, criteria, result_type, config),
+        ))
+
+    def delete(self, evaluator_id: str) -> None:
+        """Hard-delete an evaluator (DELETE /sdk/v2/evaluators/{id}; needs
+        ``evaluator:delete``). This also removes its historical evaluator results.
+        Unknown / cross-org / out-of-binding id → ``NotFoundError``."""
+        self.http.delete(f"{_EVALUATORS}/{evaluator_id}")
+
+    async def adelete(self, evaluator_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_EVALUATORS}/{evaluator_id}")
+
     # ==================== one evaluator's eval distribution ====================
 
     def evals(
@@ -117,6 +204,67 @@ class EvaluatorsResource:
     # evaluator-keyed reads above.
 
     # ==================== internals ====================
+
+    @staticmethod
+    def _reject_non_llm(type_: str) -> None:
+        """Guard: the SDK creates LLM evaluators only. The backend has no ``type``
+        field and silently coerces every create to LLM, so a CODE ``type`` would
+        otherwise be honored as an LLM create — reject it here instead. A non-string
+        or whitespace-padded value is normalized rather than crashing on ``.lower()``."""
+        normalized = type_.strip().lower() if isinstance(type_, str) else type_
+        if normalized != "llm":
+            raise InvalidOperationError(
+                f"creating a '{type_}' evaluator from the SDK is not supported — only "
+                "LLM/rubric evaluators can be created (CODE creation is deferred, "
+                "LUC-829; create CODE evaluators in the dashboard)."
+            )
+
+    def _create_body(
+        self, name: str, criteria: List[Dict[str, Any]], result_type: str,
+        description: Optional[str], icon: Optional[str], is_default: bool,
+        agent_id: Optional[str],
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "evaluators.create"),
+            "name": name, "result_type": result_type, "criteria": criteria,
+            "is_default": is_default,
+        }
+        # omit-None: let the backend default description/icon (icon="compass").
+        if description is not None:
+            body["description"] = description
+        if icon is not None:
+            body["icon"] = icon
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], description: Optional[str], icon: Optional[str],
+        is_default: Optional[bool], criteria: Optional[List[Dict[str, Any]]],
+        result_type: Optional[str], config: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        # omit-None: PUT is a partial update — send only the fields being changed.
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if icon is not None:
+            body["icon"] = icon
+        if is_default is not None:
+            body["is_default"] = is_default
+        if criteria is not None:
+            body["criteria"] = criteria
+        if result_type is not None:
+            body["result_type"] = result_type
+        if config is not None:
+            body["config"] = config
+        # An all-None update would send an empty body and silently no-op server-side;
+        # surface the likely caller mistake instead.
+        if not body:
+            raise InvalidOperationError(
+                "evaluators.update requires at least one field to change."
+            )
+        return body
 
     def _agent_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]

--- a/tests/api/resources/test_evaluators_v2.py
+++ b/tests/api/resources/test_evaluators_v2.py
@@ -1,4 +1,7 @@
-"""LUC-910 — client.evaluators reads (list / get / evals / result)."""
+"""LUC-910 — client.evaluators reads (list / get / evals / result).
+LUC-916 — client.evaluators writes (create LLM / update / delete)."""
+import json
+
 import httpx
 import pytest
 import respx
@@ -6,7 +9,15 @@ import respx
 from lucidicai.api.models.evaluator import Evaluator
 from lucidicai.api.models.session import EvalResult
 from lucidicai.api.resources.evaluators import EvaluatorsResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import (
+    ConflictError,
+    InvalidOperationError,
+    NotFoundError,
+    ValidationError,
+)
+
+# A valid pass/fail criterion (boolean result_type).
+_CRIT = [{"name": "accurate", "pass_definition": "correct", "fail_definition": "wrong"}]
 
 _BASE = "https://stub.lucidic.test"
 _EVALUATORS = f"{_BASE}/sdk/v2/evaluators"
@@ -115,4 +126,158 @@ class TestAsync:
             200, json={"results": [_result(1)], "next": None}))
         got = [r.eval_id async for r in evaluators.aevals("e1")]
         assert got == ["r1"]
+
+
+# ==================== LUC-916 writes ====================
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_llm_boolean(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        e = evaluators.create("eval-1", criteria=_CRIT, result_type="boolean")
+        assert isinstance(e, Evaluator) and e.evaluator_id == "e1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1"  # defaulted from configured agent
+        assert body["name"] == "eval-1" and body["result_type"] == "boolean"
+        assert body["criteria"] == _CRIT and body["is_default"] is False
+        # omit-None: unspecified optionals aren't sent (backend defaults icon=compass)
+        assert "description" not in body and "icon" not in body
+        # the SDK never sends a type / rubric_json — the backend hardcodes LLM + builds the rubric
+        assert "type" not in body and "rubric_json" not in body
+
+    @respx.mock
+    def test_create_with_description_icon_default(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        evaluators.create("eval-1", criteria=_CRIT, result_type="boolean",
+                          description="d", icon="wave", is_default=True)
+        body = json.loads(route.calls.last.request.read())
+        assert body["description"] == "d" and body["icon"] == "wave" and body["is_default"] is True
+
+    @respx.mock
+    def test_create_rejects_code_type_before_http(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        # A LucidicError subclass (not a bare ValueError) so `except LucidicError` catches it.
+        with pytest.raises(InvalidOperationError):
+            evaluators.create("eval-1", criteria=_CRIT, result_type="boolean", type="code")
+        assert not route.called  # rejected client-side, no request made
+
+    @respx.mock
+    def test_create_rejects_non_string_type_cleanly(self, evaluators):
+        # A non-string type must raise the clear guard error, not an opaque AttributeError.
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        with pytest.raises(InvalidOperationError):
+            evaluators.create("eval-1", criteria=_CRIT, result_type="boolean", type=123)
+        assert not route.called
+
+    @respx.mock
+    def test_create_accepts_padded_llm(self, evaluators):
+        # Whitespace/case around a genuine "llm" is normalized, not rejected.
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        assert evaluators.create("eval-1", criteria=_CRIT, result_type="boolean",
+                                 type="  LLM  ").evaluator_id == "e1"
+
+    @respx.mock
+    def test_create_duplicate_409(self, evaluators):
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(
+            409, json={"error": "An evaluator named 'eval-1' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            evaluators.create("eval-1", criteria=_CRIT, result_type="boolean")
+
+    @respx.mock
+    def test_create_bad_criteria_400(self, evaluators):
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(
+            400, json={"error": "Validation failed", "details": {"criteria": ["missing pass_definition"]}}))
+        with pytest.raises(ValidationError):
+            evaluators.create("eval-1", criteria=[{"name": "x"}], result_type="boolean")
+
+    def test_create_without_agent_id_raises(self, http):
+        from lucidicai.core.errors import AgentIdRequiredError
+        res = EvaluatorsResource(http, agent_id=None)
+        with pytest.raises(AgentIdRequiredError):
+            res.create("eval-1", criteria=_CRIT, result_type="boolean")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_update_partial_name_only(self, evaluators):
+        route = respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(
+            200, json=_evaluator(1, name="renamed")))
+        e = evaluators.update("e1", name="renamed")
+        assert isinstance(e, Evaluator) and e.name == "renamed"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed"
+        # partial update — only the provided field is sent
+        assert all(k not in body for k in
+                   ("description", "icon", "is_default", "criteria", "result_type", "config"))
+
+    @respx.mock
+    def test_update_criteria_and_code_config(self, evaluators):
+        route = respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(200, json=_evaluator(1)))
+        evaluators.update("e1", criteria=_CRIT, is_default=True, config={"user_code": "return 1"})
+        body = json.loads(route.calls.last.request.read())
+        assert body["criteria"] == _CRIT and body["is_default"] is True
+        assert body["config"] == {"user_code": "return 1"}
+        assert "name" not in body
+
+    @respx.mock
+    def test_update_rename_collision_409(self, evaluators):
+        respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(
+            409, json={"error": "An evaluator named 'taken' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            evaluators.update("e1", name="taken")
+
+    @respx.mock
+    def test_update_with_no_fields_raises_before_http(self, evaluators):
+        # An all-None update would be an empty no-op write — surface the mistake.
+        route = respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(200, json=_evaluator(1)))
+        with pytest.raises(InvalidOperationError):
+            evaluators.update("e1")
+        assert not route.called
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_204(self, evaluators):
+        route = respx.delete(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(204))
+        assert evaluators.delete("e1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_404(self, evaluators):
+        respx.delete(f"{_EVALUATORS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified Evaluator not found"}))
+        with pytest.raises(NotFoundError):
+            evaluators.delete("missing")
+
+
+class TestWriteAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, evaluators):
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        e = await evaluators.acreate("eval-1", criteria=_CRIT, result_type="boolean")
+        assert e.evaluator_id == "e1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate_rejects_code_case_insensitive(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        with pytest.raises(InvalidOperationError):
+            await evaluators.acreate("eval-1", criteria=_CRIT, result_type="boolean", type="CODE")
+        assert not route.called
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, evaluators):
+        respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(200, json=_evaluator(1)))
+        e = await evaluators.aupdate("e1", description="d")
+        assert e.evaluator_id == "e1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, evaluators):
+        route = respx.delete(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(204))
+        assert await evaluators.adelete("e1") is None
+        assert route.called
 


### PR DESCRIPTION
Adds evaluator authoring to `EvaluatorsResource` (create / update / delete).

## Surface
- `evaluators.create(name, *, criteria, result_type, description=None, icon=None, is_default=False, type="llm", agent_id=None)` → `Evaluator` (POST `/sdk/v2/evaluators`, 201; `evaluator:write`). `result_type` is `"boolean"` (pass/fail) or `"number"` (score); `criteria` is a non-empty list whose per-item shape depends on `result_type` (the backend builds the rubric — don't pass `rubric_json`). Duplicate name → `ConflictError`; malformed criterion → `ValidationError`. Returns the **list shape** (`criteria` populated; `rubric_json`/`config` need a follow-up `get`).
- `evaluators.update(id, *, name, description, icon, is_default, criteria, result_type, config)` → `Evaluator` (PUT `/sdk/v2/evaluators/{id}`, 200 detail shape; `evaluator:write`). Partial — send only what changes; metadata applies to any type, `criteria` is LLM-only, `result_type`/`config` are CODE-only (backend ignores inapplicable fields). Rename collision → `ConflictError`.
- `evaluators.delete(id)` → `None` (DELETE `/sdk/v2/evaluators/{id}`, 204; `evaluator:delete`).
- All with async siblings. Data-bearing writes → no production swallow.

## LLM-only creation (CODE rejected client-side)
CODE-type creation is deferred backend-side (LUC-829). Critically, the backend's create endpoint has **no `type` field and hardcodes LLM** — a CODE request would be silently coerced to an LLM evaluator, not rejected. So the SDK enforces "LLM only" itself: `create(type=…)` with anything but `"llm"` raises `InvalidOperationError` **before any HTTP**. Update/delete are type-agnostic (they work on existing evaluators, so CODE evaluators authored in the dashboard remain editable per LUC-826).

## Verification (two-lens: skeptic + backend-contract)
- **Contract: conforms exactly** — re-verified against a freshly-fetched `origin/sdk-first-platform-parity` (create fields + 201 `EvaluatorListSerializer`, update fields + 200 `EvaluatorDetailSerializer`, delete 204, scopes, 400/409/403/404 mapping). Confirmed the backend does **not** reject CODE, so the client-side guard is load-bearing.
- **Skeptic:** no correctness/security defects. Applied its hardening: the type guard now raises `InvalidOperationError` (a `LucidicError`, so `except LucidicError` catches it — consistent with `AgentIdRequiredError` — instead of a bare `ValueError`), is non-string/whitespace-safe (no `AttributeError` on `type=123`, accepts `"  LLM  "`), an all-None `update()` raises instead of silently no-op'ing, and `create`'s list-shape return is documented.

## Files
- `lucidicai/api/resources/evaluators.py` — create/acreate, update/aupdate, delete/adelete + `_reject_non_llm`/`_create_body`/`_update_body`.
- `tests/api/resources/test_evaluators_v2.py` — 17 new write tests (create happy/omit-None/CODE-reject/non-string-type/padded-llm/409/400/agent-guard, update partial/criteria+config/rename-409/empty-guard, delete 204/404, async). 427 hermetic total pass.