### PR TITLE
LUC-921: client.datasets generation (generate / status / retry + wait_for)

### DIFF
--- a/lucidicai/api/models/dataset.py
+++ b/lucidicai/api/models/dataset.py
@@ -53,3 +53,50 @@ class Fixture(APIModel):
     blob_key: Optional[str] = None
     byte_size: Optional[int] = None
     status: Optional[str] = None
+
+
+# Terminal generation statuses — the run is done (successfully or not) and polling
+# should stop. Everything else (queued / planning / hydrating_fixtures / generating
+# / ...) is ongoing. Mirrors the backend's DATASET_GEN_TERMINAL_STATUSES.
+_TERMINAL_GENERATION_STATUSES = frozenset({"completed", "failed"})
+
+
+@dataclass
+class DatasetGenerationRun(APIModel):
+    """A dataset-generation run — the async pipeline that fills a Dataset from a
+    schema + the experiment's trace taxonomy. The trigger / retry response populates
+    ``run_id`` / ``dataset_id`` / ``status`` / ``created_at``; the status endpoint
+    additionally reports progress (``items_generated`` / ``total_target``),
+    ``error_message`` (set when failed), and the source experiment / schema.
+
+    ``status`` is ongoing (``queued`` / ``planning`` / ``hydrating_fixtures`` /
+    ``generating`` / ...) or terminal (``completed`` = success, ``failed`` = read
+    ``error_message``). Use ``is_terminal`` / ``succeeded`` rather than comparing
+    the raw string.
+    """
+
+    run_id: str
+    dataset_id: Optional[str] = None
+    dataset_name: Optional[str] = None
+    status: Optional[str] = None
+    items_generated: Optional[int] = None
+    total_target: Optional[int] = None
+    error_message: Optional[str] = None
+    created_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    experiment_id: Optional[str] = None
+    experiment_name: Optional[str] = None
+    schema_id: Optional[str] = None
+    schema_name: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once the run has finished (``completed`` or ``failed``)."""
+        return self.status in _TERMINAL_GENERATION_STATUSES
+
+    @property
+    def succeeded(self) -> bool:
+        """True only for a ``completed`` run (a ``failed`` run is terminal but not
+        successful — read ``error_message``)."""
+        return self.status == "completed"

--- a/lucidicai/api/resources/dataset.py
+++ b/lucidicai/api/resources/dataset.py
@@ -4,13 +4,15 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
 from ..models.base import CursorPage
-from ..models.dataset import DatasetItem, DatasetSchema, Fixture
+from ..models.dataset import DatasetGenerationRun, DatasetItem, DatasetSchema, Fixture
 from ..pagination import apaginate, paginate
+from ..polling import await_for, wait_for
 
 logger = logging.getLogger("Lucidic")
 
 _SCHEMAS = "sdk/v2/datasets/schemas"
 _FIXTURES = "sdk/v2/fixtures"
+_GENERATE = "sdk/v2/datasets/generate"
 
 
 class DatasetResource:
@@ -99,6 +101,122 @@ class DatasetResource:
         if cursor:
             params["cursor"] = cursor
         return await self.http.aget(path, params or None)
+
+    # ==================== generation (LUC-921) ====================
+    #
+    # The async dataset-generation pipeline: trigger → poll → (retry). Trigger and
+    # retry kick off a Temporal workflow and return the run; status reads its
+    # progress; wait_for_generation blocks on the LUC-920 poll helper until the run
+    # is terminal. Org-scoped by the key; agent-bound via the run's experiment.
+
+    def generate(
+        self, *, agent_id: str, experiment_id: str, schema_id: str, dataset_name: str,
+        dataset_description: Optional[str] = None, target_count: Optional[int] = None,
+        combo_cap: Optional[int] = None, selected_dimension_ids: Optional[List[str]] = None,
+        resource_ids: Optional[List[str]] = None,
+    ) -> DatasetGenerationRun:
+        """Trigger dataset generation (POST /sdk/v2/datasets/generate; needs
+        ``dataset:generate``). Fills a new dataset from ``schema_id`` using the
+        ``experiment_id``'s trace taxonomy (the experiment must belong to
+        ``agent_id`` and have a completed taxonomy run). ``target_count`` (default
+        50, 1–500) and ``combo_cap`` (default 50, 1–200) bound the output; omit to
+        take the backend defaults. Returns the created run (``run_id`` +
+        ``dataset_id`` + initial ``"queued"`` status) — poll it with
+        ``generation_status`` / ``wait_for_generation``.
+
+        Raises ``ValidationError`` (bad refs / no taxonomy / unknown dimensions),
+        ``NotFoundError`` (agent / experiment / schema not visible to the key), or
+        ``ServiceUnavailableError`` (503 — the workflow couldn't start; retry)."""
+        return DatasetGenerationRun.from_dict(self.http.post(_GENERATE, self._generate_body(
+            agent_id, experiment_id, schema_id, dataset_name, dataset_description,
+            target_count, combo_cap, selected_dimension_ids, resource_ids)))
+
+    async def agenerate(
+        self, *, agent_id: str, experiment_id: str, schema_id: str, dataset_name: str,
+        dataset_description: Optional[str] = None, target_count: Optional[int] = None,
+        combo_cap: Optional[int] = None, selected_dimension_ids: Optional[List[str]] = None,
+        resource_ids: Optional[List[str]] = None,
+    ) -> DatasetGenerationRun:
+        """Async sibling of ``generate``."""
+        return DatasetGenerationRun.from_dict(await self.http.apost(_GENERATE, self._generate_body(
+            agent_id, experiment_id, schema_id, dataset_name, dataset_description,
+            target_count, combo_cap, selected_dimension_ids, resource_ids)))
+
+    def generation_status(self, run_id: str) -> DatasetGenerationRun:
+        """Read a generation run's status + progress (GET
+        /sdk/v2/datasets/generate/{run_id}/status; needs ``dataset:read``). Unknown
+        / cross-org / out-of-binding run → ``NotFoundError``."""
+        return DatasetGenerationRun.from_dict(self.http.get(f"{_GENERATE}/{run_id}/status"))
+
+    async def ageneration_status(self, run_id: str) -> DatasetGenerationRun:
+        """Async sibling of ``generation_status``."""
+        return DatasetGenerationRun.from_dict(await self.http.aget(f"{_GENERATE}/{run_id}/status"))
+
+    def retry_generation(self, run_id: str) -> DatasetGenerationRun:
+        """Retry a **failed** generation run (POST
+        /sdk/v2/datasets/generate/{run_id}/retry; needs ``dataset:generate``). Only
+        a run whose status is ``"failed"`` can be retried (else ``ValidationError``);
+        this clones a brand-new dataset + run (the failed one is left in place) and
+        returns the new run (new ``run_id`` / ``dataset_id``). May 503 like
+        ``generate``."""
+        return DatasetGenerationRun.from_dict(self.http.post(f"{_GENERATE}/{run_id}/retry"))
+
+    async def aretry_generation(self, run_id: str) -> DatasetGenerationRun:
+        """Async sibling of ``retry_generation``."""
+        return DatasetGenerationRun.from_dict(await self.http.apost(f"{_GENERATE}/{run_id}/retry"))
+
+    def wait_for_generation(
+        self, run_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> DatasetGenerationRun:
+        """Block until a generation run is terminal (``completed`` or ``failed``) or
+        ``timeout`` seconds elapse, polling ``generation_status`` every ``interval``
+        seconds. Returns the terminal run — inspect ``.succeeded`` / ``.status`` /
+        ``.error_message`` (a **failed** run is returned, not raised; retry it with
+        ``retry_generation``). Raises ``WaitTimeout`` if the deadline passes first.
+
+        The default ``timeout`` (30 min) matches the backend's own generation budget
+        so a full-length healthy run isn't cut off client-side; raise it only if that
+        server budget has been raised."""
+        return wait_for(
+            lambda: self.generation_status(run_id),
+            is_terminal=lambda run: run.is_terminal,
+            timeout=timeout, interval=interval,
+        )
+
+    async def await_for_generation(
+        self, run_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> DatasetGenerationRun:
+        """Async sibling of ``wait_for_generation``."""
+        return await await_for(
+            lambda: self.ageneration_status(run_id),
+            is_terminal=lambda run: run.is_terminal,
+            timeout=timeout, interval=interval,
+        )
+
+    @staticmethod
+    def _generate_body(
+        agent_id: str, experiment_id: str, schema_id: str, dataset_name: str,
+        dataset_description: Optional[str], target_count: Optional[int],
+        combo_cap: Optional[int], selected_dimension_ids: Optional[List[str]],
+        resource_ids: Optional[List[str]],
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "agent_id": agent_id, "experiment_id": experiment_id,
+            "schema_id": schema_id, "dataset_name": dataset_name,
+        }
+        # omit-None: let the backend apply its defaults (dataset_description="",
+        # target_count=50, combo_cap=50, selected_dimension_ids=[], resource_ids=[]).
+        if dataset_description is not None:
+            body["dataset_description"] = dataset_description
+        if target_count is not None:
+            body["target_count"] = target_count
+        if combo_cap is not None:
+            body["combo_cap"] = combo_cap
+        if selected_dimension_ids is not None:
+            body["selected_dimension_ids"] = selected_dimension_ids
+        if resource_ids is not None:
+            body["resource_ids"] = resource_ids
+        return body
 
     # ==================== Dataset Methods ====================
 

--- a/tests/api/resources/test_datasets_v2.py
+++ b/tests/api/resources/test_datasets_v2.py
@@ -5,17 +5,40 @@ import httpx
 import pytest
 import respx
 
-from lucidicai.api.models.dataset import DatasetItem, DatasetSchema, Fixture
+from lucidicai.api.models.dataset import (
+    DatasetGenerationRun,
+    DatasetItem,
+    DatasetSchema,
+    Fixture,
+)
 from lucidicai.api.resources.dataset import (
     DatasetResource,
     DatasetFixturesResource,
     DatasetSchemasResource,
 )
-from lucidicai.core.errors import ConflictError, NotFoundError, ValidationError
+from lucidicai.core.errors import (
+    ConflictError,
+    NotFoundError,
+    ServiceUnavailableError,
+    ValidationError,
+    WaitTimeout,
+)
 
 _BASE = "https://stub.lucidic.test"
 _SCHEMAS = f"{_BASE}/sdk/v2/datasets/schemas"
 _FIXTURES = f"{_BASE}/sdk/v2/fixtures"
+_GENERATE = f"{_BASE}/sdk/v2/datasets/generate"
+
+
+def _status_url(run_id):
+    return f"{_GENERATE}/{run_id}/status"
+
+
+def _gen_run(**over):
+    d = {"run_id": "run1", "dataset_id": "ds1", "status": "queued",
+         "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
 
 
 def _items_url(dataset_id):
@@ -234,3 +257,159 @@ class TestAsync:
         respx.post(_FIXTURES).mock(return_value=httpx.Response(201, json=_fixture()))
         f = await datasets.fixtures.acreate(resource_id="r1", dataset_id="d1", tables=[])
         assert f.fixture_id == "f1"
+
+
+# ==================== LUC-921 generation ====================
+
+
+class TestGenerationModel:
+    def test_terminal_and_succeeded_flags(self):
+        assert DatasetGenerationRun.from_dict(_gen_run(status="queued")).is_terminal is False
+        assert DatasetGenerationRun.from_dict(_gen_run(status="generating")).is_terminal is False
+        done = DatasetGenerationRun.from_dict(_gen_run(status="completed"))
+        assert done.is_terminal is True and done.succeeded is True
+        failed = DatasetGenerationRun.from_dict(_gen_run(status="failed", error_message="boom"))
+        assert failed.is_terminal is True and failed.succeeded is False
+        assert failed.error_message == "boom"
+
+
+class TestGenerate:
+    @respx.mock
+    def test_generate_required_fields_and_omit_none(self, datasets):
+        route = respx.post(_GENERATE).mock(return_value=httpx.Response(201, json=_gen_run()))
+        run = datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1",
+                                dataset_name="gen-1")
+        assert isinstance(run, DatasetGenerationRun)
+        assert run.run_id == "run1" and run.dataset_id == "ds1" and run.status == "queued"
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1" and body["experiment_id"] == "e1"
+        assert body["schema_id"] == "s1" and body["dataset_name"] == "gen-1"
+        # omit-None: unspecified optionals defer to the backend defaults
+        assert not any(k in body for k in
+                       ("dataset_description", "target_count", "combo_cap",
+                        "selected_dimension_ids", "resource_ids"))
+
+    @respx.mock
+    def test_generate_all_options(self, datasets):
+        route = respx.post(_GENERATE).mock(return_value=httpx.Response(201, json=_gen_run()))
+        datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1", dataset_name="g",
+                          dataset_description="d", target_count=100, combo_cap=20,
+                          selected_dimension_ids=["dim1"], resource_ids=["r1"])
+        body = json.loads(route.calls.last.request.read())
+        assert body["target_count"] == 100 and body["combo_cap"] == 20
+        assert body["selected_dimension_ids"] == ["dim1"] and body["resource_ids"] == ["r1"]
+        assert body["dataset_description"] == "d"
+
+    @respx.mock
+    def test_generate_503_service_unavailable(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1", dataset_name="g")
+
+    @respx.mock
+    def test_generate_no_taxonomy_400(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(
+            400, json={"error": "Experiment has no completed taxonomy run"}))
+        with pytest.raises(ValidationError):
+            datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1", dataset_name="g")
+
+    @respx.mock
+    def test_generate_unknown_agent_404(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(
+            404, json={"error": "Specified Agent not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.generate(agent_id="missing", experiment_id="e1", schema_id="s1", dataset_name="g")
+
+
+class TestGenerationStatus:
+    @respx.mock
+    def test_status_full_shape(self, datasets):
+        respx.get(_status_url("run1")).mock(return_value=httpx.Response(200, json=_gen_run(
+            status="generating", items_generated=12, total_target=50, dataset_name="g",
+            experiment_id="e1", schema_id="s1", config={"target_count": 50})))
+        run = datasets.generation_status("run1")
+        assert run.status == "generating" and run.items_generated == 12 and run.total_target == 50
+        assert run.is_terminal is False and run.config == {"target_count": 50}
+
+    @respx.mock
+    def test_status_404(self, datasets):
+        respx.get(_status_url("missing")).mock(return_value=httpx.Response(
+            404, json={"error": "Specified DatasetGenerationRun not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.generation_status("missing")
+
+
+class TestRetryGeneration:
+    @respx.mock
+    def test_retry_returns_new_run(self, datasets):
+        route = respx.post(f"{_GENERATE}/run1/retry").mock(
+            return_value=httpx.Response(201, json=_gen_run(run_id="run2", dataset_id="ds2")))
+        run = datasets.retry_generation("run1")
+        assert run.run_id == "run2" and run.dataset_id == "ds2"
+        assert route.called
+
+    @respx.mock
+    def test_retry_non_failed_400(self, datasets):
+        respx.post(f"{_GENERATE}/run1/retry").mock(return_value=httpx.Response(
+            400, json={"error": "Only failed runs can be retried"}))
+        with pytest.raises(ValidationError):
+            datasets.retry_generation("run1")
+
+
+class TestWaitForGeneration:
+    @respx.mock
+    def test_polls_until_completed(self, datasets):
+        respx.get(_status_url("run1")).mock(side_effect=[
+            httpx.Response(200, json=_gen_run(status="queued")),
+            httpx.Response(200, json=_gen_run(status="generating", items_generated=5)),
+            httpx.Response(200, json=_gen_run(status="completed", items_generated=50)),
+        ])
+        run = datasets.wait_for_generation("run1", timeout=30, interval=0)
+        assert run.succeeded is True and run.status == "completed" and run.items_generated == 50
+
+    @respx.mock
+    def test_failed_run_is_returned_not_raised(self, datasets):
+        respx.get(_status_url("run1")).mock(side_effect=[
+            httpx.Response(200, json=_gen_run(status="generating")),
+            httpx.Response(200, json=_gen_run(status="failed", error_message="llm error")),
+        ])
+        run = datasets.wait_for_generation("run1", timeout=30, interval=0)
+        assert run.is_terminal is True and run.succeeded is False
+        assert run.error_message == "llm error"
+
+    @respx.mock
+    def test_timeout_raises_wait_timeout(self, datasets):
+        respx.get(_status_url("run1")).mock(
+            return_value=httpx.Response(200, json=_gen_run(status="generating")))
+        with pytest.raises(WaitTimeout) as exc:
+            datasets.wait_for_generation("run1", timeout=0, interval=0)
+        assert exc.value.last_state.status == "generating"
+
+
+class TestGenerationAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_agenerate(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(201, json=_gen_run()))
+        run = await datasets.agenerate(agent_id="a1", experiment_id="e1", schema_id="s1",
+                                       dataset_name="g")
+        assert run.run_id == "run1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ageneration_status(self, datasets):
+        respx.get(_status_url("run1")).mock(return_value=httpx.Response(
+            200, json=_gen_run(status="completed")))
+        run = await datasets.ageneration_status("run1")
+        assert run.succeeded is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_await_for_generation(self, datasets):
+        respx.get(_status_url("run1")).mock(side_effect=[
+            httpx.Response(200, json=_gen_run(status="generating")),
+            httpx.Response(200, json=_gen_run(status="completed")),
+        ])
+        run = await datasets.await_for_generation("run1", timeout=30, interval=0)
+        assert run.succeeded is True


### PR DESCRIPTION
The first async trigger-then-poll consumer of the LUC-920 `wait_for` helper — the dataset-generation pipeline on `client.datasets`.

## Surface
- `datasets.generate(*, agent_id, experiment_id, schema_id, dataset_name, dataset_description=None, target_count=None, combo_cap=None, selected_dimension_ids=None, resource_ids=None)` → `DatasetGenerationRun` (POST `/sdk/v2/datasets/generate`, 201; `dataset:generate`). Triggers the Temporal pipeline; returns the created run (`run_id` + `dataset_id` + `"queued"`). The experiment must belong to the agent and have a completed taxonomy run. `target_count`/`combo_cap` omit-None to the backend defaults. Raises `ValidationError` (bad refs / no taxonomy), `NotFoundError`, or `ServiceUnavailableError` (503 — workflow couldn't start; retry).
- `datasets.generation_status(run_id)` → `DatasetGenerationRun` with progress (`items_generated`/`total_target`), `error_message`, source experiment/schema (`dataset:read`).
- `datasets.retry_generation(run_id)` → clones a **brand-new** dataset+run from a **failed** one (returns the new ids); non-failed → `ValidationError` (`dataset:generate`).
- `datasets.wait_for_generation(run_id, *, timeout=1800, interval=3)` → blocks on `wait_for` until the run is terminal (`completed`/`failed`), then **returns** it. Inspect `.succeeded`/`.status`/`.error_message` — a **failed** run is returned, not raised (use `retry_generation`); only `WaitTimeout` raises. The default timeout matches the backend's 30-min generation budget.
- All with async siblings.

## Files
- `lucidicai/api/models/dataset.py` — `DatasetGenerationRun` (14 fields matching `_serialize_run`) + `is_terminal`/`succeeded` props; `_TERMINAL_GENERATION_STATUSES = {completed, failed}`.
- `lucidicai/api/resources/dataset.py` — the generation methods + `_generate_body`.
- `tests/api/resources/test_datasets_v2.py` — 16 tests (generate required/all-options/503/400/404, status shape/404, retry new-run/not-failed-400, wait_for poll-until-complete / failed-returns-not-raises / timeout, model flags, async). 516 hermetic total pass.

## Verification (two-lens: skeptic + backend-contract, both on a fresh ref)
- **Contract: conforms exactly** — generate body field names/bounds/defaults, the 14-key status response, retry semantics, scopes, and the no-409 status-code contract. **Critical check clean:** the SDK's terminal set `{completed, failed}` exactly matches the backend's `DATASET_GEN_TERMINAL_STATUSES`, with all 7 ongoing statuses non-terminal — so `wait_for` neither stops early nor hangs.
- **Skeptic finding applied:** the default wait `timeout` was **600s**, below the backend's 30-min (`DATASET_GEN_HARD_STOP_SECONDS=1800`) generation budget — a long-but-healthy run would raise `WaitTimeout` client-side prematurely. Raised the default to **1800s** and documented the relationship.