### PR TITLE
docs: note the DELETE-retry 404-on-committed-delete edge on HttpClient.delete

### DIFF
--- a/lucidicai/api/client.py
+++ b/lucidicai/api/client.py
@@ -347,6 +347,17 @@ class HttpClient:
 
         Returns:
             Response data as dictionary
+
+        Note:
+            DELETE is auto-retried on a 429/503 status (it is idempotent). One benign
+            edge for a *destructive* delete: if the backend commits the delete and
+            then a 429/503 comes back (e.g. a gateway/load-balancer 503 during a
+            deploy or drain), the retry can hit a 404 and surface as ``NotFoundError``
+            even though the delete actually succeeded. This is rare — the delete paths
+            dispatch no async work, so the retryable status can only originate at an
+            infra layer, not the backend — and harmless (the resource is gone either
+            way). The clean fix is request idempotency keys, deferred until mutation
+            retry-safety is worth building.
         """
         return self.request("DELETE", endpoint, params=params, json=data)
 


### PR DESCRIPTION
Doc-only. Records a known, benign transport edge so it isn't rediscovered — no code/behavior change, and (per discussion) no idempotency-key build-out.

DELETE is auto-retried on a 429/503 status (it's idempotent). If a *destructive* delete commits server-side and then a 429/503 comes back (e.g. a gateway/LB 503 during a deploy/drain), the retry can hit a 404 and surface as `NotFoundError` even though the delete actually succeeded. It's rare — the delete paths dispatch no async work, so a post-commit retryable status can only originate at an infra layer, not the backend — and harmless (the resource is gone either way). The clean fix is request idempotency keys (which would also unlock POST/PATCH retry), deferred until mutation retry-safety is worth building.

- `lucidicai/api/client.py` — `Note:` added to `HttpClient.delete`'s docstring (the single behavioral source; `adelete` points to it).

Verified accurate by a code-skeptic pass against the retry gate (`_IDEMPOTENT_METHODS` + `_RETRY_STATUSES`) and the `404 → NotFoundError` mapping; its one precision note (name the 429/503 status rather than "the response fails") was applied.