### PR TITLE
LUC-922: client.experiments taxonomy + failure-modes (async)

### DIFF
--- a/lucidicai/api/models/experiment.py
+++ b/lucidicai/api/models/experiment.py
@@ -35,3 +35,18 @@ class Experiment(APIModel):
     num_events_data_by_tag: Optional[Dict[str, Any]] = None
     event_failure_groups: List[Dict[str, Any]] = field(default_factory=list)
     analytics_session_count: Optional[int] = None
+
+
+@dataclass
+class FailureGroup(APIModel):
+    """One clustered failure mode in an experiment (LUC-922) — a named group of
+    failing events, produced by ``experiments.generate_failure_modes`` and read
+    back via ``experiments.failure_groups``. ``events`` is a list of
+    ``{event_id, session_id}``. Keyed by ``id`` (the backend serializes it plain,
+    not as ``failure_group_id``)."""
+
+    id: str
+    group_name: Optional[str] = None
+    group_description: Optional[str] = None
+    icon: Optional[str] = None
+    events: List[Dict[str, Any]] = field(default_factory=list)

--- a/lucidicai/api/models/taxonomy.py
+++ b/lucidicai/api/models/taxonomy.py
@@ -1,0 +1,50 @@
+"""Typed response models for client.experiments.taxonomy (LUC-922)."""
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class TaxonomyRun(APIModel):
+    """A trace-taxonomy run for an experiment. The trigger / ongoing shape carries
+    ``run_id`` / ``version`` / ``status`` / ``created_at``; the completed read
+    (``taxonomy.get``) adds ``completed_at`` and the ``taxonomy`` dimensions output.
+    ``status`` is ongoing (``queued`` / ``sampling`` / ``discovering_dimensions`` /
+    ... ) or terminal (``completed`` / ``failed``)."""
+
+    run_id: str
+    version: Optional[int] = None
+    status: Optional[str] = None
+    created_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    taxonomy: Optional[Any] = None
+
+
+@dataclass
+class TaxonomyStatus(APIModel):
+    """The poll target for taxonomy generation (``GET .../taxonomy/status``): the
+    experiment's in-flight run (``ongoing``, null when none) and its latest completed
+    taxonomy (``latest_completed``, null until one finishes). Terminal once no run is
+    ongoing — a run either completes (into ``latest_completed``) or fails (clears
+    ``ongoing`` without updating ``latest_completed``)."""
+
+    ongoing: Optional[TaxonomyRun] = None
+    latest_completed: Optional[TaxonomyRun] = None
+    evaluating_session_count: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data):
+        obj = super().from_dict(data)
+        # The two nested run objects arrive as raw dicts — type them.
+        for attr in ("ongoing", "latest_completed"):
+            value = getattr(obj, attr, None)
+            if isinstance(value, dict):
+                setattr(obj, attr, TaxonomyRun.from_dict(value))
+        return obj
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once no taxonomy run is in progress (the triggered run finished —
+        successfully into ``latest_completed`` or by failing out of ``ongoing``)."""
+        return self.ongoing is None

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -5,8 +5,10 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.evaluator import Evaluator
-from ..models.experiment import Experiment
+from ..models.experiment import Experiment, FailureGroup
+from ..models.taxonomy import TaxonomyRun, TaxonomyStatus
 from ..pagination import apaginate, paginate
+from ..polling import await_for, wait_for
 from ...core.errors import require_agent_id
 
 logger = logging.getLogger("Lucidic")
@@ -31,10 +33,11 @@ class ExperimentResource:
         self.http = http
         self._agent_id = agent_id
         self._production = production
-        # client.experiments.evaluators — attach/detach/list evaluators on an
-        # experiment. Stateless (experiment id is passed per call), so one instance
-        # is reused across calls.
+        # Sub-namespaces (stateless — experiment id passed per call, one instance each).
+        # client.experiments.evaluators — attach/detach/list evaluators (LUC-915).
         self._evaluators = ExperimentEvaluatorsResource(http)
+        # client.experiments.taxonomy — trace-taxonomy generation (LUC-922).
+        self._taxonomy = ExperimentTaxonomyResource(http)
 
     @property
     def evaluators(self) -> "ExperimentEvaluatorsResource":
@@ -42,6 +45,14 @@ class ExperimentResource:
         ``client.experiments.evaluators.attach(experiment_id, ["accuracy"])`` /
         ``.list(experiment_id)`` / ``.detach(experiment_id, evaluator_id)``."""
         return self._evaluators
+
+    @property
+    def taxonomy(self) -> "ExperimentTaxonomyResource":
+        """Trace-taxonomy generation on an experiment — e.g.
+        ``client.experiments.taxonomy.generate(experiment_id)`` /
+        ``.status(experiment_id)`` / ``.wait_for(experiment_id)`` /
+        ``.get(experiment_id)``."""
+        return self._taxonomy
 
     def create(
         self,
@@ -211,6 +222,40 @@ class ExperimentResource:
             f"sdk/v2/experiments/{experiment_id}", data={"delete_sessions": delete_sessions}
         )
 
+    # ==================== failure modes (LUC-922) ====================
+    #
+    # Async failure-mode analysis: generate_failure_modes triggers a Temporal run
+    # (fire-and-forget — there is NO status endpoint), failure_groups reads the
+    # result. Data-bearing → no production swallow. Each has an async sibling.
+    # (Taxonomy generation is the client.experiments.taxonomy sub-namespace.)
+
+    def generate_failure_modes(self, experiment_id: str) -> None:
+        """Trigger failure-mode analysis for an experiment (POST
+        /sdk/v2/experiments/{id}/failure-modes; needs ``failure-group:generate``).
+        Clears the prior groups and recomputes them asynchronously; poll
+        ``failure_groups`` for the result. Note there is **no status endpoint** — an
+        experiment with no failures completes with zero groups, so treat a persistently
+        empty list as "no failure modes found", not "still running". Needs at least one
+        session (→ ``ValidationError``). May raise ``ServiceUnavailableError`` (503) if
+        the calculation can't start — retry."""
+        self.http.post(f"sdk/v2/experiments/{experiment_id}/failure-modes")
+
+    async def agenerate_failure_modes(self, experiment_id: str) -> None:
+        """Async sibling of ``generate_failure_modes``."""
+        await self.http.apost(f"sdk/v2/experiments/{experiment_id}/failure-modes")
+
+    def failure_groups(self, experiment_id: str) -> List[FailureGroup]:
+        """Read an experiment's failure-mode groups (GET
+        /sdk/v2/experiments/{id}/failure-groups; needs ``failure-group:read``) — the
+        result of ``generate_failure_modes``. Not paginated (returns the full set)."""
+        resp = self.http.get(f"sdk/v2/experiments/{experiment_id}/failure-groups")
+        return FailureGroup.from_list(resp.get("event_failure_groups", []))
+
+    async def afailure_groups(self, experiment_id: str) -> List[FailureGroup]:
+        """Async sibling of ``failure_groups``."""
+        resp = await self.http.aget(f"sdk/v2/experiments/{experiment_id}/failure-groups")
+        return FailureGroup.from_list(resp.get("event_failure_groups", []))
+
     # ---- internals ----
 
     def _list_params(
@@ -323,3 +368,105 @@ class ExperimentEvaluatorsResource:
         if cursor:
             params["cursor"] = cursor
         return await self.http.aget(path, params or None)
+
+
+class ExperimentTaxonomyResource:
+    """``client.experiments.taxonomy`` — trace-taxonomy generation (LUC-922).
+
+    Trigger a taxonomy run over an experiment's finished sessions, read the latest
+    completed taxonomy, and poll generation to completion. A taxonomy is the required
+    input to dataset generation (``client.datasets.generate``). The experiment id is
+    passed per call. Data-bearing → no production swallow. Each method has an async
+    sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def _base(self, experiment_id: str) -> str:
+        return f"sdk/v2/experiments/{experiment_id}/taxonomy"
+
+    def generate(
+        self, experiment_id: str, *,
+        seed_dimensions: Optional[List[Dict[str, Any]]] = None,
+        use_previous: Optional[bool] = None,
+    ) -> TaxonomyRun:
+        """Trigger a taxonomy run (POST /sdk/v2/experiments/{id}/taxonomy; needs
+        ``taxonomy:generate``). ``seed_dimensions`` (≤20 ``{name, description?}``) and
+        ``use_previous`` (warm-start from the last completed run) are optional. Needs
+        ≥20 finished sessions (→ ``ValidationError``) and no run already in progress
+        (→ ``ConflictError``). Returns the created run (``run_id`` + ``"queued"``
+        status). May raise ``ServiceUnavailableError`` (503) — retry."""
+        return TaxonomyRun.from_dict(
+            self.http.post(self._base(experiment_id), self._generate_body(seed_dimensions, use_previous)))
+
+    async def agenerate(
+        self, experiment_id: str, *,
+        seed_dimensions: Optional[List[Dict[str, Any]]] = None,
+        use_previous: Optional[bool] = None,
+    ) -> TaxonomyRun:
+        """Async sibling of ``generate``."""
+        return TaxonomyRun.from_dict(
+            await self.http.apost(self._base(experiment_id), self._generate_body(seed_dimensions, use_previous)))
+
+    def get(self, experiment_id: str) -> TaxonomyRun:
+        """Read the latest **completed** taxonomy (GET /sdk/v2/experiments/{id}/
+        taxonomy; needs ``taxonomy:read``) — its dimensions are in ``.taxonomy``.
+        Raises ``NotFoundError`` until a run has completed (in-flight state isn't
+        surfaced here — use ``status`` / ``wait_for``)."""
+        return TaxonomyRun.from_dict(self.http.get(self._base(experiment_id)))
+
+    async def aget(self, experiment_id: str) -> TaxonomyRun:
+        """Async sibling of ``get``."""
+        return TaxonomyRun.from_dict(await self.http.aget(self._base(experiment_id)))
+
+    def status(self, experiment_id: str) -> TaxonomyStatus:
+        """Read taxonomy generation status (GET /sdk/v2/experiments/{id}/taxonomy/
+        status; needs ``taxonomy:read``) — the ``ongoing`` run (if any) and the
+        ``latest_completed`` taxonomy."""
+        return TaxonomyStatus.from_dict(self.http.get(f"{self._base(experiment_id)}/status"))
+
+    async def astatus(self, experiment_id: str) -> TaxonomyStatus:
+        """Async sibling of ``status``."""
+        return TaxonomyStatus.from_dict(await self.http.aget(f"{self._base(experiment_id)}/status"))
+
+    def wait_for(
+        self, experiment_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> TaxonomyStatus:
+        """Block until no taxonomy run is in progress (or ``timeout`` elapses),
+        polling ``status`` every ``interval`` seconds. Call this after ``generate``.
+        Returns the terminal ``TaxonomyStatus``.
+
+        To tell whether **your** run succeeded, compare the returned
+        ``.latest_completed.run_id`` (or ``.version``) against the run ``generate``
+        returned: on success they match. A **failed** run clears ``.ongoing`` without
+        updating ``.latest_completed`` — so ``.latest_completed`` is then either a
+        *prior* completed taxonomy (a run_id/version that is NOT yours — do not treat
+        it as your result, and don't feed its stale dimensions into
+        ``datasets.generate``) or ``None`` (no taxonomy ever completed). The failure
+        reason itself isn't exposed by this endpoint. Raises ``WaitTimeout`` if the
+        deadline passes first."""
+        return wait_for(
+            lambda: self.status(experiment_id),
+            is_terminal=lambda s: s.is_terminal, timeout=timeout, interval=interval)
+
+    async def await_for(
+        self, experiment_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> TaxonomyStatus:
+        """Async sibling of ``wait_for``."""
+        return await await_for(
+            lambda: self.astatus(experiment_id),
+            is_terminal=lambda s: s.is_terminal, timeout=timeout, interval=interval)
+
+    @staticmethod
+    def _generate_body(
+        seed_dimensions: Optional[List[Dict[str, Any]]], use_previous: Optional[bool]
+    ) -> Dict[str, Any]:
+        # omit-None: both fields are optional (backend defaults seed_dimensions=[],
+        # use_previous=False).
+        body: Dict[str, Any] = {}
+        if seed_dimensions is not None:
+            body["seed_dimensions"] = seed_dimensions
+        if use_previous is not None:
+            body["use_previous"] = use_previous
+        return body

--- a/tests/api/resources/test_experiments_v2.py
+++ b/tests/api/resources/test_experiments_v2.py
@@ -1,5 +1,6 @@
 """LUC-908 — client.experiments reads (list / count / get).
-LUC-915 — client.experiments writes (delete + evaluators attach/detach/list)."""
+LUC-915 — client.experiments writes (delete + evaluators attach/detach/list).
+LUC-922 — client.experiments taxonomy + failure-modes (async, trigger-then-poll)."""
 import json
 
 import httpx
@@ -7,9 +8,17 @@ import pytest
 import respx
 
 from lucidicai.api.models.evaluator import Evaluator
-from lucidicai.api.models.experiment import Experiment
-from lucidicai.api.resources.experiment import ExperimentResource
-from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
+from lucidicai.api.models.experiment import Experiment, FailureGroup
+from lucidicai.api.models.taxonomy import TaxonomyRun, TaxonomyStatus
+from lucidicai.api.resources.experiment import ExperimentResource, ExperimentTaxonomyResource
+from lucidicai.core.errors import (
+    ConflictError,
+    InsufficientScopeError,
+    NotFoundError,
+    ServiceUnavailableError,
+    ValidationError,
+    WaitTimeout,
+)
 
 _BASE = "https://stub.lucidic.test"
 _EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
@@ -17,6 +26,38 @@ _EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
 
 def _evals_url(xid):
     return f"{_EXPERIMENTS}/{xid}/evaluators"
+
+
+def _tax_url(xid):
+    return f"{_EXPERIMENTS}/{xid}/taxonomy"
+
+
+def _tax_run(**over):
+    d = {"run_id": "tr1", "version": 1, "status": "queued", "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _tax_status(**over):
+    d = {"ongoing": None, "latest_completed": None, "evaluating_session_count": 0}
+    d.update(over)
+    return d
+
+
+def _tax_completed(**over):
+    # The status endpoint's latest_completed carries NO status field (unlike a run) —
+    # {run_id, version, created_at, completed_at}. Keep the fixture faithful.
+    d = {"run_id": "tr1", "version": 1, "created_at": "2026-07-22T00:00:00Z",
+         "completed_at": "2026-07-22T01:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _fgroup(i, **over):
+    d = {"id": f"fg{i}", "group_name": f"group-{i}", "group_description": "",
+         "icon": "warn", "events": [{"event_id": "e1", "session_id": "s1"}]}
+    d.update(over)
+    return d
 
 
 @pytest.fixture
@@ -260,3 +301,184 @@ class TestWriteAsync:
         ])
         got = [e.evaluator_id async for e in experiments.evaluators.alist("x1")]
         assert got == ["e1", "e2"]
+
+
+# ==================== LUC-922 taxonomy + failure-modes ====================
+
+
+class TestWiring:
+    def test_taxonomy_subnamespace_resolves(self, experiments):
+        assert isinstance(experiments.taxonomy, ExperimentTaxonomyResource)
+
+
+class TestTaxonomyModel:
+    def test_status_types_nested_runs_and_is_terminal(self):
+        # ongoing present -> not terminal, nested runs typed
+        st = TaxonomyStatus.from_dict(_tax_status(
+            ongoing=_tax_run(status="sampling"), latest_completed=_tax_completed(run_id="tr0", version=0)))
+        assert st.is_terminal is False
+        assert isinstance(st.ongoing, TaxonomyRun) and st.ongoing.status == "sampling"
+        assert isinstance(st.latest_completed, TaxonomyRun) and st.latest_completed.run_id == "tr0"
+
+    def test_status_no_ongoing_is_terminal(self):
+        st = TaxonomyStatus.from_dict(_tax_status(latest_completed=_tax_completed()))
+        assert st.is_terminal is True and st.ongoing is None
+        assert isinstance(st.latest_completed, TaxonomyRun)
+
+
+class TestTaxonomyGenerate:
+    @respx.mock
+    def test_generate_empty_body_and_typed(self, experiments):
+        route = respx.post(_tax_url("x1")).mock(return_value=httpx.Response(201, json=_tax_run()))
+        run = experiments.taxonomy.generate("x1")
+        assert isinstance(run, TaxonomyRun) and run.run_id == "tr1" and run.status == "queued"
+        body = json.loads(route.calls.last.request.read())
+        assert "seed_dimensions" not in body and "use_previous" not in body  # omit-None
+
+    @respx.mock
+    def test_generate_with_seeds_and_use_previous(self, experiments):
+        route = respx.post(_tax_url("x1")).mock(return_value=httpx.Response(201, json=_tax_run()))
+        seeds = [{"name": "tone", "description": "d"}]
+        experiments.taxonomy.generate("x1", seed_dimensions=seeds, use_previous=True)
+        body = json.loads(route.calls.last.request.read())
+        assert body["seed_dimensions"] == seeds and body["use_previous"] is True
+
+    @respx.mock
+    def test_generate_too_few_sessions_400(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(
+            400, json={"error": "Need at least 20 finished sessions, found 3"}))
+        with pytest.raises(ValidationError):
+            experiments.taxonomy.generate("x1")
+
+    @respx.mock
+    def test_generate_already_running_409(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(
+            409, json={"error": "A taxonomy run is already in progress", "ongoing_run_id": "tr9"}))
+        with pytest.raises(ConflictError):
+            experiments.taxonomy.generate("x1")
+
+    @respx.mock
+    def test_generate_503(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            experiments.taxonomy.generate("x1")
+
+
+class TestTaxonomyGetStatus:
+    @respx.mock
+    def test_get_completed_taxonomy(self, experiments):
+        respx.get(_tax_url("x1")).mock(return_value=httpx.Response(200, json=_tax_run(
+            status=None, completed_at="2026-07-22T01:00:00Z", taxonomy={"dimensions": []})))
+        run = experiments.taxonomy.get("x1")
+        assert run.taxonomy == {"dimensions": []} and run.completed_at is not None
+
+    @respx.mock
+    def test_get_404_until_completed(self, experiments):
+        respx.get(_tax_url("x1")).mock(return_value=httpx.Response(
+            404, json={"error": "Specified CompletedTaxonomyRun not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.taxonomy.get("x1")
+
+    @respx.mock
+    def test_status_typed(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(return_value=httpx.Response(
+            200, json=_tax_status(ongoing=_tax_run(status="validating"), evaluating_session_count=4)))
+        st = experiments.taxonomy.status("x1")
+        assert isinstance(st, TaxonomyStatus) and st.evaluating_session_count == 4
+        assert st.ongoing.status == "validating" and st.is_terminal is False
+
+
+class TestTaxonomyWaitFor:
+    @respx.mock
+    def test_polls_until_no_ongoing(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(side_effect=[
+            httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="queued"))),
+            httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="validating"))),
+            httpx.Response(200, json=_tax_status(latest_completed=_tax_completed(run_id="tr1"))),
+        ])
+        st = experiments.taxonomy.wait_for("x1", timeout=30, interval=0)
+        assert st.is_terminal is True and st.ongoing is None
+        # latest_completed carries no status field from the backend — match on run_id
+        assert st.latest_completed.run_id == "tr1" and st.latest_completed.status is None
+
+    @respx.mock
+    def test_timeout_raises(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(
+            return_value=httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="sampling"))))
+        with pytest.raises(WaitTimeout) as exc:
+            experiments.taxonomy.wait_for("x1", timeout=0, interval=0)
+        assert exc.value.last_state.ongoing.status == "sampling"
+
+
+class TestFailureModes:
+    @respx.mock
+    def test_generate_failure_modes_returns_none(self, experiments):
+        route = respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(
+            return_value=httpx.Response(202, json={"experiment_id": "x1", "status": "started"}))
+        assert experiments.generate_failure_modes("x1") is None
+        assert route.called
+
+    @respx.mock
+    def test_generate_failure_modes_no_sessions_400(self, experiments):
+        respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(return_value=httpx.Response(
+            400, json={"error": "No sessions found in experiment"}))
+        with pytest.raises(ValidationError):
+            experiments.generate_failure_modes("x1")
+
+    @respx.mock
+    def test_generate_failure_modes_503(self, experiments):
+        respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            experiments.generate_failure_modes("x1")
+
+    @respx.mock
+    def test_failure_groups_unwraps_typed_list(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1/failure-groups").mock(return_value=httpx.Response(
+            200, json={"event_failure_groups": [_fgroup(1), _fgroup(2)]}))
+        groups = experiments.failure_groups("x1")
+        assert [g.id for g in groups] == ["fg1", "fg2"]
+        assert all(isinstance(g, FailureGroup) for g in groups)
+        assert groups[0].events == [{"event_id": "e1", "session_id": "s1"}]
+
+    @respx.mock
+    def test_failure_groups_empty(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1/failure-groups").mock(
+            return_value=httpx.Response(200, json={"event_failure_groups": []}))
+        assert experiments.failure_groups("x1") == []
+
+
+class TestTaxonomyFailureAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_agenerate(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(201, json=_tax_run()))
+        run = await experiments.taxonomy.agenerate("x1")
+        assert run.run_id == "tr1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_await_for(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(side_effect=[
+            httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="sampling"))),
+            httpx.Response(200, json=_tax_status(latest_completed=_tax_completed())),
+        ])
+        st = await experiments.taxonomy.await_for("x1", timeout=30, interval=0)
+        assert st.is_terminal is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afailure_groups(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1/failure-groups").mock(return_value=httpx.Response(
+            200, json={"event_failure_groups": [_fgroup(1)]}))
+        groups = await experiments.afailure_groups("x1")
+        assert groups[0].id == "fg1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_agenerate_failure_modes(self, experiments):
+        route = respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(
+            return_value=httpx.Response(202, json={"experiment_id": "x1", "status": "started"}))
+        assert await experiments.agenerate_failure_modes("x1") is None
+        assert route.called


### PR DESCRIPTION
Two more trigger-then-poll shapes on `client.experiments`, reusing the LUC-920 `wait_for` helper.

## `client.experiments.taxonomy` sub-namespace
- `generate(id, *, seed_dimensions=None, use_previous=None)` → `TaxonomyRun` (POST `.../taxonomy`, 201; `taxonomy:generate`). Needs ≥20 finished sessions (→ `ValidationError`); a run already in progress → `ConflictError`; may `ServiceUnavailableError` (503).
- `get(id)` → the latest **completed** taxonomy (its dimensions in `.taxonomy`); `NotFoundError` until one completes (`taxonomy:read`).
- `status(id)` → `TaxonomyStatus` (`{ongoing, latest_completed, evaluating_session_count}`).
- `wait_for(id, *, timeout=1800, interval=3)` → blocks until no run is `ongoing`, returns the terminal `TaxonomyStatus`.
- New `TaxonomyRun` / `TaxonomyStatus` models — the status model types its nested `ongoing`/`latest_completed` runs and exposes `is_terminal` (`ongoing is None`).

## Flat on `client.experiments`
- `generate_failure_modes(id)` → `None` (POST `.../failure-modes`, 202; `failure-group:generate`, may 503). Needs ≥1 session.
- `failure_groups(id)` → `List[FailureGroup]` (GET `.../failure-groups`, `failure-group:read`, unpaginated).
- **No `wait_for` for failure modes** — the backend has no failure-modes status endpoint, and an experiment with no failures legitimately completes with zero groups, so a poller can't reliably detect completion (documented on the trigger). New `FailureGroup` model (keyed on `id`, not `failure_group_id`, to match the serializer).

All with async siblings.

## Files
- `lucidicai/api/models/taxonomy.py` (new) — `TaxonomyRun` / `TaxonomyStatus`.
- `lucidicai/api/models/experiment.py` — `FailureGroup`.
- `lucidicai/api/resources/experiment.py` — the `taxonomy` sub-namespace + failure-mode methods.
- `tests/api/resources/test_experiments_v2.py` — 22 tests. 538 hermetic total pass.

## Verification (two-lens: skeptic + backend-contract, both on a fresh ref)
- **Contract: conforms exactly** — and the **critical terminal condition is confirmed**: the SDK's `is_terminal = (ongoing is None)` corresponds exactly to the backend's "no run in `ONGOING_STATUSES`" (the ONGOING/TERMINAL sets partition the enum; `ongoing` is populated iff a run is non-terminal). The post-`generate` race is a non-issue — the queued run is committed (and `queued` is ongoing) before the trigger returns.
- **Skeptic findings applied:** (1) documented the **stale-taxonomy footgun** — a *failed re-run* leaves `latest_completed` pointing at a prior completed run, so the docstring now tells callers to compare `.latest_completed.run_id`/`.version` against their `generate()` run and not feed a stale taxonomy into `datasets.generate`; (2) made the `latest_completed` test fixtures faithful (the backend emits no `status` field there).