### PR TITLE
Release 4.0.0: version bump (3.7.2 → 4.0.0)

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -79,7 +79,7 @@ from .sdk.tools.adapters import (
 from .integrations.livekit import setup_livekit
 
 # Version
-__version__ = "3.7.2"
+__version__ = "4.0.0"
 
 # All exports
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="lucidicai",
-    version="3.7.2",
+    version="4.0.0",
     packages=find_packages(),
     install_requires=[
         "requests>=2.25.1",


### PR DESCRIPTION
Bumps the package version to `4.0.0` for the SDK-First Platform Parity release. Merge this into the umbrella branch first, so the umbrella → `main` release PR ships as 4.0.0.

- `setup.py` — `version="4.0.0"`
- `lucidicai/__init__.py` — `__version__ = "4.0.0"`

Verified: both locations updated, no stragglers, `import lucidicai; lucidicai.__version__ == "4.0.0"`. (No code/behavior change — a version bump has no logic to adversarially review; the whole parity surface was skeptic-reviewed on its per-ticket PRs.)