### PR TITLE
LUC-923: client.evosims run management (list / get / cancel / iteration_instances + wait_for)

### DIFF
--- a/lucidicai/api/models/evosim.py
+++ b/lucidicai/api/models/evosim.py
@@ -1,0 +1,88 @@
+"""Typed response models for client.evosims run management (LUC-923)."""
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from .base import APIModel
+
+
+# A run's terminal statuses, for polling. NOTE this INCLUDES ``CANCELED`` — unlike
+# the backend's internal ``_TERMINAL_EVOSIM_STATUSES`` constant, which omits it (that
+# one exists only so the cancel path won't relabel an already-finished run). A
+# null/absent status means "iteration not yet materialized" — keep polling, not
+# terminal.
+_TERMINAL_EVOSIM_STATUSES = frozenset({"SUCCEEDED", "PARTIAL_SUCCESS", "FAILED", "CANCELED"})
+
+
+@dataclass
+class EvoSimIteration(APIModel):
+    """One optimization cycle of an EvoSim run, with its own rolled-up ``status``."""
+
+    evosimiteration_id: str
+    evosim_id: Optional[str] = None
+    iteration: Optional[int] = None
+    status: Optional[str] = None
+    failure_reason: Optional[str] = None
+    is_finished: Optional[bool] = None
+    hard_stop: Optional[Any] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass
+class EvoSim(APIModel):
+    """An EvoSim run (an evolutionary optimization of an agent). ``list`` returns the
+    light shape; ``get`` additionally rolls up the run ``status`` / ``failure_reason``,
+    the derived ``checkpoint_id`` (the checkpoint the run produced — null until one is
+    published, and always null for a FAILED / no-ready run), and its ``iterations``.
+
+    ``status`` is ``RUNNING`` (ongoing) / ``SUCCEEDED`` / ``PARTIAL_SUCCESS`` /
+    ``FAILED`` / ``CANCELED`` (terminal), or ``None`` before the first iteration
+    exists. Use ``is_terminal`` rather than comparing the raw string.
+    """
+
+    evosim_id: str
+    agent_id: Optional[str] = None
+    experiment_id: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    max_iterations: Optional[int] = None
+    hard_stop_seconds_per_iteration: Optional[int] = None
+    max_session_concurrency: Optional[int] = None
+    webhook_url: Optional[str] = None
+    temporal_workflow_id: Optional[str] = None
+    temporal_run_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    # detail-only (get): the rolled-up run status + produced checkpoint + iterations.
+    status: Optional[str] = None
+    failure_reason: Optional[str] = None
+    checkpoint_id: Optional[str] = None
+    iterations: List[EvoSimIteration] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data):
+        obj = super().from_dict(data)
+        if obj.iterations and isinstance(obj.iterations[0], dict):
+            setattr(obj, "iterations", EvoSimIteration.from_list(obj.iterations))
+        return obj
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once the run has finished (``SUCCEEDED`` / ``PARTIAL_SUCCESS`` /
+        ``FAILED`` / ``CANCELED``). A ``None`` status (no iteration yet) is not
+        terminal — keep polling."""
+        return self.status in _TERMINAL_EVOSIM_STATUSES
+
+
+@dataclass
+class TrainingModuleInstance(APIModel):
+    """One Training Module Instance (TMI) — a module's run within an EvoSim iteration.
+    ``status`` is ``BUILDING`` (ongoing) / ``READY`` / ``FAILED`` / ``ARCHIVED``."""
+
+    tmi_id: str
+    module_key: Optional[str] = None
+    module_artifact_key: Optional[str] = None
+    created_by: Optional[str] = None
+    status: Optional[str] = None
+    session_id: Optional[str] = None
+    created_at: Optional[str] = None

--- a/lucidicai/api/resources/evosim.py
+++ b/lucidicai/api/resources/evosim.py
@@ -1,17 +1,33 @@
-"""EvoSim resource API operations."""
+"""EvoSim resource API operations (LUC-923 run management).
+
+``client.evosims`` manages EvoSim runs: kick one off (``train``), list / read runs,
+cancel a run, inspect an iteration's Training Module Instances, and block until a
+run is terminal (``wait_for``). These hit the gen-3 ``/sdk/...`` paths (there is no
+``/sdk/v2/evosim*`` surface).
+
+``train`` / ``atrain`` swallow in production (a kickoff convenience); the
+run-management reads/writes are data-bearing and do NOT swallow. Each has an
+``a``-prefixed async sibling.
+"""
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.evosim import EvoSim, TrainingModuleInstance
+from ..pagination import apaginate, paginate
+from ..polling import await_for, wait_for
 from ...core.errors import LucidicError, require_agent_id
 
 logger = logging.getLogger("Lucidic")
 
+_EVOSIMS = "sdk/evosims"
 
-class EvoSimResource:
-    """Handle EvoSim-related API operations."""
+
+class EvoSimsResource:
+    """Handle EvoSim run-management API operations."""
 
     def __init__(
         self,
@@ -23,12 +39,14 @@ class EvoSimResource:
 
         Args:
             http: HTTP client instance
-            agent_id: Default agent ID for training runs
-            production: Whether to suppress errors in production mode
+            agent_id: Default agent ID for training runs / listing
+            production: Whether to suppress errors in production mode (train only)
         """
         self.http = http
         self._agent_id = agent_id
         self._production = production
+
+    # ==================== kickoff (gen-3, swallows) ====================
 
     def train(self, config_json_file: Union[str, Path]) -> Dict[str, Any]:
         """Start an EvoSim training run from a JSON config file.
@@ -51,7 +69,7 @@ class EvoSimResource:
             return self.http.post("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:
-                logger.error(f"[EvoSimResource] Failed to start training run: {e}")
+                logger.error(f"[EvoSimsResource] Failed to start training run: {e}")
                 return {"status": "failed", "error": str(e)}
             raise
 
@@ -64,9 +82,128 @@ class EvoSimResource:
             return await self.http.apost("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:
-                logger.error(f"[EvoSimResource] Failed to start training run: {e}")
+                logger.error(f"[EvoSimsResource] Failed to start training run: {e}")
                 return {"status": "failed", "error": str(e)}
             raise
+
+    # ==================== run management (LUC-923, no swallow) ====================
+
+    def list(self, agent_id: Optional[str] = None, *, page_size: Optional[int] = None) -> Iterator[EvoSim]:
+        """Lazily iterate an agent's EvoSim runs, newest first (GET /sdk/evosims;
+        needs ``evosim:read``). ``agent_id`` defaults to the configured agent. List
+        items are the light shape (no rolled-up ``status`` — call ``get`` for that)."""
+        base = self._list_params(agent_id, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=EvoSim)
+
+    def alist(self, agent_id: Optional[str] = None, *, page_size: Optional[int] = None) -> AsyncIterator[EvoSim]:
+        """Async sibling of ``list``."""
+        base = self._list_params(agent_id, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=EvoSim)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of an agent's EvoSim runs."""
+        return CursorPage.from_body(self._page_get(self._list_params(agent_id, page_size), cursor), model=EvoSim)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._list_params(agent_id, page_size), cursor)
+        return CursorPage.from_body(body, model=EvoSim)
+
+    def get(self, evosim_id: str) -> EvoSim:
+        """Read one EvoSim run with its rolled-up ``status`` / ``failure_reason``,
+        derived ``checkpoint_id``, and ``iterations`` (GET /sdk/evosims/{id}; needs
+        ``evosim:read``). Unknown / cross-org / out-of-binding id → ``NotFoundError``."""
+        return self._detail(self.http.get(f"{_EVOSIMS}/{evosim_id}"))
+
+    async def aget(self, evosim_id: str) -> EvoSim:
+        """Async sibling of ``get``."""
+        return self._detail(await self.http.aget(f"{_EVOSIMS}/{evosim_id}"))
+
+    def cancel(self, evosim_id: str) -> Optional[str]:
+        """Cancel an EvoSim run (POST /sdk/evosims/{id}/cancel; needs
+        ``evosim:delete``). A kill switch — terminates the Temporal workflow and
+        projects ``CANCELED`` onto the run. Idempotent: cancelling an already-terminal
+        run leaves it untouched. Returns the effective status (e.g. ``"CANCELED"``, or
+        the run's terminal status if it finished first). Raises
+        ``ServiceUnavailableError`` (503) if Temporal is unavailable — retry."""
+        resp = self.http.post(f"{_EVOSIMS}/{evosim_id}/cancel")
+        return resp.get("status")
+
+    async def acancel(self, evosim_id: str) -> Optional[str]:
+        """Async sibling of ``cancel``."""
+        resp = await self.http.apost(f"{_EVOSIMS}/{evosim_id}/cancel")
+        return resp.get("status")
+
+    def iteration_instances(self, iteration_id: str) -> List[TrainingModuleInstance]:
+        """List the Training Module Instances (TMIs) of an EvoSim iteration (GET
+        /sdk/evosim-iterations/{id}/instances; needs ``evosim:read``). Iteration ids
+        come from ``get(evosim_id).iterations``. Not paginated."""
+        resp = self.http.get(f"sdk/evosim-iterations/{iteration_id}/instances")
+        return TrainingModuleInstance.from_list(resp.get("training_module_instances", []))
+
+    async def aiteration_instances(self, iteration_id: str) -> List[TrainingModuleInstance]:
+        """Async sibling of ``iteration_instances``."""
+        resp = await self.http.aget(f"sdk/evosim-iterations/{iteration_id}/instances")
+        return TrainingModuleInstance.from_list(resp.get("training_module_instances", []))
+
+    def wait_for(self, evosim_id: str, *, timeout: float = 3600.0, interval: float = 10.0) -> EvoSim:
+        """Block until an EvoSim run reaches a terminal status (``SUCCEEDED`` /
+        ``PARTIAL_SUCCESS`` / ``FAILED`` / ``CANCELED``) or ``timeout`` elapses,
+        polling ``get`` every ``interval`` seconds. Returns the terminal run — inspect
+        ``.status`` / ``.failure_reason`` / ``.checkpoint_id``. Raises ``WaitTimeout``
+        if the deadline passes first.
+
+        EvoSim runs are long (up to ``max_iterations`` ×
+        ``hard_stop_seconds_per_iteration`` — the defaults allow multiple hours), so
+        the default ``timeout`` (1 h) may be too short for a big run; pass a larger
+        value, or poll ``get`` yourself."""
+        return wait_for(
+            lambda: self.get(evosim_id),
+            is_terminal=lambda run: run.is_terminal, timeout=timeout, interval=interval)
+
+    async def await_for(self, evosim_id: str, *, timeout: float = 3600.0, interval: float = 10.0) -> EvoSim:
+        """Async sibling of ``wait_for``."""
+        return await await_for(
+            lambda: self.aget(evosim_id),
+            is_terminal=lambda run: run.is_terminal, timeout=timeout, interval=interval)
+
+    # ==================== internals ====================
+
+    def _list_params(self, agent_id: Optional[str], page_size: Optional[int]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "evosims.list"),
+        }
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_EVOSIMS, params)
+
+    async def _apage_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_EVOSIMS, params)
+
+    @staticmethod
+    def _detail(resp: Dict[str, Any]) -> EvoSim:
+        """Flatten the detail envelope ``{evosim, iterations, status, failure_reason,
+        checkpoint_id}`` into a single typed ``EvoSim`` (the run id lives nested under
+        ``evosim``, the rolled-up status at the top level)."""
+        data = dict(resp.get("evosim") or {})
+        data["status"] = resp.get("status")
+        data["failure_reason"] = resp.get("failure_reason")
+        data["checkpoint_id"] = resp.get("checkpoint_id")
+        data["iterations"] = resp.get("iterations", [])
+        return EvoSim.from_dict(data)
 
 
 def _load_training_config(config_json_file: Union[str, Path]) -> Dict[str, Any]:

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -37,7 +37,7 @@ from .api.resources.experiment import ExperimentResource
 from .api.resources.prompt import PromptResource
 from .api.resources.feature_flag import FeatureFlagResource
 from .api.resources.evals import EvalsResource
-from .api.resources.evosim import EvoSimResource
+from .api.resources.evosim import EvoSimsResource
 from .api.resources.mock_call import MockCallResource
 from .sdk.training_modules.resource import TrainingModulesResource
 from .sdk.tools.resource import ToolsResource
@@ -174,7 +174,7 @@ class LucidicAI:
             "prompts": PromptResource(self._http, self._config, self._production),
             "feature_flags": FeatureFlagResource(self._http, self._config.agent_id, self._production),
             "evals": EvalsResource(self._http, self._production),
-            "evosims": EvoSimResource(self._http, self._config.agent_id, self._production),
+            "evosims": EvoSimsResource(self._http, self._config.agent_id, self._production),
             "mock_calls": MockCallResource(self._http, self._production),
         }
 
@@ -417,8 +417,10 @@ class LucidicAI:
         return self._resources["evals"]
 
     @property
-    def evosims(self) -> EvoSimResource:
-        """Access EvoSim resource for agent optimization runs.
+    def evosims(self) -> EvoSimsResource:
+        """Access EvoSim run management (LUC-923): ``train`` kickoff, ``list`` /
+        ``get`` runs, ``cancel``, ``iteration_instances``, and ``wait_for`` a run to
+        a terminal status.
 
         Example:
             result = client.evosims.train("training_config.json")

--- a/tests/api/resources/test_evosims.py
+++ b/tests/api/resources/test_evosims.py
@@ -1,0 +1,223 @@
+"""LUC-923 — client.evosims run management (list / get / cancel / iteration_instances
+/ wait_for). The gen-3 train() kickoff is covered elsewhere (agent-id guard test)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.evosim import EvoSim, EvoSimIteration, TrainingModuleInstance
+from lucidicai.api.resources.evosim import EvoSimsResource
+from lucidicai.core.errors import (
+    AgentIdRequiredError,
+    NotFoundError,
+    ServiceUnavailableError,
+    WaitTimeout,
+)
+
+_BASE = "https://stub.lucidic.test"
+_EVOSIMS = f"{_BASE}/sdk/evosims"
+
+
+@pytest.fixture
+def evosims(http):
+    return EvoSimsResource(http, agent_id="a1", production=False)
+
+
+def _evosim(i, **over):
+    d = {"evosim_id": f"es{i}", "agent_id": "a1", "experiment_id": "e1",
+         "name": f"run-{i}", "description": "", "max_iterations": 10,
+         "hard_stop_seconds_per_iteration": 1800, "max_session_concurrency": 10,
+         "webhook_url": None, "temporal_workflow_id": "wf1", "temporal_run_id": "trun1",
+         "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _iteration(**over):
+    d = {"evosimiteration_id": "it1", "evosim_id": "es1", "iteration": 1,
+         "status": "RUNNING", "failure_reason": None, "is_finished": False,
+         "hard_stop": None, "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _detail(status=None, **over):
+    d = {"evosim": _evosim(1), "iterations": [], "status": status,
+         "failure_reason": None, "checkpoint_id": None}
+    d.update(over)
+    return d
+
+
+def _tmi(i, **over):
+    d = {"tmi_id": f"tmi{i}", "module_key": "filesystem", "module_artifact_key": None,
+         "created_by": "u1", "status": "READY", "session_id": "s1",
+         "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+class TestModel:
+    def test_is_terminal_across_statuses(self):
+        for s in (None, "RUNNING"):
+            assert EvoSim.from_dict(_evosim(1, status=s)).is_terminal is False
+        for s in ("SUCCEEDED", "PARTIAL_SUCCESS", "FAILED", "CANCELED"):
+            assert EvoSim.from_dict(_evosim(1, status=s)).is_terminal is True
+
+    def test_iterations_typed(self):
+        run = EvoSim.from_dict(_evosim(1, iterations=[_iteration(), _iteration(evosimiteration_id="it2")]))
+        assert all(isinstance(it, EvoSimIteration) for it in run.iterations)
+        assert run.iterations[0].evosimiteration_id == "it1"
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed_and_defaults_agent(self, evosims):
+        route = respx.get(_EVOSIMS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evosim(1), _evosim(2)],
+                                      "next": f"{_EVOSIMS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evosim(3)], "next": None}),
+        ])
+        got = list(evosims.list())
+        assert [e.evosim_id for e in got] == ["es1", "es2", "es3"]
+        assert all(isinstance(e, EvoSim) for e in got)
+        assert route.calls[0].request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_explicit_agent_and_page_size(self, evosims):
+        route = respx.get(_EVOSIMS).mock(return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(evosims.list("a2", page_size=25))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a2" and p["page_size"] == "25"
+
+    def test_list_without_agent_id_raises(self, http):
+        res = EvoSimsResource(http, agent_id=None)
+        with pytest.raises(AgentIdRequiredError):
+            list(res.list())
+
+
+class TestGet:
+    @respx.mock
+    def test_get_flattens_detail_envelope(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(
+            status="SUCCEEDED", evosim=_evosim(1), iterations=[_iteration(status="SUCCEEDED")],
+            checkpoint_id="ck1", failure_reason=None)))
+        run = evosims.get("es1")
+        assert isinstance(run, EvoSim) and run.evosim_id == "es1"
+        assert run.status == "SUCCEEDED" and run.checkpoint_id == "ck1" and run.is_terminal is True
+        assert run.iterations[0].evosimiteration_id == "it1"
+
+    @respx.mock
+    def test_get_running_status_none_checkpoint(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(status="RUNNING")))
+        run = evosims.get("es1")
+        assert run.status == "RUNNING" and run.is_terminal is False and run.checkpoint_id is None
+
+    @respx.mock
+    def test_get_404(self, evosims):
+        respx.get(f"{_EVOSIMS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified EvoSim not found"}))
+        with pytest.raises(NotFoundError):
+            evosims.get("missing")
+
+
+class TestCancel:
+    @respx.mock
+    def test_cancel_returns_effective_status(self, evosims):
+        route = respx.post(f"{_EVOSIMS}/es1/cancel").mock(
+            return_value=httpx.Response(200, json={"evosim_id": "es1", "status": "CANCELED"}))
+        assert evosims.cancel("es1") == "CANCELED"
+        assert route.called
+
+    @respx.mock
+    def test_cancel_already_terminal_returns_its_status(self, evosims):
+        # idempotent — cancelling a finished run reports its real terminal status
+        respx.post(f"{_EVOSIMS}/es1/cancel").mock(
+            return_value=httpx.Response(200, json={"evosim_id": "es1", "status": "SUCCEEDED"}))
+        assert evosims.cancel("es1") == "SUCCEEDED"
+
+    @respx.mock
+    def test_cancel_503(self, evosims):
+        respx.post(f"{_EVOSIMS}/es1/cancel").mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            evosims.cancel("es1")
+
+
+class TestIterationInstances:
+    @respx.mock
+    def test_unwraps_typed_list(self, evosims):
+        respx.get(f"{_BASE}/sdk/evosim-iterations/it1/instances").mock(return_value=httpx.Response(
+            200, json={"evosim_iteration_id": "it1", "training_module_instances": [_tmi(1), _tmi(2)]}))
+        tmis = evosims.iteration_instances("it1")
+        assert [t.tmi_id for t in tmis] == ["tmi1", "tmi2"]
+        assert all(isinstance(t, TrainingModuleInstance) for t in tmis)
+        assert tmis[0].module_key == "filesystem" and tmis[0].status == "READY"
+
+    @respx.mock
+    def test_empty(self, evosims):
+        respx.get(f"{_BASE}/sdk/evosim-iterations/it1/instances").mock(
+            return_value=httpx.Response(200, json={"evosim_iteration_id": "it1", "training_module_instances": []}))
+        assert evosims.iteration_instances("it1") == []
+
+
+class TestWaitFor:
+    @respx.mock
+    def test_polls_past_none_and_running_to_terminal(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(side_effect=[
+            httpx.Response(200, json=_detail(status=None)),      # iteration not yet materialized
+            httpx.Response(200, json=_detail(status="RUNNING")),
+            httpx.Response(200, json=_detail(status="SUCCEEDED", checkpoint_id="ck1")),
+        ])
+        run = evosims.wait_for("es1", timeout=60, interval=0)
+        assert run.is_terminal is True and run.status == "SUCCEEDED" and run.checkpoint_id == "ck1"
+
+    @respx.mock
+    def test_canceled_is_terminal(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(side_effect=[
+            httpx.Response(200, json=_detail(status="RUNNING")),
+            httpx.Response(200, json=_detail(status="CANCELED")),
+        ])
+        run = evosims.wait_for("es1", timeout=60, interval=0)
+        assert run.status == "CANCELED" and run.is_terminal is True
+
+    @respx.mock
+    def test_timeout_raises(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(status="RUNNING")))
+        with pytest.raises(WaitTimeout) as exc:
+            evosims.wait_for("es1", timeout=0, interval=0)
+        assert exc.value.last_state.status == "RUNNING"
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, evosims):
+        respx.get(_EVOSIMS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evosim(1)], "next": f"{_EVOSIMS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evosim(2)], "next": None}),
+        ])
+        got = [e.evosim_id async for e in evosims.alist()]
+        assert got == ["es1", "es2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(status="FAILED")))
+        run = await evosims.aget("es1")
+        assert run.status == "FAILED" and run.is_terminal is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acancel(self, evosims):
+        respx.post(f"{_EVOSIMS}/es1/cancel").mock(
+            return_value=httpx.Response(200, json={"evosim_id": "es1", "status": "CANCELED"}))
+        assert await evosims.acancel("es1") == "CANCELED"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_await_for(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(side_effect=[
+            httpx.Response(200, json=_detail(status="RUNNING")),
+            httpx.Response(200, json=_detail(status="SUCCEEDED")),
+        ])
+        run = await evosims.await_for("es1", timeout=60, interval=0)
+        assert run.is_terminal is True

--- a/tests/api/test_agent_id_guard.py
+++ b/tests/api/test_agent_id_guard.py
@@ -7,7 +7,7 @@ production — when it's actually needed but absent.
 import pytest
 
 from lucidicai.api.resources.evaluators import EvaluatorsResource
-from lucidicai.api.resources.evosim import EvoSimResource
+from lucidicai.api.resources.evosim import EvoSimsResource
 from lucidicai.api.resources.experiment import ExperimentResource
 from lucidicai.api.resources.prompt import PromptResource
 from lucidicai.api.resources.session import SessionResource
@@ -58,7 +58,7 @@ class TestIngestionGuard:
 
     def test_evosim_train_raises_even_in_production(self, http):
         # Guard is before the try/except swallow, so production doesn't eat it.
-        res = EvoSimResource(http, agent_id=None, production=True)
+        res = EvoSimsResource(http, agent_id=None, production=True)
         with pytest.raises(AgentIdRequiredError):
             res.train("does-not-matter.json")  # raises before reading the file
 


### PR DESCRIPTION
The final C4 ticket. Extends the `client.evosims` namespace (previously `train`/`atrain` only) with run management, and renames the singular `EvoSimResource` → `EvoSimsResource` to match the plural namespace (as the ticket asked). These hit the gen-3 `/sdk/...` paths (there is no `/sdk/v2/evosim*` surface).

## Surface
- `evosims.list(agent_id=None, *, page_size=None)` → cursor-iterated `EvoSim`s, newest first (`evosim:read`). Light shape (no rolled-up status).
- `evosims.get(id)` → one `EvoSim` with rolled-up `status` / `failure_reason`, derived `checkpoint_id`, and typed `iterations` (`evosim:read`). Flattens the `{evosim, iterations, status, failure_reason, checkpoint_id}` detail envelope into a single model.
- `evosims.cancel(id)` → the effective status string (POST `.../cancel`, `evosim:delete`). Kill switch; idempotent; `ServiceUnavailableError` (503) when Temporal is down.
- `evosims.iteration_instances(iteration_id)` → `List[TrainingModuleInstance]` (`evosim:read`, unpaginated). Iteration ids come from `get(...).iterations`.
- `evosims.wait_for(id, *, timeout=3600, interval=10)` → blocks until the run is terminal (`SUCCEEDED` / `PARTIAL_SUCCESS` / `FAILED` / `CANCELED`), returns the terminal `EvoSim`.
- `train`/`atrain` kickoff preserved (still swallow in production behind the agent-id guard); run-management is data-bearing → raises. All with async siblings.
- New `EvoSim` / `EvoSimIteration` / `TrainingModuleInstance` models.

## Files
- `lucidicai/api/models/evosim.py` (new) — the three models.
- `lucidicai/api/resources/evosim.py` — rename + run-management methods + the `_detail` flattener.
- `lucidicai/client.py` — evosims wiring/property renamed.
- `tests/api/resources/test_evosims.py` (new) — 20 tests. `tests/api/test_agent_id_guard.py` — rename ref.
- 558 hermetic total pass; the rename smoke-checked (old name gone, wiring resolves).

## Verification (two-lens: skeptic + backend-contract, both on a fresh ref)
- **Contract: conforms exactly** — list/detail shapes, the nested `evosim_id` + top-level status flattening, `EvoSimIteration`/`TrainingModuleInstance` fields, scopes (`evosim:read` / `evosim:delete`), cancel `{evosim_id, status}` + 503, and auth. **Critical check confirmed:** the SDK's terminal set `{SUCCEEDED, PARTIAL_SUCCESS, FAILED, CANCELED}` **includes `CANCELED`** (the backend's own `_TERMINAL_EVOSIM_STATUSES` deliberately omits it) and treats `None` as non-terminal — so `wait_for` neither stops early after kickoff nor hangs on a canceled run.
- **Skeptic: no correctness defects.** Two low, documented DX tradeoffs reviewed and consciously accepted: the 1h `wait_for` default under a possible ~5h run (a 5h blocking default would be worse; the docstring gives the `max_iterations × hard_stop_seconds_per_iteration` formula), and `is_terminal` being `False` on the light `list()` shape (inherent to the shared light-list/detail model every resource uses; documented).