### PR TITLE
LUC-917: client.resources — SQL-substrate Resource CRUD (new namespace)

### DIFF
--- a/lucidicai/api/models/resource.py
+++ b/lucidicai/api/models/resource.py
@@ -1,0 +1,31 @@
+"""Typed response model for client.resources (LUC-917)."""
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Resource(APIModel):
+    """A SQL-substrate Resource — the org-scoped definition of an external service
+    the client mocks at runtime (``type`` ``SQL`` / ``API`` / ``CUSTOM``). Authored
+    once per org and attached to Datasets and Tools; ``spec`` is the parsed schema
+    that backs fixture hydration + runtime mocking. Org-scoped, so a bound key still
+    sees all of the org's resources.
+
+    ``name`` and ``tool_name`` are each unique per org. ``handler_type`` is derived
+    from ``type`` by the backend (read-only). The write-only ``ddl`` create input
+    is parsed into ``spec`` server-side and never returned.
+    """
+
+    resource_id: str
+    type: Optional[str] = None
+    dialect: Optional[str] = None
+    tool_name: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    spec: Optional[Dict[str, Any]] = None
+    handler_type: Optional[str] = None
+    hydration_config: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None

--- a/lucidicai/api/resources/resources.py
+++ b/lucidicai/api/resources/resources.py
@@ -1,0 +1,213 @@
+"""client.resources — SQL-substrate Resource CRUD (LUC-917).
+
+A new namespace. Resources are the org-scoped definitions of external services the
+client mocks at runtime (SQL / API / CUSTOM), attached to Datasets and Tools — the
+SQL substrate backing tool-config mocking. Org-scoped: a bound key still reaches
+all of the org's resources (agent binding is a no-op here).
+
+Reads and writes are data-bearing — they do NOT swallow in production; typed
+transport errors propagate. Every method has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.resource import Resource
+from ..pagination import apaginate, paginate
+
+_RESOURCES = "sdk/v2/resources"
+
+
+class ResourcesResource:
+    """Handle for the ``/sdk/v2/resources`` endpoints."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    # ==================== list ====================
+
+    def list(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> Iterator[Resource]:
+        """Lazily iterate the org's resources, newest first. ``ordering`` accepts
+        ``id`` (± prefix). Handy for resolving a ``resource_id`` by name."""
+        base = self._params(ordering, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=Resource)
+
+    def alist(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> AsyncIterator[Resource]:
+        """Async sibling of ``list``."""
+        base = self._params(ordering, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=Resource)
+
+    def list_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of resources."""
+        return CursorPage.from_body(
+            self._page_get(self._params(ordering, page_size), cursor), model=Resource
+        )
+
+    async def alist_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Resource)
+
+    # ==================== get ====================
+
+    def get(self, resource_id: str) -> Resource:
+        """Read one resource by id (raises ``NotFoundError`` if absent/cross-org)."""
+        return Resource.from_dict(self.http.get(f"{_RESOURCES}/{resource_id}"))
+
+    async def aget(self, resource_id: str) -> Resource:
+        """Async sibling of ``get``."""
+        return Resource.from_dict(await self.http.aget(f"{_RESOURCES}/{resource_id}"))
+
+    # ==================== create ====================
+
+    def create(
+        self, *, type: str, tool_name: str, name: str,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        dialect: Optional[str] = None, description: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Create a resource in the key's org (POST /sdk/v2/resources; needs
+        ``resource:write``). ``type`` is ``"SQL"`` / ``"API"`` / ``"CUSTOM"``, and
+        ``dialect`` (e.g. ``"POSTGRES"``) is required when ``type == "SQL"``. Supply
+        the schema exactly one way — either a parsed ``spec`` dict or raw ``ddl``
+        (``CREATE TABLE`` SQL the backend parses into ``spec``); passing both or
+        neither → ``ValidationError``. ``name`` and ``tool_name`` are each unique
+        per org — a duplicate → ``ConflictError``. The org is taken from the API
+        key, never the body."""
+        return Resource.from_dict(self.http.post(
+            _RESOURCES,
+            self._create_body(type, tool_name, name, spec, ddl, dialect, description, hydration_config),
+        ))
+
+    async def acreate(
+        self, *, type: str, tool_name: str, name: str,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        dialect: Optional[str] = None, description: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Async sibling of ``create``."""
+        return Resource.from_dict(await self.http.apost(
+            _RESOURCES,
+            self._create_body(type, tool_name, name, spec, ddl, dialect, description, hydration_config),
+        ))
+
+    # ==================== update ====================
+
+    def update(
+        self, resource_id: str, *, name: Optional[str] = None,
+        tool_name: Optional[str] = None, description: Optional[str] = None,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Partially update a resource (PUT /sdk/v2/resources/{id}; needs
+        ``resource:write``). Send only the fields to change — ``name`` /
+        ``tool_name`` / ``description`` / ``hydration_config``, and the schema via a
+        new ``spec`` or ``ddl`` (re-parsed into ``spec``). ``type`` and ``dialect``
+        are immutable after creation and are intentionally not accepted here. A
+        rename / ``tool_name`` collision → ``ConflictError``."""
+        return Resource.from_dict(self.http.put(
+            f"{_RESOURCES}/{resource_id}",
+            self._update_body(name, tool_name, description, spec, ddl, hydration_config),
+        ))
+
+    async def aupdate(
+        self, resource_id: str, *, name: Optional[str] = None,
+        tool_name: Optional[str] = None, description: Optional[str] = None,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Async sibling of ``update``."""
+        return Resource.from_dict(await self.http.aput(
+            f"{_RESOURCES}/{resource_id}",
+            self._update_body(name, tool_name, description, spec, ddl, hydration_config),
+        ))
+
+    # ==================== delete ====================
+
+    def delete(self, resource_id: str) -> None:
+        """Delete a resource (DELETE /sdk/v2/resources/{id}; needs
+        ``resource:delete``). A resource still attached to any Dataset, Fixture, or
+        Tool is protected → ``ConflictError`` (detach it there first). A missing /
+        cross-org id → ``NotFoundError``."""
+        self.http.delete(f"{_RESOURCES}/{resource_id}")
+
+    async def adelete(self, resource_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_RESOURCES}/{resource_id}")
+
+    # ==================== internals ====================
+
+    @staticmethod
+    def _params(ordering: Optional[str], page_size: Optional[int]) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params or None
+
+    def _page_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_RESOURCES, params or None)
+
+    async def _apage_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_RESOURCES, params or None)
+
+    @staticmethod
+    def _create_body(
+        type_: str, tool_name: str, name: str, spec: Optional[Dict[str, Any]],
+        ddl: Optional[str], dialect: Optional[str], description: Optional[str],
+        hydration_config: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        # type/tool_name/name are always required; the backend enforces the
+        # spec/ddl XOR and the dialect-required-when-SQL rule, so we just forward
+        # what was provided (omit-None) and let it validate.
+        body: Dict[str, Any] = {"type": type_, "tool_name": tool_name, "name": name}
+        if spec is not None:
+            body["spec"] = spec
+        if ddl is not None:
+            body["ddl"] = ddl
+        if dialect is not None:
+            body["dialect"] = dialect
+        if description is not None:
+            body["description"] = description
+        if hydration_config is not None:
+            body["hydration_config"] = hydration_config
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], tool_name: Optional[str], description: Optional[str],
+        spec: Optional[Dict[str, Any]], ddl: Optional[str],
+        hydration_config: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        # omit-None: PUT is a partial update — send only the fields being changed.
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if tool_name is not None:
+            body["tool_name"] = tool_name
+        if description is not None:
+            body["description"] = description
+        if spec is not None:
+            body["spec"] = spec
+        if ddl is not None:
+            body["ddl"] = ddl
+        if hydration_config is not None:
+            body["hydration_config"] = hydration_config
+        return body

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -28,6 +28,7 @@ from .api.resources.agents import AgentsResource
 from .api.resources.evaluator_results import EvaluatorResultsResource
 from .api.resources.evaluators import EvaluatorsResource
 from .api.resources.projects import ProjectsResource
+from .api.resources.resources import ResourcesResource
 from .api.resources.session import SessionResource
 from .api.resources.usage import UsageResource
 from .api.resources.event import EventResource
@@ -164,6 +165,7 @@ class LucidicAI:
             "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
             "evaluator_results": EvaluatorResultsResource(self._http),
             "projects": ProjectsResource(self._http),
+            "resources": ResourcesResource(self._http),
             "usage": UsageResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
@@ -288,6 +290,15 @@ class LucidicAI:
         (SET_NULL) rather than destroying them.
         """
         return self._resources["projects"]
+
+    @property
+    def resources(self) -> ResourcesResource:
+        """Access SQL-substrate Resource CRUD (LUC-917): ``list`` / ``create`` /
+        ``get`` / ``update`` / ``delete``. Org-scoped definitions of external
+        services the client mocks at runtime (SQL / API / CUSTOM), attached to
+        Datasets and Tools. ``delete`` is protected while the resource is in use.
+        """
+        return self._resources["resources"]
 
     @property
     def usage(self) -> UsageResource:

--- a/tests/api/resources/test_resources_v2.py
+++ b/tests/api/resources/test_resources_v2.py
@@ -1,0 +1,199 @@
+"""LUC-917 — client.resources CRUD (SQL-substrate resources; new namespace)."""
+import json
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.resource import Resource
+from lucidicai.api.resources.resources import ResourcesResource
+from lucidicai.core.errors import ConflictError, NotFoundError, ValidationError
+
+_BASE = "https://stub.lucidic.test"
+_RESOURCES = f"{_BASE}/sdk/v2/resources"
+
+
+@pytest.fixture
+def resources(http):
+    return ResourcesResource(http)
+
+
+def _resource(i, **over):
+    d = {
+        "resource_id": f"res{i}", "type": "SQL", "dialect": "POSTGRES",
+        "tool_name": f"tool_{i}", "name": f"resource-{i}", "description": "",
+        "spec": {"tables": []}, "handler_type": "SQL",
+        "hydration_config": {"default_rows_per_table": 100},
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, resources):
+        respx.get(_RESOURCES).mock(side_effect=[
+            httpx.Response(200, json={"results": [_resource(1), _resource(2)],
+                                      "next": f"{_RESOURCES}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_resource(3)], "next": None}),
+        ])
+        got = list(resources.list())
+        assert [r.resource_id for r in got] == ["res1", "res2", "res3"]
+        assert all(isinstance(r, Resource) for r in got)
+
+    @respx.mock
+    def test_org_scoped_no_agent_id_param(self, resources):
+        # Resources are org-scoped: no agent_id is sent (scoped by the key's org).
+        route = respx.get(_RESOURCES).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(resources.list(ordering="id", page_size=10))
+        p = route.calls.last.request.url.params
+        assert "agent_id" not in p and p["ordering"] == "id" and p["page_size"] == "10"
+
+    @respx.mock
+    def test_list_page(self, resources):
+        respx.get(_RESOURCES).mock(return_value=httpx.Response(
+            200, json={"results": [_resource(1)], "next": f"{_RESOURCES}?cursor=c9"}))
+        page = resources.list_page()
+        assert isinstance(page.results[0], Resource) and page.next_cursor == "c9"
+
+
+class TestGet:
+    @respx.mock
+    def test_get_typed(self, resources):
+        respx.get(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        r = resources.get("res1")
+        assert isinstance(r, Resource) and r.resource_id == "res1"
+        assert r.type == "SQL" and r.spec == {"tables": []}
+        assert r.handler_type == "SQL" and r.hydration_config == {"default_rows_per_table": 100}
+
+    @respx.mock
+    def test_get_404(self, resources):
+        respx.get(f"{_RESOURCES}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "Specified Resource not found"}))
+        with pytest.raises(NotFoundError):
+            resources.get("missing")
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_with_spec(self, resources):
+        route = respx.post(_RESOURCES).mock(return_value=httpx.Response(201, json=_resource(1)))
+        spec = {"tables": [{"name": "users", "columns": []}]}
+        r = resources.create(type="SQL", tool_name="query_db", name="prod-db",
+                             dialect="POSTGRES", spec=spec)
+        assert isinstance(r, Resource) and r.resource_id == "res1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["type"] == "SQL" and body["tool_name"] == "query_db"
+        assert body["name"] == "prod-db" and body["dialect"] == "POSTGRES"
+        assert body["spec"] == spec and "ddl" not in body
+        # the org is taken from the key server-side — never sent from the client
+        assert "org" not in body and "org_id" not in body
+
+    @respx.mock
+    def test_create_with_ddl_and_optionals(self, resources):
+        route = respx.post(_RESOURCES).mock(return_value=httpx.Response(201, json=_resource(1)))
+        resources.create(type="SQL", tool_name="query_db", name="db2", dialect="POSTGRES",
+                        ddl="CREATE TABLE users (id INT);", description="d",
+                        hydration_config={"default_rows_per_table": 50})
+        body = json.loads(route.calls.last.request.read())
+        assert body["ddl"] == "CREATE TABLE users (id INT);" and "spec" not in body
+        assert body["description"] == "d"
+        assert body["hydration_config"] == {"default_rows_per_table": 50}
+
+    @respx.mock
+    def test_create_duplicate_409(self, resources):
+        respx.post(_RESOURCES).mock(return_value=httpx.Response(
+            409, json={"error": "A resource named 'db2' already exists for this org."}))
+        with pytest.raises(ConflictError):
+            resources.create(type="SQL", tool_name="t", name="db2", dialect="POSTGRES", spec={})
+
+    @respx.mock
+    def test_create_xor_violation_400(self, resources):
+        # Neither spec nor ddl — the SDK forwards and lets the backend enforce the XOR.
+        respx.post(_RESOURCES).mock(return_value=httpx.Response(
+            400, json={"error": "exactly one of ddl or spec is required on create"}))
+        with pytest.raises(ValidationError):
+            resources.create(type="SQL", tool_name="t", name="db3", dialect="POSTGRES")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_update_partial(self, resources):
+        route = respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        r = resources.update("res1", name="renamed", hydration_config={"max_result_rows": 5000})
+        assert isinstance(r, Resource)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed" and body["hydration_config"] == {"max_result_rows": 5000}
+        # type/dialect are immutable and intentionally absent from the update surface
+        assert "type" not in body and "dialect" not in body
+        assert all(k not in body for k in ("tool_name", "description", "spec", "ddl"))
+
+    @respx.mock
+    def test_update_ddl_reparse(self, resources):
+        route = respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        resources.update("res1", ddl="CREATE TABLE t (id INT);")
+        assert json.loads(route.calls.last.request.read())["ddl"] == "CREATE TABLE t (id INT);"
+
+    @respx.mock
+    def test_update_rename_collision_409(self, resources):
+        respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(
+            409, json={"error": "A resource named 'taken' already exists for this org."}))
+        with pytest.raises(ConflictError):
+            resources.update("res1", name="taken")
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_204(self, resources):
+        route = respx.delete(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(204))
+        assert resources.delete("res1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_in_use_409(self, resources):
+        respx.delete(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(
+            409, json={"error": "detach it from those Datasets first", "dataset_ids": ["d1"]}))
+        with pytest.raises(ConflictError):
+            resources.delete("res1")
+
+    @respx.mock
+    def test_delete_404(self, resources):
+        respx.delete(f"{_RESOURCES}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified Resource not found"}))
+        with pytest.raises(NotFoundError):
+            resources.delete("missing")
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, resources):
+        respx.get(_RESOURCES).mock(side_effect=[
+            httpx.Response(200, json={"results": [_resource(1)], "next": f"{_RESOURCES}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_resource(2)], "next": None}),
+        ])
+        got = [r.resource_id async for r in resources.alist()]
+        assert got == ["res1", "res2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, resources):
+        respx.post(_RESOURCES).mock(return_value=httpx.Response(201, json=_resource(1)))
+        r = await resources.acreate(type="SQL", tool_name="t", name="n", dialect="POSTGRES", spec={})
+        assert r.resource_id == "res1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, resources):
+        respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        r = await resources.aupdate("res1", description="d")
+        assert r.resource_id == "res1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, resources):
+        route = respx.delete(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(204))
+        assert await resources.adelete("res1") is None
+        assert route.called


### PR DESCRIPTION
Adds a new `client.resources` namespace — CRUD over the org-scoped SQL-substrate Resources that back tool-config mocking (a Resource is the definition of an external service the client mocks at runtime: SQL / API / CUSTOM, attached to Datasets and Tools).

## Surface (org-scoped, mirrors `client.projects`)
- `resources.list()` / `list_page()` → cursor-iterated `Resource`s, newest first (no `agent_id` — scoped by the key's org).
- `resources.get(id)` → `Resource`.
- `resources.create(*, type, tool_name, name, spec=None, ddl=None, dialect=None, description=None, hydration_config=None)` → `Resource` (POST, 201; `resource:write`). Supply the schema as **exactly one** of `spec` (parsed dict) or `ddl` (raw `CREATE TABLE` SQL the backend parses into `spec`) — the backend enforces the XOR (→ `ValidationError`). `dialect` required when `type=="SQL"`. `name`/`tool_name` are each unique per org → duplicate is `ConflictError` (409). **Org is taken from the API key, never sent in the body.**
- `resources.update(id, *, name=None, tool_name=None, description=None, spec=None, ddl=None, hydration_config=None)` → `Resource` (PUT, 200; partial). `type`/`dialect` are immutable and intentionally **not accepted here**, so a caller can't trip the backend's immutable-field 400. Rename/`tool_name` collision → `ConflictError`.
- `resources.delete(id)` → `None` (DELETE, 204; `resource:delete`). Protected while the resource is attached to any Dataset, Fixture, or Tool → `ConflictError` (detach first). Missing/cross-org → `NotFoundError`.
- All with async siblings. Data-bearing → no production swallow.

## New files
- `lucidicai/api/models/resource.py` — typed `Resource` model (matches `ResourceSerializer` output; `ddl` is write-only and absent).
- `lucidicai/api/resources/resources.py` — `ResourcesResource`.
- `lucidicai/client.py` — wired `client.resources` (import + registry + property).
- `tests/api/resources/test_resources_v2.py` — 19 tests (list/org-scoped/get/create spec+ddl/dup-409/XOR-400/update-partial+immutables/rename-409/delete-204/in-use-409/404/async). 446 hermetic total pass.

## Verification (two-lens: skeptic + backend-contract)
- **Contract: conforms exactly** — verified against a freshly-fetched `origin/sdk-first-platform-parity` (model↔serializer keys, org-scoping, scopes `resource:read`/`write`/`delete`, spec/ddl XOR, immutable `type`/`dialect`, 201/200/204, 409 dup + 409 in-use, 404).
- **Skeptic:** its two findings (dup → 400 not 409; delete doesn't guard Tools) were **false alarms** — it read the *dashboard* `resource_views.py` because the luc-866 working tree lacks the merged sdk/v2 endpoint. Refuted by direct `git show` of the merged view: dup → **409** ("the SDK v2 convention"), and `resource_in_use_conflict` guards Dataset/Fixture/**Tool**. Docstrings and tests are correct as written.