### PR TITLE
LUC-918: client.datasets v2 — items + schemas CRUD + fixtures.create

### DIFF
--- a/lucidicai/api/models/dataset.py
+++ b/lucidicai/api/models/dataset.py
@@ -1,0 +1,55 @@
+"""Typed response models for client.datasets v2 (LUC-918).
+
+Distinct from the SDK's grandfathered gen-3 dataset helpers (which return raw
+dicts). These model the v2 schemas / items / fixtures surface.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class DatasetSchema(APIModel):
+    """A reusable, org-scoped typed definition of the shape of a dataset item's
+    ``input`` — a required input to dataset generation. ``fields`` is a list of
+    typed field defs (``{key, type, description?, required?, options?, children?}``);
+    ``type`` is one of ``string`` / ``number`` / ``categorical`` / ``object``.
+    ``name`` is unique per org.
+    """
+
+    schema_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    fields: List[Any] = field(default_factory=list)
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass
+class DatasetItem(APIModel):
+    """One test case in a dataset — an ``input`` (matching the dataset's schema)
+    and its ``expected_output``, plus tags/metadata. Returned by
+    ``client.datasets.items(dataset_id)``."""
+
+    datasetitem_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    tags: List[Any] = field(default_factory=list)
+    input: Optional[Dict[str, Any]] = None
+    expected_output: Optional[Any] = None
+    metadata: Optional[Dict[str, Any]] = None
+    flag_overrides: Optional[Any] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class Fixture(APIModel):
+    """A hydrated mock-data fixture (a DuckDB blob in object storage) authored for
+    one ``(dataset, resource)`` pair. The create response returns its id, storage
+    key, byte size, and status (``COMPLETED`` for a row-authored fixture)."""
+
+    fixture_id: str
+    blob_key: Optional[str] = None
+    byte_size: Optional[int] = None
+    status: Optional[str] = None

--- a/lucidicai/api/resources/dataset.py
+++ b/lucidicai/api/resources/dataset.py
@@ -1,10 +1,16 @@
 """Dataset resource API operations."""
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.dataset import DatasetItem, DatasetSchema, Fixture
+from ..pagination import apaginate, paginate
 
 logger = logging.getLogger("Lucidic")
+
+_SCHEMAS = "sdk/v2/datasets/schemas"
+_FIXTURES = "sdk/v2/fixtures"
 
 
 class DatasetResource:
@@ -26,6 +32,73 @@ class DatasetResource:
         self.http = http
         self._agent_id = agent_id
         self._production = production
+        # v2 sub-namespaces (LUC-918): client.datasets.schemas / .fixtures.
+        # Stateless (ids passed per call), so one instance each is reused.
+        self._schemas = DatasetSchemasResource(http)
+        self._fixtures = DatasetFixturesResource(http)
+
+    # ==================== v2 surface (LUC-918) ====================
+    #
+    # Data-bearing v2 reads/writes: they do NOT swallow in production (typed
+    # transport errors propagate), unlike the gen-3 methods below. ``items`` is a
+    # cursor-paginated read of a dataset's items; ``schemas`` / ``fixtures`` are
+    # sub-namespaces. Each has an async sibling.
+
+    @property
+    def schemas(self) -> "DatasetSchemasResource":
+        """Dataset schema CRUD — ``client.datasets.schemas.list()`` /
+        ``create`` / ``get`` / ``update`` / ``delete`` (org-scoped typed
+        definitions of a dataset item's ``input`` shape)."""
+        return self._schemas
+
+    @property
+    def fixtures(self) -> "DatasetFixturesResource":
+        """Fixture authoring — ``client.datasets.fixtures.create(...)`` builds a
+        base DuckDB fixture for a ``(dataset, resource)`` pair from JSON rows."""
+        return self._fixtures
+
+    def items(self, dataset_id: str, *, page_size: Optional[int] = None) -> Iterator[DatasetItem]:
+        """Lazily iterate a dataset's items, newest first (GET
+        /sdk/v2/datasets/{id}/items; needs ``dataset-item:read``). Cursor-paginated
+        — transparently walks every page. Unknown / cross-org dataset →
+        ``NotFoundError`` on first iteration."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        path = f"sdk/v2/datasets/{dataset_id}/items"
+        return paginate(lambda c: self._v2_page_get(path, base, c), model=DatasetItem)
+
+    def aitems(self, dataset_id: str, *, page_size: Optional[int] = None) -> AsyncIterator[DatasetItem]:
+        """Async sibling of ``items``."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        path = f"sdk/v2/datasets/{dataset_id}/items"
+        return apaginate(lambda c: self._v2_apage_get(path, base, c), model=DatasetItem)
+
+    def items_page(
+        self, dataset_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of a dataset's items."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        body = self._v2_page_get(f"sdk/v2/datasets/{dataset_id}/items", base, cursor)
+        return CursorPage.from_body(body, model=DatasetItem)
+
+    async def aitems_page(
+        self, dataset_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``items_page``."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        body = await self._v2_apage_get(f"sdk/v2/datasets/{dataset_id}/items", base, cursor)
+        return CursorPage.from_body(body, model=DatasetItem)
+
+    def _v2_page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params or None)
+
+    async def _v2_apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params or None)
 
     # ==================== Dataset Methods ====================
 
@@ -530,3 +603,188 @@ class DatasetResource:
                 logger.error(f"[DatasetResource] Failed to list item sessions: {e}")
                 return {"num_sessions": 0, "sessions": []}
             raise
+
+
+class DatasetSchemasResource:
+    """``client.datasets.schemas`` — dataset schema CRUD (LUC-918).
+
+    A dataset schema is an org-scoped typed definition of a dataset item's ``input``
+    shape (required for dataset generation). Org-scoped: a bound key reaches them
+    all. Data-bearing — no production swallow. Each method has an async sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def list(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> Iterator[DatasetSchema]:
+        """Lazily iterate the org's dataset schemas, newest first. ``ordering``
+        accepts ``id`` (± prefix)."""
+        base = self._params(ordering, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=DatasetSchema)
+
+    def alist(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> AsyncIterator[DatasetSchema]:
+        """Async sibling of ``list``."""
+        base = self._params(ordering, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=DatasetSchema)
+
+    def list_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of dataset schemas."""
+        return CursorPage.from_body(
+            self._page_get(self._params(ordering, page_size), cursor), model=DatasetSchema
+        )
+
+    async def alist_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=DatasetSchema)
+
+    def get(self, schema_id: str) -> DatasetSchema:
+        """Read one schema by id (raises ``NotFoundError`` if absent/cross-org)."""
+        return DatasetSchema.from_dict(self.http.get(f"{_SCHEMAS}/{schema_id}"))
+
+    async def aget(self, schema_id: str) -> DatasetSchema:
+        """Async sibling of ``get``."""
+        return DatasetSchema.from_dict(await self.http.aget(f"{_SCHEMAS}/{schema_id}"))
+
+    def create(
+        self, name: str, *, fields: List[Dict[str, Any]], description: Optional[str] = None
+    ) -> DatasetSchema:
+        """Create a dataset schema in the key's org (POST /sdk/v2/datasets/schemas;
+        needs ``dataset-schema:write``). ``fields`` is a non-empty list of typed
+        field defs — each ``{key, type, description?, required?, options?,
+        children?}`` where ``type`` is ``string`` / ``number`` / ``categorical`` /
+        ``object`` (``categorical`` needs ``options``; ``object`` needs
+        ``children``). ``name`` is unique per org — a duplicate → ``ConflictError``;
+        a malformed field → ``ValidationError``."""
+        return DatasetSchema.from_dict(
+            self.http.post(_SCHEMAS, self._create_body(name, fields, description))
+        )
+
+    async def acreate(
+        self, name: str, *, fields: List[Dict[str, Any]], description: Optional[str] = None
+    ) -> DatasetSchema:
+        """Async sibling of ``create``."""
+        return DatasetSchema.from_dict(
+            await self.http.apost(_SCHEMAS, self._create_body(name, fields, description))
+        )
+
+    def update(
+        self, schema_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, fields: Optional[List[Dict[str, Any]]] = None,
+    ) -> DatasetSchema:
+        """Partially update a schema (PUT /sdk/v2/datasets/schemas/{id}; needs
+        ``dataset-schema:write``). Send only the fields to change. A rename
+        collision → ``ConflictError``."""
+        return DatasetSchema.from_dict(
+            self.http.put(f"{_SCHEMAS}/{schema_id}", self._update_body(name, description, fields))
+        )
+
+    async def aupdate(
+        self, schema_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, fields: Optional[List[Dict[str, Any]]] = None,
+    ) -> DatasetSchema:
+        """Async sibling of ``update``."""
+        return DatasetSchema.from_dict(
+            await self.http.aput(f"{_SCHEMAS}/{schema_id}", self._update_body(name, description, fields))
+        )
+
+    def delete(self, schema_id: str) -> None:
+        """Delete a schema (DELETE /sdk/v2/datasets/schemas/{id}; needs
+        ``dataset-schema:delete``). Datasets/generation runs pointing at it are
+        un-linked (their schema pointer is set null), not deleted. A missing /
+        cross-org id → ``NotFoundError``."""
+        self.http.delete(f"{_SCHEMAS}/{schema_id}")
+
+    async def adelete(self, schema_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_SCHEMAS}/{schema_id}")
+
+    # ---- internals ----
+
+    @staticmethod
+    def _params(ordering: Optional[str], page_size: Optional[int]) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params or None
+
+    def _page_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_SCHEMAS, params or None)
+
+    async def _apage_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_SCHEMAS, params or None)
+
+    @staticmethod
+    def _create_body(
+        name: str, fields: List[Dict[str, Any]], description: Optional[str]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {"name": name, "fields": fields}
+        if description is not None:
+            body["description"] = description
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], description: Optional[str], fields: Optional[List[Dict[str, Any]]]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if fields is not None:
+            body["fields"] = fields
+        return body
+
+
+class DatasetFixturesResource:
+    """``client.datasets.fixtures`` — author base fixtures from JSON rows (LUC-918).
+
+    A fixture is the hydrated mock data (a DuckDB blob) for one ``(dataset,
+    resource)`` pair. ``create`` builds one from explicit rows. Data-bearing — no
+    production swallow. Has an async sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def create(
+        self, *, resource_id: str, dataset_id: str, tables: List[Dict[str, Any]]
+    ) -> Fixture:
+        """Author a base fixture from JSON rows (POST /sdk/v2/fixtures; needs
+        ``fixture:write``). ``tables`` is a list of ``{"name": <table>, "rows":
+        [<row dict>, ...]}`` validated against the resource's ``spec``. Exactly one
+        fixture may exist per ``(dataset, resource)`` — a duplicate →
+        ``ConflictError``; a row/spec mismatch → ``ValidationError``. Unknown
+        resource or dataset → ``NotFoundError``."""
+        return Fixture.from_dict(self.http.post(_FIXTURES, self._body(resource_id, dataset_id, tables)))
+
+    async def acreate(
+        self, *, resource_id: str, dataset_id: str, tables: List[Dict[str, Any]]
+    ) -> Fixture:
+        """Async sibling of ``create``."""
+        return Fixture.from_dict(
+            await self.http.apost(_FIXTURES, self._body(resource_id, dataset_id, tables))
+        )
+
+    @staticmethod
+    def _body(resource_id: str, dataset_id: str, tables: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {"resource_id": resource_id, "dataset_id": dataset_id, "tables": tables}

--- a/tests/api/resources/test_datasets_v2.py
+++ b/tests/api/resources/test_datasets_v2.py
@@ -1,0 +1,236 @@
+"""LUC-918 — client.datasets v2: items + schemas (CRUD) + fixtures.create."""
+import json
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.dataset import DatasetItem, DatasetSchema, Fixture
+from lucidicai.api.resources.dataset import (
+    DatasetResource,
+    DatasetFixturesResource,
+    DatasetSchemasResource,
+)
+from lucidicai.core.errors import ConflictError, NotFoundError, ValidationError
+
+_BASE = "https://stub.lucidic.test"
+_SCHEMAS = f"{_BASE}/sdk/v2/datasets/schemas"
+_FIXTURES = f"{_BASE}/sdk/v2/fixtures"
+
+
+def _items_url(dataset_id):
+    return f"{_BASE}/sdk/v2/datasets/{dataset_id}/items"
+
+
+@pytest.fixture
+def datasets(http):
+    return DatasetResource(http, agent_id="a1", production=False)
+
+
+def _schema(i, **over):
+    d = {
+        "schema_id": f"s{i}", "name": f"schema-{i}", "description": "",
+        "fields": [{"key": "q", "type": "string"}],
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+def _item(i, **over):
+    d = {
+        "datasetitem_id": f"it{i}", "name": f"item-{i}", "description": "",
+        "tags": [], "input": {"q": "hi"}, "expected_output": "ok",
+        "metadata": {}, "flag_overrides": None, "created_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+def _fixture(**over):
+    d = {"fixture_id": "f1", "blob_key": "tenant=o/dataset=d/fixture=f1/data.duckdb",
+         "byte_size": 2048, "status": "COMPLETED"}
+    d.update(over)
+    return d
+
+
+class TestWiring:
+    def test_subnamespaces_resolve(self, datasets):
+        assert isinstance(datasets.schemas, DatasetSchemasResource)
+        assert isinstance(datasets.fixtures, DatasetFixturesResource)
+
+
+class TestItems:
+    @respx.mock
+    def test_follows_pages_typed(self, datasets):
+        url = _items_url("d1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_item(1), _item(2)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_item(3)], "next": None}),
+        ])
+        got = list(datasets.items("d1"))
+        assert [i.datasetitem_id for i in got] == ["it1", "it2", "it3"]
+        assert all(isinstance(i, DatasetItem) for i in got)
+        assert got[0].input == {"q": "hi"} and got[0].expected_output == "ok"
+
+    @respx.mock
+    def test_items_page_size(self, datasets):
+        route = respx.get(_items_url("d1")).mock(
+            return_value=httpx.Response(200, json={"results": [_item(1)], "next": None}))
+        page = datasets.items_page("d1", page_size=25)
+        assert isinstance(page.results[0], DatasetItem)
+        assert route.calls.last.request.url.params["page_size"] == "25"
+
+    @respx.mock
+    def test_items_404(self, datasets):
+        respx.get(_items_url("missing")).mock(
+            return_value=httpx.Response(404, json={"error": "Specified Dataset not found"}))
+        with pytest.raises(NotFoundError):
+            list(datasets.items("missing"))
+
+
+class TestSchemas:
+    @respx.mock
+    def test_list_typed_org_scoped(self, datasets):
+        route = respx.get(_SCHEMAS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_schema(1), _schema(2)], "next": f"{_SCHEMAS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_schema(3)], "next": None}),
+        ])
+        got = list(datasets.schemas.list(ordering="id"))
+        assert [s.schema_id for s in got] == ["s1", "s2", "s3"]
+        assert all(isinstance(s, DatasetSchema) for s in got)
+        p = route.calls[0].request.url.params
+        assert "agent_id" not in p and p["ordering"] == "id"
+
+    @respx.mock
+    def test_get(self, datasets):
+        respx.get(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(200, json=_schema(1)))
+        s = datasets.schemas.get("s1")
+        assert isinstance(s, DatasetSchema) and s.fields == [{"key": "q", "type": "string"}]
+
+    @respx.mock
+    def test_create(self, datasets):
+        route = respx.post(_SCHEMAS).mock(return_value=httpx.Response(201, json=_schema(1)))
+        fields = [{"key": "question", "type": "string"}]
+        s = datasets.schemas.create("qa-schema", fields=fields)
+        assert isinstance(s, DatasetSchema) and s.schema_id == "s1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "qa-schema" and body["fields"] == fields
+        assert "description" not in body  # omit-None
+
+    @respx.mock
+    def test_create_with_description(self, datasets):
+        route = respx.post(_SCHEMAS).mock(return_value=httpx.Response(201, json=_schema(1)))
+        datasets.schemas.create("s", fields=[{"key": "q", "type": "string"}], description="d")
+        assert json.loads(route.calls.last.request.read())["description"] == "d"
+
+    @respx.mock
+    def test_create_duplicate_409(self, datasets):
+        respx.post(_SCHEMAS).mock(return_value=httpx.Response(
+            409, json={"error": "A schema named 's' already exists for this org."}))
+        with pytest.raises(ConflictError):
+            datasets.schemas.create("s", fields=[{"key": "q", "type": "string"}])
+
+    @respx.mock
+    def test_create_bad_field_400(self, datasets):
+        respx.post(_SCHEMAS).mock(return_value=httpx.Response(
+            400, json={"error": "Validation failed", "details": {"fields": ["categorical needs options"]}}))
+        with pytest.raises(ValidationError):
+            datasets.schemas.create("s", fields=[{"key": "c", "type": "categorical"}])
+
+    @respx.mock
+    def test_update_partial(self, datasets):
+        route = respx.put(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(200, json=_schema(1)))
+        s = datasets.schemas.update("s1", name="renamed")
+        assert isinstance(s, DatasetSchema)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed" and "fields" not in body and "description" not in body
+
+    @respx.mock
+    def test_update_rename_collision_409(self, datasets):
+        respx.put(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(
+            409, json={"error": "A schema with this name already exists for this org."}))
+        with pytest.raises(ConflictError):
+            datasets.schemas.update("s1", name="taken")
+
+    @respx.mock
+    def test_delete_204(self, datasets):
+        route = respx.delete(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(204))
+        assert datasets.schemas.delete("s1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_404(self, datasets):
+        respx.delete(f"{_SCHEMAS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified DatasetSchema not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.schemas.delete("missing")
+
+
+class TestFixtures:
+    @respx.mock
+    def test_create(self, datasets):
+        route = respx.post(_FIXTURES).mock(return_value=httpx.Response(201, json=_fixture()))
+        tables = [{"name": "users", "rows": [{"id": 1, "name": "a"}]}]
+        f = datasets.fixtures.create(resource_id="r1", dataset_id="d1", tables=tables)
+        assert isinstance(f, Fixture) and f.fixture_id == "f1"
+        assert f.status == "COMPLETED" and f.byte_size == 2048
+        body = json.loads(route.calls.last.request.read())
+        assert body["resource_id"] == "r1" and body["dataset_id"] == "d1"
+        assert body["tables"] == tables
+
+    @respx.mock
+    def test_create_duplicate_409(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(
+            409, json={"error": "A fixture already exists for this dataset and resource."}))
+        with pytest.raises(ConflictError):
+            datasets.fixtures.create(resource_id="r1", dataset_id="d1", tables=[])
+
+    @respx.mock
+    def test_create_validation_400(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(
+            400, json={"error": "Fixture validation failed", "details": {"users": ["unknown column"]}}))
+        with pytest.raises(ValidationError):
+            datasets.fixtures.create(resource_id="r1", dataset_id="d1",
+                                     tables=[{"name": "users", "rows": [{"bad": 1}]}])
+
+    @respx.mock
+    def test_create_unknown_resource_404(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(
+            404, json={"error": "Specified Resource not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.fixtures.create(resource_id="missing", dataset_id="d1", tables=[])
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aitems(self, datasets):
+        url = _items_url("d1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_item(1)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_item(2)], "next": None}),
+        ])
+        got = [i.datasetitem_id async for i in datasets.aitems("d1")]
+        assert got == ["it1", "it2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aschema_create(self, datasets):
+        respx.post(_SCHEMAS).mock(return_value=httpx.Response(201, json=_schema(1)))
+        s = await datasets.schemas.acreate("s", fields=[{"key": "q", "type": "string"}])
+        assert s.schema_id == "s1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aschema_delete(self, datasets):
+        route = respx.delete(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(204))
+        assert await datasets.schemas.adelete("s1") is None
+        assert route.called
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afixture_create(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(201, json=_fixture()))
+        f = await datasets.fixtures.acreate(resource_id="r1", dataset_id="d1", tables=[])
+        assert f.fixture_id == "f1"


### PR DESCRIPTION
Adds the v2 dataset surface to `DatasetResource`, consolidated under `client.datasets`. The gen-3 dataset/item CRUD is left untouched (the ticket says don't rebuild it); these are purely additive, data-bearing (no production swallow) methods.

## Surface
- `client.datasets.items(dataset_id, *, page_size=None)` → cursor-paginated `Iterator[DatasetItem]` (+ `items_page` / async). `GET /sdk/v2/datasets/{id}/items` (`dataset-item:read`). Read-only on v2 — item *create* stays on the gen-3 endpoint.
- `client.datasets.schemas` sub-namespace — full CRUD over org-scoped `DatasetSchema`s:
  - `list()` / `list_page()` (cursor, org-scoped, no `agent_id`), `get(id)`.
  - `create(name, *, fields, description=None)` → `POST /sdk/v2/datasets/schemas` (`dataset-schema:write`, 201). `fields` is a non-empty list of typed field defs (`{key, type, …}`); duplicate name → `ConflictError`; malformed field → `ValidationError`.
  - `update(id, *, name=None, description=None, fields=None)` (partial PUT; rename → `ConflictError`), `delete(id)` → 204 (`dataset-schema:delete`).
- `client.datasets.fixtures.create(*, resource_id, dataset_id, tables)` → `Fixture` — `POST /sdk/v2/fixtures` (`fixture:write`). Authors a base DuckDB fixture from JSON rows. **The backend field is `tables` = `[{name, rows}]`** (the ticket sketched it as `rows=…`; I followed the actual serializer). One fixture per `(dataset, resource)` → duplicate is `ConflictError`; row/spec mismatch → `ValidationError`; unknown resource/dataset → `NotFoundError`.
- All with async siblings.

## New / changed files
- `lucidicai/api/models/dataset.py` — typed `DatasetSchema` / `DatasetItem` / `Fixture` (match the backend serializer output keys: `schema_id` / `datasetitem_id` / `fixture_id` via `source=id`; `DatasetItem` has no `updated_at`; the fixture create response is a plain 4-key dict).
- `lucidicai/api/resources/dataset.py` — v2 `items*` methods + `schemas` / `fixtures` properties + the two new sub-resource classes (`DatasetSchemasResource`, `DatasetFixturesResource`).
- `tests/api/resources/test_datasets_v2.py` — 22 tests (items pagination/page_size/404, schemas list-org-scoped/get/create±desc/dup-409/bad-field-400/update-partial/rename-409/delete-204/404, fixtures create/dup-409/validation-400/404, sub-namespace wiring, async). 468 hermetic total pass.

## Verification (two-lens: skeptic + backend-contract, both on a freshly-fetched ref)
- **Contract: conforms exactly** — schema/item field parity with the serializers, scopes (`dataset-schema:*` / `dataset-item:read` / `fixture:write`), 201/200/204, 409s, 404s, and org-scoping (no `agent_id` sent anywhere).
- **Skeptic: no defects** — confirmed the `fields`-named dataclass attribute doesn't collide with `dataclasses.fields()`/`asdict()`, the v2 methods raise (don't swallow) while the gen-3 helpers keep their swallow, pagination is correct, and `fixtures.create` uses the right `tables` field.