### PR TITLE
LUC-919: client.sessions bulk finish

### DIFF
--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -469,6 +469,45 @@ class SessionResource:
             await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}/events/{event_id}", params)
         )
 
+    def finish(self, session_ids: List[str]) -> int:
+        """Bulk-finish sessions by id (POST /sdk/v2/sessions/finish; needs
+        ``session:write``). Idempotent and best-effort — unknown, cross-org,
+        already-finished, non-UUID, or (for an agent-bound key) other-agent ids are
+        silently skipped, and the call still succeeds. Finishing marks each session
+        finished, recomputes its status, and — when it has evaluators — kicks off
+        async evaluation/summarization. Unlike the single-session gen-3 ``update``,
+        this only closes sessions; it does not set per-session success/eval/tags.
+        Returns the number of sessions matched and finished.
+
+        Data-bearing write — raises the typed transport error (does not swallow),
+        unlike the gen-3 ``create``/``end`` above."""
+        resp = self.http.post("sdk/v2/sessions/finish", self._finish_body(session_ids))
+        return self._finished_count(resp)
+
+    async def afinish(self, session_ids: List[str]) -> int:
+        """Async sibling of ``finish``."""
+        resp = await self.http.apost("sdk/v2/sessions/finish", self._finish_body(session_ids))
+        return self._finished_count(resp)
+
+    @staticmethod
+    def _finish_body(session_ids: List[str]) -> Dict[str, Any]:
+        # Guard the bare-string footgun: finish("<uuid>") would list()-split the
+        # string into single-char ids the backend silently drops (→ a misleading 0).
+        # The sibling get()/end()/event() take a bare str, so this mistake is easy;
+        # fail loudly instead, matching _filter_params' TypeError discipline.
+        if isinstance(session_ids, (str, bytes)):
+            raise TypeError(
+                "session_ids must be a list of session ids, not a single string — "
+                "wrap it in a list, e.g. finish([session_id])."
+            )
+        return {"session_ids": list(session_ids)}
+
+    @staticmethod
+    def _finished_count(resp: Dict[str, Any]) -> int:
+        # `or 0` (not a .get default) so a present-but-null count degrades to 0
+        # rather than raising int(None).
+        return int(resp.get("num_sessions_finished") or 0)
+
     def update(self, session_id: str, **updates) -> Dict[str, Any]:
         """Update an existing session.
 

--- a/tests/api/resources/test_sessions_v2.py
+++ b/tests/api/resources/test_sessions_v2.py
@@ -1,5 +1,8 @@
 """LUC-907 — client.sessions v2 reads (list/count/tags, detail+trace,
-evaluator-results, event raw)."""
+evaluator-results, event raw).
+LUC-919 — client.sessions bulk finish."""
+import json
+
 import httpx
 import pytest
 import respx
@@ -13,7 +16,7 @@ from lucidicai.api.models.session import (
     SessionTrace,
 )
 from lucidicai.api.resources.session import SessionResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
 
 _BASE = "https://stub.lucidic.test"
 _SESSIONS = f"{_BASE}/sdk/v2/sessions"
@@ -264,3 +267,79 @@ class TestAsync:
             200, json={"event_id": "e1"}))
         ev = await sessions.aevent("s1", "e1")
         assert ev.event_id == "e1"
+
+
+class TestBulkFinish:
+    _FINISH = f"{_SESSIONS}/finish"
+
+    @respx.mock
+    def test_finish_returns_count_and_sends_ids(self, sessions):
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 2}))
+        n = sessions.finish(["s1", "s2", "s3"])
+        assert n == 2
+        body = json.loads(route.calls.last.request.read())
+        assert body["session_ids"] == ["s1", "s2", "s3"]
+        # bulk finish is ownership-scoped server-side — the client sends no agent_id
+        assert "agent_id" not in body
+
+    @respx.mock
+    def test_finish_empty_list_is_zero(self, sessions):
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 0}))
+        assert sessions.finish([]) == 0
+        assert json.loads(route.calls.last.request.read())["session_ids"] == []
+
+    @respx.mock
+    def test_finish_missing_count_defaults_zero(self, sessions):
+        respx.post(self._FINISH).mock(return_value=httpx.Response(200, json={}))
+        assert sessions.finish(["s1"]) == 0
+
+    @respx.mock
+    def test_finish_null_count_degrades_to_zero(self, sessions):
+        # a present-but-null count must not raise int(None)
+        respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": None}))
+        assert sessions.finish(["s1"]) == 0
+
+    @respx.mock
+    def test_finish_bare_string_raises_before_http(self, sessions):
+        # finish("s1") would char-split into single-char ids the backend drops -> a
+        # silent 0. Guard it loudly instead, with no request made.
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 0}))
+        with pytest.raises(TypeError):
+            sessions.finish("s1")
+        assert not route.called
+
+    @respx.mock
+    def test_finish_accepts_any_iterable(self, sessions):
+        # a generator/tuple is materialized into a list before sending
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 1}))
+        sessions.finish((sid for sid in ["s9"]))
+        assert json.loads(route.calls.last.request.read())["session_ids"] == ["s9"]
+
+    @respx.mock
+    def test_finish_not_a_list_400(self, sessions):
+        respx.post(self._FINISH).mock(return_value=httpx.Response(
+            400, json={"error": "session_ids must be a list of session ids"}))
+        # the SDK always sends a list, but a backend 400 surfaces as ValidationError
+        with pytest.raises(ValidationError):
+            sessions.finish(["s1"])
+
+    @respx.mock
+    def test_finish_forbidden_without_write_403(self, sessions):
+        respx.post(self._FINISH).mock(return_value=httpx.Response(
+            403, json={"error": "This API key is not authorized for this action."}))
+        with pytest.raises(InsufficientScopeError):
+            sessions.finish(["s1"])
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afinish(self, sessions):
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 5}))
+        n = await sessions.afinish(["s1", "s2"])
+        assert n == 5
+        assert json.loads(route.calls.last.request.read())["session_ids"] == ["s1", "s2"]


### PR DESCRIPTION
Adds bulk session-finish to `SessionResource` — the last C2 ticket.

## Surface
- `sessions.finish(session_ids)` → `int` (+ async `afinish`). `POST /sdk/v2/sessions/finish` (`session:write`), body `{"session_ids": [...]}`, returns the count `num_sessions_finished`. Idempotent and best-effort: unknown / cross-org / already-finished / non-UUID / (for an agent-bound key) other-agent ids are silently skipped server-side, and the call still succeeds. Ownership is enforced entirely server-side (org + optional bound-agent filter), so **no `agent_id` is sent**.
- Distinct from the gen-3 single-session `update` (which carries per-session success/eval/tags) — this only *closes* sessions by id. Data-bearing → raises the typed transport error (no production swallow), unlike the surrounding gen-3 `create`/`end`.

## Files
- `lucidicai/api/resources/session.py` — `finish`/`afinish` + `_finish_body` / `_finished_count` helpers.
- `tests/api/resources/test_sessions_v2.py` — 9 tests (count + ids sent, empty→0, missing-count→0, null-count→0, any-iterable, bare-string guard, 400/403 mapping, async).

## Verification (two-lens: skeptic + backend-contract, both on a fresh ref)
- **Contract: conforms exactly** — route/method, body key `session_ids`, response `num_sessions_finished`, scope `session:write` (not `session:finish`), 400/403 mapping, silent-skip semantics, no `agent_id`.
- **Skeptic hardening applied:**
  - **Bare-string footgun** — `finish("<uuid>")` would `list()`-char-split the string into single-char ids the backend drops (a silent `0`). Since sibling `get`/`end`/`event` take a bare str, this misuse is easy, so it now raises `TypeError` (matching the class's own `_filter_params` discipline) before any request.
  - **Null-safe count** — a present-but-null `num_sessions_finished` degrades to `0` instead of raising `int(None)`.

Closes the **C2 — Writes & lifecycle** milestone (LUC-912–919).