### PR TITLE
LUC-920: generic trigger-then-poll wait_for helper + training-modules refactor

### DIFF
--- a/lucidicai/api/polling.py
+++ b/lucidicai/api/polling.py
@@ -1,0 +1,85 @@
+"""Generic trigger-then-poll ``wait_for`` primitive (LUC-920).
+
+The reusable poll loop behind the SDK's async, workflow-backed resources (dataset
+generation, taxonomy / failure-modes, evosim runs, training-module inference). A
+resource triggers a backend workflow, then blocks on ``wait_for`` — polling a
+status callable on a fixed interval until it reports a terminal state or a deadline
+elapses.
+
+This owns only the loop mechanics (deadline, interval, optional pre-fetched initial
+state, final-sleep clamping). Terminal-state *interpretation* — which states are
+terminal, and whether a terminal state means success or failure — stays with the
+caller via ``is_terminal`` and its handling of the returned state.
+"""
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, TypeVar
+
+from ..core.errors import WaitTimeout
+
+T = TypeVar("T")
+
+# Distinguishes "no initial state supplied" from a legitimately falsy/None state.
+_UNSET: Any = object()
+
+
+def wait_for(
+    poll: Callable[[], T],
+    *,
+    is_terminal: Callable[[T], bool],
+    timeout: float,
+    interval: float,
+    initial: Any = _UNSET,
+) -> T:
+    """Poll ``poll()`` until ``is_terminal(state)`` is true or the ``timeout``
+    deadline elapses.
+
+    Returns the first terminal state. Raises :class:`WaitTimeout` (carrying the
+    last polled state) if the deadline elapses first. ``poll`` is called once up
+    front unless an ``initial`` state is supplied (e.g. a trigger response already
+    carries the first status), then once per ``interval`` thereafter. The final
+    sleep is clamped so polling never overshoots the deadline.
+
+    Args:
+        poll: Zero-arg callable returning the current state.
+        is_terminal: Predicate — true when a state should stop the loop.
+        timeout: Total budget in seconds (clamped to >= 0).
+        interval: Seconds to sleep between polls (clamped to >= 0). Note: ``0``
+            busy-polls with no delay between calls — pass a real interval (e.g.
+            a couple of seconds) for anything backed by a network status request.
+        initial: A state already in hand; when given, ``poll`` is not called until
+            after the first interval.
+    """
+    budget = max(0.0, timeout)
+    deadline = time.monotonic() + budget
+    state: T = poll() if initial is _UNSET else initial
+    while not is_terminal(state):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WaitTimeout(state, budget)
+        time.sleep(min(max(0.0, interval), remaining))
+        state = poll()
+    return state
+
+
+async def await_for(
+    poll: Callable[[], Awaitable[T]],
+    *,
+    is_terminal: Callable[[T], bool],
+    timeout: float,
+    interval: float,
+    initial: Any = _UNSET,
+) -> T:
+    """Async sibling of :func:`wait_for` — ``poll`` is an ``async`` callable and the
+    inter-poll wait uses ``asyncio.sleep``. Same semantics otherwise (including the
+    ``interval=0`` busy-poll caveat)."""
+    budget = max(0.0, timeout)
+    deadline = time.monotonic() + budget
+    state: T = (await poll()) if initial is _UNSET else initial
+    while not is_terminal(state):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WaitTimeout(state, budget)
+        await asyncio.sleep(min(max(0.0, interval), remaining))
+        state = await poll()
+    return state

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -8,6 +8,21 @@ class LucidicError(Exception):
     pass
 
 
+class WaitTimeout(LucidicError):
+    """Raised by the ``wait_for`` / ``await_for`` poll helpers (LUC-920) when a
+    trigger-then-poll workflow does not reach a terminal state before the deadline.
+
+    ``last_state`` is the most recently polled state (so a caller can still inspect
+    partial progress); ``timeout`` is the budget in seconds that elapsed.
+    """
+
+    def __init__(self, last_state: Any = None, timeout: Optional[float] = None):
+        self.last_state = last_state
+        self.timeout = timeout
+        detail = f" within {timeout:g}s" if timeout is not None else ""
+        super().__init__(f"Polling did not reach a terminal state{detail}.")
+
+
 # ---------------------------------------------------------------------------
 # HTTP / API errors (LUC-900)
 # ---------------------------------------------------------------------------

--- a/lucidicai/sdk/training_modules/resource.py
+++ b/lucidicai/sdk/training_modules/resource.py
@@ -4,15 +4,14 @@
 checkpoint-backed module tools. It hides backend inference-run bookkeeping
 on success and returns structured soft failures for agent-facing failures.
 """
-import asyncio
 import json
 import logging
-import time
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+from ...api.polling import await_for, wait_for
 from ...api.resources.training_modules import TrainingModulesAPIResource
-from ...core.errors import LucidicError
+from ...core.errors import LucidicError, WaitTimeout
 from ..context import current_session_id
 
 if TYPE_CHECKING:
@@ -22,6 +21,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger("Lucidic")
 
 ACTIVE_STATUSES = {"PENDING", "SUBMITTED", "RUNNING"}
+
+
+class _PollAbort(Exception):
+    """Carries a soft-failure result out of the poll closure (LUC-920 refactor).
+
+    The training-module mock-call contract never raises — a poll-time problem
+    (malformed response, transport error) degrades to a structured soft failure.
+    The generic ``wait_for`` loop can't produce those, so the poll closure raises
+    this to hand the already-built failure back for the caller to return."""
+
+    def __init__(self, failure: Dict[str, Any]):
+        self.failure = failure
+        super().__init__(failure.get("error", {}).get("code", "poll_abort"))
 
 
 class TrainingModulesResource:
@@ -355,37 +367,40 @@ class TrainingModulesResource:
         timeout_seconds: Optional[float],
         poll_interval_seconds: Optional[float],
     ) -> Any:
-        deadline = time.monotonic() + self._timeout(timeout_seconds)
-        interval = self._poll_interval(poll_interval_seconds)
+        box = {"run": run}
 
-        while run.get("status") in ACTIVE_STATUSES:
-            if time.monotonic() >= deadline:
-                return self._timeout_failure(run, timeout_seconds)
-            inference_run_id = run.get("inference_run_id")
+        def poll() -> Dict[str, Any]:
+            current = box["run"]
+            inference_run_id = current.get("inference_run_id")
             if not inference_run_id:
-                return self._soft_failure(
+                raise _PollAbort(self._soft_failure(
                     code="training_module_malformed_response",
                     message="Training Module inference response did not include inference_run_id.",
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
-            time.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
             try:
-                run = self._api.get_inference(
-                    inference_run_id=str(inference_run_id),
-                    session_id=session_id,
-                )
+                box["run"] = self._api.get_inference(
+                    inference_run_id=str(inference_run_id), session_id=session_id)
             except Exception as exc:
-                return self._soft_failure(
-                    code="training_module_poll_failed",
-                    message=str(exc),
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
+                raise _PollAbort(self._soft_failure(
+                    code="training_module_poll_failed", message=str(exc),
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
+            return box["run"]
 
-        return self._terminal_tool_result(run)
+        try:
+            final = wait_for(
+                poll,
+                is_terminal=lambda r: r.get("status") not in ACTIVE_STATUSES,
+                timeout=self._timeout(timeout_seconds),
+                interval=self._poll_interval(poll_interval_seconds),
+                initial=run,
+            )
+        except WaitTimeout as timed_out:
+            return self._timeout_failure(timed_out.last_state, timeout_seconds)
+        except _PollAbort as aborted:
+            return aborted.failure
+        return self._terminal_tool_result(final)
 
     async def _apoll_to_tool_result(
         self,
@@ -395,37 +410,40 @@ class TrainingModulesResource:
         timeout_seconds: Optional[float],
         poll_interval_seconds: Optional[float],
     ) -> Any:
-        deadline = time.monotonic() + self._timeout(timeout_seconds)
-        interval = self._poll_interval(poll_interval_seconds)
+        box = {"run": run}
 
-        while run.get("status") in ACTIVE_STATUSES:
-            if time.monotonic() >= deadline:
-                return self._timeout_failure(run, timeout_seconds)
-            inference_run_id = run.get("inference_run_id")
+        async def poll() -> Dict[str, Any]:
+            current = box["run"]
+            inference_run_id = current.get("inference_run_id")
             if not inference_run_id:
-                return self._soft_failure(
+                raise _PollAbort(self._soft_failure(
                     code="training_module_malformed_response",
                     message="Training Module inference response did not include inference_run_id.",
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
-            await asyncio.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
             try:
-                run = await self._api.aget_inference(
-                    inference_run_id=str(inference_run_id),
-                    session_id=session_id,
-                )
+                box["run"] = await self._api.aget_inference(
+                    inference_run_id=str(inference_run_id), session_id=session_id)
             except Exception as exc:
-                return self._soft_failure(
-                    code="training_module_poll_failed",
-                    message=str(exc),
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
+                raise _PollAbort(self._soft_failure(
+                    code="training_module_poll_failed", message=str(exc),
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
+            return box["run"]
 
-        return self._terminal_tool_result(run)
+        try:
+            final = await await_for(
+                poll,
+                is_terminal=lambda r: r.get("status") not in ACTIVE_STATUSES,
+                timeout=self._timeout(timeout_seconds),
+                interval=self._poll_interval(poll_interval_seconds),
+                initial=run,
+            )
+        except WaitTimeout as timed_out:
+            return self._timeout_failure(timed_out.last_state, timeout_seconds)
+        except _PollAbort as aborted:
+            return aborted.failure
+        return self._terminal_tool_result(final)
 
     def _terminal_tool_result(self, run: Dict[str, Any]) -> Any:
         status = run.get("status")

--- a/tests/api/test_polling.py
+++ b/tests/api/test_polling.py
@@ -1,0 +1,108 @@
+"""LUC-920 — the generic wait_for / await_for poll primitive."""
+import pytest
+
+from lucidicai.api.polling import await_for, wait_for
+from lucidicai.core.errors import LucidicError, WaitTimeout
+
+
+def _terminal(state):
+    return state == "done"
+
+
+class TestWaitForSync:
+    def test_returns_initial_without_polling_when_already_terminal(self):
+        def poll():
+            raise AssertionError("poll must not run when initial is terminal")
+        assert wait_for(poll, is_terminal=_terminal, timeout=5, interval=0,
+                        initial="done") == "done"
+
+    def test_polls_until_terminal(self):
+        states = iter(["running", "running", "done"])
+        calls = {"n": 0}
+
+        def poll():
+            calls["n"] += 1
+            return next(states)
+
+        # no initial -> poll() supplies the first state too
+        assert wait_for(poll, is_terminal=_terminal, timeout=5, interval=0) == "done"
+        assert calls["n"] == 3
+
+    def test_initial_supplied_skips_first_poll(self):
+        states = iter(["done"])
+        calls = {"n": 0}
+
+        def poll():
+            calls["n"] += 1
+            return next(states)
+
+        # initial is non-terminal, so exactly one poll is needed to reach "done"
+        assert wait_for(poll, is_terminal=_terminal, timeout=5, interval=0,
+                        initial="running") == "done"
+        assert calls["n"] == 1
+
+    def test_timeout_raises_with_last_state_and_budget(self):
+        def poll():
+            return "running"  # never terminal
+
+        with pytest.raises(WaitTimeout) as exc:
+            wait_for(poll, is_terminal=_terminal, timeout=0, interval=0, initial="running")
+        assert exc.value.last_state == "running"
+        assert exc.value.timeout == 0
+        assert isinstance(exc.value, LucidicError)  # catchable as a LucidicError
+
+    def test_timeout_last_state_is_most_recent_poll(self):
+        # no initial: the first poll runs, then the deadline (0) trips
+        def poll():
+            return "step-1"
+
+        with pytest.raises(WaitTimeout) as exc:
+            wait_for(poll, is_terminal=_terminal, timeout=0, interval=0)
+        assert exc.value.last_state == "step-1"
+
+    def test_negative_timeout_clamps_reported_budget_to_zero(self):
+        # a misused negative timeout raises immediately AND reports a sane budget
+        # (not "within -5s") — the deadline is clamped, so is the WaitTimeout.
+        def poll():
+            return "running"
+        with pytest.raises(WaitTimeout) as exc:
+            wait_for(poll, is_terminal=_terminal, timeout=-5, interval=0, initial="running")
+        assert exc.value.timeout == 0
+        assert "-5" not in str(exc.value)
+
+    def test_falsy_initial_state_is_honored_not_treated_as_unset(self):
+        # initial=None must NOT trigger a first poll (None != the _UNSET sentinel)
+        def poll():
+            raise AssertionError("poll must not run for a terminal None initial")
+        assert wait_for(poll, is_terminal=lambda s: s is None, timeout=5, interval=0,
+                        initial=None) is None
+
+
+class TestAwaitForAsync:
+    @pytest.mark.asyncio
+    async def test_returns_initial_when_terminal(self):
+        async def poll():
+            raise AssertionError("poll must not run when initial is terminal")
+        assert await await_for(poll, is_terminal=_terminal, timeout=5, interval=0,
+                               initial="done") == "done"
+
+    @pytest.mark.asyncio
+    async def test_polls_until_terminal(self):
+        states = iter(["running", "done"])
+        calls = {"n": 0}
+
+        async def poll():
+            calls["n"] += 1
+            return next(states)
+
+        assert await await_for(poll, is_terminal=_terminal, timeout=5, interval=0) == "done"
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises(self):
+        async def poll():
+            return "running"
+
+        with pytest.raises(WaitTimeout) as exc:
+            await await_for(poll, is_terminal=_terminal, timeout=0, interval=0, initial="running")
+        assert exc.value.last_state == "running"

--- a/tests/sdk/test_training_modules_poll.py
+++ b/tests/sdk/test_training_modules_poll.py
@@ -1,0 +1,107 @@
+"""Characterization tests for TrainingModulesResource's inference poll loop.
+
+These pin the observable behavior of ``_poll_to_tool_result`` /
+``_apoll_to_tool_result`` (terminal mapping, SDK timeout, malformed-response and
+poll-error soft failures, poll progression) so the LUC-920 refactor onto the
+generic ``wait_for`` primitive provably changes no behavior.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from lucidicai.sdk.training_modules.resource import TrainingModulesResource
+
+
+@pytest.fixture
+def tm():
+    # A MagicMock client is enough — we drive _api directly per test.
+    resource = TrainingModulesResource(client=MagicMock())
+    resource._api = MagicMock()
+    return resource
+
+
+def _run(status, **over):
+    d = {"status": status, "inference_run_id": "ir1", "tool_name": "t", "session_id": "sess"}
+    d.update(over)
+    return d
+
+
+def _poll(tm, run, *, timeout=5.0, interval=0.001):
+    return tm._poll_to_tool_result(
+        run, session_id="sess", timeout_seconds=timeout, poll_interval_seconds=interval)
+
+
+class TestTerminalMapping:
+    def test_initial_succeeded_unwraps_return_value(self, tm):
+        out = _poll(tm, _run("SUCCEEDED", result={"return_value": 42}))
+        assert out == 42
+        tm._api.get_inference.assert_not_called()  # already terminal, no poll
+
+    def test_succeeded_without_return_value_returns_result(self, tm):
+        out = _poll(tm, _run("SUCCEEDED", result={"other": "x"}))
+        assert out == {"other": "x"}
+
+    def test_failed_is_soft_failure(self, tm):
+        out = _poll(tm, _run("FAILED", error={"code": "x", "message": "bad"}))
+        assert out["error"]["message"] == "bad"
+
+    def test_timed_out_maps_to_code(self, tm):
+        out = _poll(tm, _run("TIMED_OUT"))
+        assert out["error"]["code"] == "training_module_inference_timed_out"
+
+    def test_cancelled_maps_to_code(self, tm):
+        out = _poll(tm, _run("CANCELLED"))
+        assert out["error"]["code"] == "training_module_inference_cancelled"
+
+    def test_unknown_terminal_status_maps_to_code(self, tm):
+        out = _poll(tm, _run("WEIRD"))
+        assert out["error"]["code"] == "training_module_inference_unknown_status"
+
+
+class TestPollProgression:
+    def test_polls_running_until_succeeded(self, tm):
+        tm._api.get_inference.side_effect = [
+            _run("RUNNING"), _run("SUCCEEDED", result={"return_value": "ok"})]
+        out = _poll(tm, _run("RUNNING"))
+        assert out == "ok"
+        assert tm._api.get_inference.call_count == 2
+
+    def test_poll_passes_inference_run_id_and_session(self, tm):
+        tm._api.get_inference.side_effect = [_run("SUCCEEDED", result={"return_value": 1})]
+        _poll(tm, _run("RUNNING", inference_run_id="ir-42"))
+        tm._api.get_inference.assert_called_once_with(inference_run_id="ir-42", session_id="sess")
+
+
+class TestFailurePaths:
+    def test_sdk_timeout_before_first_poll(self, tm):
+        out = _poll(tm, _run("RUNNING"), timeout=0)
+        assert out["error"]["code"] == "training_module_sdk_timeout"
+        tm._api.get_inference.assert_not_called()
+
+    def test_missing_inference_run_id_is_malformed(self, tm):
+        out = _poll(tm, _run("RUNNING", inference_run_id=None))
+        assert out["error"]["code"] == "training_module_malformed_response"
+        tm._api.get_inference.assert_not_called()  # never fetches without an id
+
+    def test_poll_exception_is_soft_failure(self, tm):
+        tm._api.get_inference.side_effect = RuntimeError("boom")
+        out = _poll(tm, _run("RUNNING"))
+        assert out["error"]["code"] == "training_module_poll_failed"
+        assert "boom" in out["error"]["message"]
+
+
+class TestAsyncParity:
+    @pytest.mark.asyncio
+    async def test_apoll_running_until_succeeded(self, tm):
+        async def _aget(*, inference_run_id, session_id):
+            return _run("SUCCEEDED", result={"return_value": "async-ok"})
+        tm._api.aget_inference = _aget
+        out = await tm._apoll_to_tool_result(
+            _run("RUNNING"), session_id="sess", timeout_seconds=5.0, poll_interval_seconds=0.001)
+        assert out == "async-ok"
+
+    @pytest.mark.asyncio
+    async def test_apoll_sdk_timeout(self, tm):
+        out = await tm._apoll_to_tool_result(
+            _run("RUNNING"), session_id="sess", timeout_seconds=0, poll_interval_seconds=0.001)
+        assert out["error"]["code"] == "training_module_sdk_timeout"


### PR DESCRIPTION
The C3 foundation — generalizes the one bespoke poll loop into a reusable primitive that the workflow-backed async resources (dataset generation, taxonomy/failure-modes, evosim runs) will share.

## New primitive — `api/polling.py`
- `wait_for(poll, *, is_terminal, timeout, interval, initial=...)` / `await_for` (sync + async): poll a status callable on a fixed interval until it reports a terminal state or the deadline elapses; returns the first terminal state, raises **`WaitTimeout`** (a `LucidicError` carrying `last_state`) on timeout. Owns only the loop mechanics — terminal *interpretation* (which states are terminal, success vs failure) stays with the caller.
- `WaitTimeout` added to `core/errors.py`.

## Refactor — `TrainingModulesResource` poll loop
`_poll_to_tool_result` / `_apoll_to_tool_result` (the existing bespoke `time.monotonic()` deadline loop — the one implementation the ticket names) now run on the primitive, carrying their soft-failures out through a private `_PollAbort` signal (the mock-call contract degrades to a soft failure, never raises). Removed the now-unused `time`/`asyncio` imports.

## No-behavior-change discipline
That loop had **zero test coverage**, so I wrote **13 characterization tests first**, confirmed they pass against the *original* code, then refactored and confirmed they still pass — the terminal mapping (SUCCEEDED/FAILED/TIMED_OUT/CANCELLED/unknown), SDK timeout, malformed-response and poll-error soft failures, and poll progression (call count + args) are all preserved.

## Files
- `lucidicai/api/polling.py` (new) — the primitive.
- `lucidicai/core/errors.py` — `WaitTimeout`.
- `lucidicai/sdk/training_modules/resource.py` — refactor + `_PollAbort` + import cleanup.
- `tests/api/test_polling.py` (new) — 10 unit tests for the primitive.
- `tests/sdk/test_training_modules_poll.py` (new) — 13 characterization tests. 500 hermetic total pass.

## Verification (two-lens: refactor-equivalence + primitive-correctness)
- **Equivalence: behavior-preserving** — all 7 enumerated paths produce identical observable outcomes (return value, soft-failure code/message/metadata, `get_inference` call count/args). The one divergence — the malformed-missing-id check now runs one interval later — yields a byte-identical failure and still never calls `get_inference`; judged acceptable (timing-only, in a should-never-happen path).
- **Primitive: sound** — `_UNSET` checked by identity (a falsy `initial` is honored), exact poll count, correct immediate-timeout boundary, clamped sleeps never overshoot, `last_state` always the most-recent poll. Applied its two low hardening notes: documented the `interval=0` busy-loop, and clamped the `WaitTimeout` budget so a misused negative timeout no longer reports "within -5s".