### PR TITLE
SDK-First Platform Parity — client.* full dashboard alternative (v4.0.0)

### DIFF
--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -32,6 +32,16 @@ from .core.errors import (
     InvalidOperationError,
     PromptError,
     FeatureFlagError,
+    # Typed HTTP/API errors (LUC-900)
+    LucidicAPIError,
+    ValidationError,
+    AuthError,
+    InsufficientScopeError,
+    NotFoundError,
+    ConflictError,
+    RateLimitError,
+    ServiceUnavailableError,
+    APIError,
     # mock_call dispatch error family (LUC-607)
     LucidicMockCallError,
     LucidicToolDriftError,
@@ -46,6 +56,9 @@ from .core.errors import (
     LucidicUnsupportedSQLError,
 )
 from .sdk.training_modules import TrainingModulesResource
+
+# Typed response-model base (LUC-905)
+from .api.models import APIModel, CursorPage
 
 # Prompt object
 from .api.resources.prompt import Prompt
@@ -81,6 +94,16 @@ __all__ = [
     "InvalidOperationError",
     "PromptError",
     "FeatureFlagError",
+    # Typed HTTP/API errors (LUC-900)
+    "LucidicAPIError",
+    "ValidationError",
+    "AuthError",
+    "InsufficientScopeError",
+    "NotFoundError",
+    "ConflictError",
+    "RateLimitError",
+    "ServiceUnavailableError",
+    "APIError",
     # mock_call dispatch error family (LUC-607)
     "LucidicMockCallError",
     "LucidicToolDriftError",
@@ -94,6 +117,9 @@ __all__ = [
     "LucidicMissingImplError",
     "LucidicUnsupportedSQLError",
     "TrainingModulesResource",
+    # Typed response-model base (LUC-905)
+    "APIModel",
+    "CursorPage",
     # Prompt object
     "Prompt",
     # Tool dispatch (v2 tool-backed)

--- a/lucidicai/__init__.py
+++ b/lucidicai/__init__.py
@@ -79,7 +79,7 @@ from .sdk.tools.adapters import (
 from .integrations.livekit import setup_livekit
 
 # Version
-__version__ = "3.7.2"
+__version__ = "4.0.0"
 
 # All exports
 __all__ = [

--- a/lucidicai/api/client.py
+++ b/lucidicai/api/client.py
@@ -334,17 +334,21 @@ class HttpClient:
         data = self._add_timestamp(data)
         return self.request("PATCH", endpoint, json=data)
 
-    def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None,
+               data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make a synchronous DELETE request.
-        
+
         Args:
             endpoint: API endpoint (without base URL)
             params: Query parameters
-            
+            data: Optional JSON body. Most deletes carry none; a few endpoints
+                take a small flag in the DELETE body (e.g. the experiments
+                delete's ``delete_sessions``).
+
         Returns:
             Response data as dictionary
         """
-        return self.request("DELETE", endpoint, params=params)
+        return self.request("DELETE", endpoint, params=params, json=data)
 
     def head(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
         """Make a synchronous HEAD request and return the response headers (LUC-903).
@@ -455,17 +459,19 @@ class HttpClient:
         data = self._add_timestamp(data)
         return await self.arequest("PATCH", endpoint, json=data)
 
-    async def adelete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    async def adelete(self, endpoint: str, params: Optional[Dict[str, Any]] = None,
+                      data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Make an asynchronous DELETE request.
-        
+
         Args:
             endpoint: API endpoint (without base URL)
             params: Query parameters
-            
+            data: Optional JSON body (see ``delete``).
+
         Returns:
             Response data as dictionary
         """
-        return await self.arequest("DELETE", endpoint, params=params)
+        return await self.arequest("DELETE", endpoint, params=params, json=data)
 
     async def ahead(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
         """Async sibling of ``head`` (LUC-903)."""

--- a/lucidicai/api/client.py
+++ b/lucidicai/api/client.py
@@ -347,6 +347,17 @@ class HttpClient:
 
         Returns:
             Response data as dictionary
+
+        Note:
+            DELETE is auto-retried on a 429/503 status (it is idempotent). One benign
+            edge for a *destructive* delete: if the backend commits the delete and
+            then a 429/503 comes back (e.g. a gateway/load-balancer 503 during a
+            deploy or drain), the retry can hit a 404 and surface as ``NotFoundError``
+            even though the delete actually succeeded. This is rare — the delete paths
+            dispatch no async work, so the retryable status can only originate at an
+            infra layer, not the backend — and harmless (the resource is gone either
+            way). The clean fix is request idempotency keys, deferred until mutation
+            retry-safety is worth building.
         """
         return self.request("DELETE", endpoint, params=params, json=data)
 

--- a/lucidicai/api/client.py
+++ b/lucidicai/api/client.py
@@ -4,14 +4,56 @@ This module contains only the HTTP client logic using httpx,
 supporting both synchronous and asynchronous operations.
 """
 import asyncio
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import httpx
 
 from ..core.config import SDKConfig, get_config
-from ..core.errors import APIKeyVerificationError
+from ..core.errors import exception_from_response
 from ..utils.logger import debug, info, warning, error, mask_sensitive, truncate_data
+
+
+# Status codes the transport retries with backoff (LUC-901). Connection-level
+# failures are retried separately by the httpx transport's own ``retries=``.
+# 429 (throttled) and 503 (unavailable / workflow couldn't start) are retried.
+_RETRY_STATUSES = frozenset({429, 503})
+
+# Retries are gated to idempotent methods. A POST/PATCH may have committed a
+# write before the backend returned 429/503 — the EvoSim kickoff, for example,
+# commits the run row and only then 503s if Temporal can't start — so a blind
+# retry would duplicate it. GET/HEAD/PUT/DELETE are safe to replay. Trigger
+# endpoints that want at-least-once retry need a server-side idempotency key
+# first (LUC-808); until then POST/PATCH fail fast, as they did pre-C0.
+_IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE", "OPTIONS"})
+
+# Hard ceiling on a single retry sleep, so a large (or proxy-injected)
+# ``Retry-After`` can't pin the calling thread for minutes/hours.
+_MAX_RETRY_DELAY_SECONDS = 30.0
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Parse a ``Retry-After: <seconds>`` header. The HTTP-date form is not
+    supported (returns None → caller falls back to computed backoff)."""
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _retry_delay(response: httpx.Response, attempt: int, backoff: float) -> float:
+    """Seconds to wait before the next attempt: honor ``Retry-After`` when the
+    server sends it, else exponential backoff (``backoff * 2**attempt``).
+
+    Clamped to ``_MAX_RETRY_DELAY_SECONDS`` so a huge or proxy-injected
+    ``Retry-After`` can't block the caller for minutes/hours.
+    """
+    retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+    delay = retry_after if retry_after is not None else backoff * (2 ** attempt)
+    return min(delay, _MAX_RETRY_DELAY_SECONDS)
 
 
 class HttpClient:
@@ -123,35 +165,35 @@ class HttpClient:
         data["current_time"] = datetime.now(timezone.utc).isoformat()
         return data
     
-    def _handle_response(self, response: httpx.Response) -> Dict[str, Any]:
-        """Handle HTTP response and parse JSON.
-        
-        Args:
-            response: httpx Response object
-            
-        Returns:
-            Response data as dictionary
-            
-        Raises:
-            APIKeyVerificationError: On 401 Unauthorized responses
-            httpx.HTTPStatusError: On other HTTP errors
+    def _raise_if_error(self, response: httpx.Response) -> None:
+        """Decode a non-2xx response and raise a typed ``LucidicError`` (LUC-900).
+
+        The single decode point: the backend ``{"error": ...}`` /
+        ``{"detail": ...}`` / mock-call ``{"error": {"code"}}`` envelopes all
+        map to typed exceptions via ``exception_from_response``. No-op on 2xx.
         """
-        # Log and raise for HTTP errors
-        if not response.is_success:
-            try:
-                error_data = response.json()
-                error_msg = error_data.get('detail', response.text)
-            except Exception:
-                error_msg = response.text
-            
-            error(f"[HTTP] Error {response.status_code}: {error_msg}")
-            
-            # Raise specific error for authentication/authorization failures
-            if response.status_code in (401, 403):
-                raise APIKeyVerificationError(f"Authentication failed: {error_msg}")
-        
-        response.raise_for_status()
-        
+        if response.is_success:
+            return
+        text = response.text
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+        exc = exception_from_response(
+            response.status_code, body, text, retry_after=retry_after
+        )
+        error(f"[HTTP] Error {response.status_code}: {exc}")
+        raise exc
+
+    def _handle_response(self, response: httpx.Response) -> Dict[str, Any]:
+        """Raise a typed error on non-2xx, else parse and return the JSON body.
+
+        Raises:
+            LucidicError subclass: on any non-2xx response (see ``core.errors``).
+        """
+        self._raise_if_error(response)
+
         # Parse JSON response
         try:
             data = response.json()
@@ -162,10 +204,82 @@ class HttpClient:
             else:
                 # Return text if not JSON
                 data = {"response": response.text}
-        
+
         debug(f"[HTTP] Response ({response.status_code}): {truncate_data(data)}")
-        
+
         return data
+
+    def _send_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> httpx.Response:
+        """Send one request, retrying transient 429/503 on idempotent methods (LUC-901).
+
+        Connection-level failures are retried by the httpx transport's own
+        ``retries=``; this loop adds status-based retries for 429/503, but only
+        for idempotent methods (GET/HEAD/PUT/DELETE) — a POST/PATCH may have
+        committed a write before the error, so retrying could duplicate it.
+        Delays honor ``Retry-After`` (capped). Returns the final response (which
+        may still be an error — ``_handle_response`` types it).
+        """
+        max_retries = self.config.network.max_retries
+        backoff = self.config.network.backoff_factor
+        attempt = 0
+        while True:
+            response = self.sync_client.request(
+                method=method, url=url, params=params, json=json, **kwargs
+            )
+            retryable = (
+                method.upper() in _IDEMPOTENT_METHODS
+                and response.status_code in _RETRY_STATUSES
+            )
+            if retryable and attempt < max_retries:
+                delay = _retry_delay(response, attempt, backoff)
+                warning(
+                    f"[HTTP] {response.status_code} on {method} {url}; "
+                    f"retry {attempt + 1}/{max_retries} in {delay:.2f}s"
+                )
+                time.sleep(delay)
+                attempt += 1
+                continue
+            return response
+
+    async def _asend_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> httpx.Response:
+        """Async sibling of ``_send_with_retry``."""
+        max_retries = self.config.network.max_retries
+        backoff = self.config.network.backoff_factor
+        attempt = 0
+        while True:
+            response = await self.async_client.request(
+                method=method, url=url, params=params, json=json, **kwargs
+            )
+            retryable = (
+                method.upper() in _IDEMPOTENT_METHODS
+                and response.status_code in _RETRY_STATUSES
+            )
+            if retryable and attempt < max_retries:
+                delay = _retry_delay(response, attempt, backoff)
+                warning(
+                    f"[HTTP] {response.status_code} on {method} {url}; "
+                    f"retry {attempt + 1}/{max_retries} in {delay:.2f}s"
+                )
+                await asyncio.sleep(delay)
+                attempt += 1
+                continue
+            return response
     
     # ==================== Synchronous Methods ====================
     
@@ -231,7 +345,27 @@ class HttpClient:
             Response data as dictionary
         """
         return self.request("DELETE", endpoint, params=params)
-    
+
+    def head(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
+        """Make a synchronous HEAD request and return the response headers (LUC-903).
+
+        List endpoints answer HEAD with counts in headers (e.g. ``X-Total-Count``,
+        and sessions' ``X-Tags``) so callers can get a cheap count/tag summary
+        without paging. Raises a typed error on non-2xx.
+
+        Args:
+            endpoint: API endpoint (without base URL)
+            params: Query parameters (same filters as the matching ``.list()``)
+
+        Returns:
+            The response headers (case-insensitive ``httpx.Headers``).
+        """
+        url = f"/{endpoint}"
+        debug(f"[HTTP] HEAD {self.base_url}{url}")
+        response = self._send_with_retry("HEAD", url, params=params)
+        self._raise_if_error(response)
+        return response.headers
+
     def request(
         self,
         method: str,
@@ -264,14 +398,8 @@ class HttpClient:
         if json:
             debug(f"[HTTP] Request body: {truncate_data(mask_sensitive(json))}")
         
-        response = self.sync_client.request(
-            method=method,
-            url=url,
-            params=params,
-            json=json,
-            **kwargs
-        )
-        
+        response = self._send_with_retry(method, url, params=params, json=json, **kwargs)
+
         return self._handle_response(response)
     
     # ==================== Asynchronous Methods ====================
@@ -338,7 +466,15 @@ class HttpClient:
             Response data as dictionary
         """
         return await self.arequest("DELETE", endpoint, params=params)
-    
+
+    async def ahead(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> httpx.Headers:
+        """Async sibling of ``head`` (LUC-903)."""
+        url = f"/{endpoint}"
+        debug(f"[HTTP] HEAD {self.base_url}{url}")
+        response = await self._asend_with_retry("HEAD", url, params=params)
+        self._raise_if_error(response)
+        return response.headers
+
     async def arequest(
         self,
         method: str,
@@ -371,14 +507,8 @@ class HttpClient:
         if json:
             debug(f"[HTTP] Request body: {truncate_data(mask_sensitive(json))}")
         
-        response = await self.async_client.request(
-            method=method,
-            url=url,
-            params=params,
-            json=json,
-            **kwargs
-        )
-        
+        response = await self._asend_with_retry(method, url, params=params, json=json, **kwargs)
+
         return self._handle_response(response)
     
     # ==================== Lifecycle Methods ====================

--- a/lucidicai/api/downloads.py
+++ b/lucidicai/api/downloads.py
@@ -1,0 +1,37 @@
+"""Presigned-URL download fetch-through (LUC-904).
+
+Backend read paths — event raw blobs (``GET .../events/{id}?raw=true``) and
+training-module export downloads (``GET .../download-url``) — return
+short-lived presigned S3 GET URLs (5-20 min). These helpers download the bytes
+directly from S3 with **no** Lucidic auth header, mirroring the presigned
+PUT-upload path in ``sdk/event.py``.
+
+Never cache a presigned URL — it expires. Fetch the presigned URL fresh from
+the API each time and download immediately.
+"""
+from typing import Optional
+
+import httpx
+
+# Blob downloads can be large; give them a more generous default than the
+# 30s API timeout, but still bounded.
+DEFAULT_TIMEOUT = 60.0
+
+
+def fetch_presigned(url: str, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> bytes:
+    """Download and return the bytes at a presigned URL (sync).
+
+    Raises ``httpx.HTTPStatusError`` on a non-2xx from S3 (e.g. an expired
+    URL → 403). The caller re-requests a fresh presigned URL and retries.
+    """
+    resp = httpx.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.content
+
+
+async def afetch_presigned(url: str, *, timeout: Optional[float] = DEFAULT_TIMEOUT) -> bytes:
+    """Async sibling of ``fetch_presigned``."""
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return resp.content

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -12,6 +12,7 @@ from .session import (
     SessionEvaluatorResults,
     SessionTrace,
 )
+from .usage import Usage
 
 __all__ = [
     "APIModel",
@@ -29,4 +30,5 @@ __all__ = [
     "EvalResult",
     "EventEval",
     "SessionEvaluatorResults",
+    "Usage",
 ]

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -3,6 +3,7 @@ from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
 from .evaluator import Evaluator
 from .experiment import Experiment
+from .project import Project
 from .prompt import PromptInfo, PromptVersion
 from .session import (
     EvalResult,
@@ -22,6 +23,7 @@ __all__ = [
     "CatalogTool",
     "Evaluator",
     "Experiment",
+    "Project",
     "PromptInfo",
     "PromptVersion",
     "Session",

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,4 +1,5 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
+from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
 
-__all__ = ["APIModel", "CursorPage"]
+__all__ = ["APIModel", "CursorPage", "Agent", "AgentToolCatalog", "CatalogTool"]

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,6 +1,7 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
+from .experiment import Experiment
 from .session import (
     EvalResult,
     Event,
@@ -16,6 +17,7 @@ __all__ = [
     "Agent",
     "AgentToolCatalog",
     "CatalogTool",
+    "Experiment",
     "Session",
     "SessionTrace",
     "Event",

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,6 +1,7 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
+from .evaluator import Evaluator
 from .experiment import Experiment
 from .prompt import PromptInfo, PromptVersion
 from .session import (
@@ -18,6 +19,7 @@ __all__ = [
     "Agent",
     "AgentToolCatalog",
     "CatalogTool",
+    "Evaluator",
     "Experiment",
     "PromptInfo",
     "PromptVersion",

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -2,6 +2,7 @@
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
 from .experiment import Experiment
+from .prompt import PromptInfo, PromptVersion
 from .session import (
     EvalResult,
     Event,
@@ -18,6 +19,8 @@ __all__ = [
     "AgentToolCatalog",
     "CatalogTool",
     "Experiment",
+    "PromptInfo",
+    "PromptVersion",
     "Session",
     "SessionTrace",
     "Event",

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,5 +1,25 @@
 """Typed response models for the Lucidic SDK read surface (LUC-905)."""
 from .agent import Agent, AgentToolCatalog, CatalogTool
 from .base import APIModel, CursorPage
+from .session import (
+    EvalResult,
+    Event,
+    EventEval,
+    Session,
+    SessionEvaluatorResults,
+    SessionTrace,
+)
 
-__all__ = ["APIModel", "CursorPage", "Agent", "AgentToolCatalog", "CatalogTool"]
+__all__ = [
+    "APIModel",
+    "CursorPage",
+    "Agent",
+    "AgentToolCatalog",
+    "CatalogTool",
+    "Session",
+    "SessionTrace",
+    "Event",
+    "EvalResult",
+    "EventEval",
+    "SessionEvaluatorResults",
+]

--- a/lucidicai/api/models/__init__.py
+++ b/lucidicai/api/models/__init__.py
@@ -1,0 +1,4 @@
+"""Typed response models for the Lucidic SDK read surface (LUC-905)."""
+from .base import APIModel, CursorPage
+
+__all__ = ["APIModel", "CursorPage"]

--- a/lucidicai/api/models/agent.py
+++ b/lucidicai/api/models/agent.py
@@ -1,0 +1,69 @@
+"""Typed response models for client.agents (LUC-906)."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Agent(APIModel):
+    """An agent — the top-level entity every SDK call hangs off.
+
+    Returned by ``client.agents.list()`` / ``.get()``. ``agent_id`` is the id an
+    SDK-first caller needs to bootstrap (``LucidicAI(agent_id=...)``).
+    """
+
+    agent_id: str
+    name: Optional[str] = None
+    icon: Optional[str] = None
+    project_id: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class CatalogTool(APIModel):
+    """One tool in an agent's tool catalog, incl. denormalized usage counters
+    (``call_count`` / ``last_called_at``, bumped at event ingestion)."""
+
+    tool_id: str
+    name: Optional[str] = None
+    tier: Optional[str] = None
+    signature: Optional[Dict[str, Any]] = None
+    docstring: Optional[str] = None
+    return_shape: Optional[Any] = None
+    source_hash: Optional[str] = None
+    drift_acknowledged_hash: Optional[str] = None
+    has_drift: bool = False
+    impl_body: Optional[str] = None
+    impl_entry_point: Optional[str] = None
+    last_seen_at: Optional[str] = None
+    discovered_at: Optional[str] = None
+    call_count: int = 0
+    last_called_at: Optional[str] = None
+    resources: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class AgentToolCatalog(APIModel):
+    """An agent's tool catalog: its tools (typed) plus the deduped, agent-wide
+    reachable Resource set.
+
+    ``resources`` is kept as raw dicts — an auxiliary section most callers
+    don't need typed. ``tools`` are converted to ``CatalogTool`` on construction
+    (the nested-model pattern C1+ resources reuse).
+    """
+
+    agent_id: str
+    agent_name: Optional[str] = None
+    tools: List[CatalogTool] = field(default_factory=list)
+    resources: List[Dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentToolCatalog":
+        obj = super().from_dict(data)
+        # Convert the nested tool dicts to typed CatalogTool models (read the
+        # raw list from `data`, not obj.tools, which super() left as dicts).
+        # `or []` guards against the key being absent OR present-but-null.
+        raw_tools = (data.get("tools") or []) if isinstance(data, dict) else []
+        object.__setattr__(obj, "tools", CatalogTool.from_list(raw_tools))
+        return obj

--- a/lucidicai/api/models/base.py
+++ b/lucidicai/api/models/base.py
@@ -14,7 +14,7 @@ owning model's ``from_dict`` override.
 ``CursorPage`` lives here too since it is the paginated container of models;
 the iteration helpers that walk ``next`` live in ``api/pagination.py``.
 """
-from dataclasses import asdict, dataclass, fields
+from dataclasses import MISSING, asdict, dataclass, fields
 from typing import Any, Dict, List, Optional, Type, TypeVar
 from urllib.parse import parse_qs, urlparse
 
@@ -33,15 +33,32 @@ class APIModel:
 
     @classmethod
     def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
-        """Build a model from a backend JSON object, ignoring unknown keys."""
+        """Build a model from a backend JSON object.
+
+        Unknown keys are ignored (kept on ``.extra`` for forward-compat). A
+        ``null`` for a field that has a default (or ``default_factory``) is
+        dropped so the default applies — turning a backend ``"tools": null``
+        into ``[]`` rather than ``None``, which keeps a downstream
+        ``for x in model.field`` safe. A genuinely missing required field still
+        surfaces a clear ``TypeError`` from the dataclass constructor.
+        """
         if not isinstance(data, dict):
             raise TypeError(
                 f"{cls.__name__}.from_dict expected a dict, got "
                 f"{type(data).__name__}"
             )
-        field_names = {f.name for f in fields(cls)}
-        known = {k: v for k, v in data.items() if k in field_names}
-        extra = {k: v for k, v in data.items() if k not in field_names}
+        field_map = {f.name: f for f in fields(cls)}
+        known: Dict[str, Any] = {}
+        extra: Dict[str, Any] = {}
+        for key, value in data.items():
+            f = field_map.get(key)
+            if f is None:
+                extra[key] = value
+                continue
+            has_default = f.default is not MISSING or f.default_factory is not MISSING
+            if value is None and has_default:
+                continue  # let the field default apply instead of a null
+            known[key] = value
         obj = cls(**known)
         # object.__setattr__ works whether or not the subclass is frozen.
         object.__setattr__(obj, "_extra", extra)

--- a/lucidicai/api/models/base.py
+++ b/lucidicai/api/models/base.py
@@ -1,0 +1,106 @@
+"""Typed response-model base for the SDK read surface (LUC-905).
+
+Read methods return typed dataclasses instead of raw dicts. Each model is a
+plain ``@dataclass`` that mixes in ``APIModel`` and is built from backend JSON
+via ``from_dict`` — which ignores unrecognized keys (kept on ``.extra`` for
+forward-compat, so a newer backend can add fields without breaking an older
+SDK) and lets the dataclass surface a clear error for a genuinely missing
+required field.
+
+No pydantic — this extends the SDK's lone prior model precedent, the ``Prompt``
+dataclass (``api/resources/prompt.py``). Nested typed models convert in the
+owning model's ``from_dict`` override.
+
+``CursorPage`` lives here too since it is the paginated container of models;
+the iteration helpers that walk ``next`` live in ``api/pagination.py``.
+"""
+from dataclasses import asdict, dataclass, fields
+from typing import Any, Dict, List, Optional, Type, TypeVar
+from urllib.parse import parse_qs, urlparse
+
+T = TypeVar("T", bound="APIModel")
+
+
+class APIModel:
+    """Mixin for typed backend response models.
+
+    Subclasses must be ``@dataclass``. ``APIModel`` is intentionally *not*
+    itself a dataclass so that a base field (e.g. a defaulted ``extra``) does
+    not force every subclass field to carry a default — the classic dataclass
+    inheritance ordering trap. Unknown backend fields are stashed on a private
+    ``_extra`` attribute and exposed read-only via ``.extra``.
+    """
+
+    @classmethod
+    def from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
+        """Build a model from a backend JSON object, ignoring unknown keys."""
+        if not isinstance(data, dict):
+            raise TypeError(
+                f"{cls.__name__}.from_dict expected a dict, got "
+                f"{type(data).__name__}"
+            )
+        field_names = {f.name for f in fields(cls)}
+        known = {k: v for k, v in data.items() if k in field_names}
+        extra = {k: v for k, v in data.items() if k not in field_names}
+        obj = cls(**known)
+        # object.__setattr__ works whether or not the subclass is frozen.
+        object.__setattr__(obj, "_extra", extra)
+        return obj
+
+    @classmethod
+    def from_list(cls: Type[T], items: List[Dict[str, Any]]) -> List[T]:
+        """Build a list of models from a list of backend JSON objects."""
+        return [cls.from_dict(item) for item in items]
+
+    @property
+    def extra(self) -> Dict[str, Any]:
+        """Backend fields not mapped to a declared attribute (forward-compat)."""
+        return getattr(self, "_extra", {})
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Shallow dict of the declared dataclass fields (excludes ``extra``)."""
+        return asdict(self)
+
+
+def _extract_cursor(url: Optional[str]) -> Optional[str]:
+    """Pull the ``cursor`` query param out of a paginated ``next``/``previous``
+    URL. Returns None when there is no such page or no cursor present."""
+    if not url:
+        return None
+    values = parse_qs(urlparse(url).query).get("cursor")
+    return values[0] if values else None
+
+
+@dataclass
+class CursorPage:
+    """One page of a cursor-paginated list endpoint.
+
+    ``results`` are typed models when a ``model`` was supplied to
+    ``from_body``, else raw dicts. ``next_cursor`` / ``previous_cursor`` are the
+    extracted cursor tokens (None at the ends). ``raw`` is the untouched body.
+    """
+
+    results: List[Any]
+    next_cursor: Optional[str]
+    previous_cursor: Optional[str]
+    raw: Dict[str, Any]
+
+    @classmethod
+    def from_body(
+        cls, body: Dict[str, Any], *, model: Optional[Type[APIModel]] = None
+    ) -> "CursorPage":
+        raw_results = body.get("results", []) if isinstance(body, dict) else []
+        results = [
+            model.from_dict(item) if model is not None else item
+            for item in raw_results
+        ]
+        return cls(
+            results=results,
+            next_cursor=_extract_cursor(body.get("next") if isinstance(body, dict) else None),
+            previous_cursor=_extract_cursor(body.get("previous") if isinstance(body, dict) else None),
+            raw=body if isinstance(body, dict) else {},
+        )
+
+    @property
+    def has_next(self) -> bool:
+        return self.next_cursor is not None

--- a/lucidicai/api/models/dataset.py
+++ b/lucidicai/api/models/dataset.py
@@ -53,3 +53,50 @@ class Fixture(APIModel):
     blob_key: Optional[str] = None
     byte_size: Optional[int] = None
     status: Optional[str] = None
+
+
+# Terminal generation statuses — the run is done (successfully or not) and polling
+# should stop. Everything else (queued / planning / hydrating_fixtures / generating
+# / ...) is ongoing. Mirrors the backend's DATASET_GEN_TERMINAL_STATUSES.
+_TERMINAL_GENERATION_STATUSES = frozenset({"completed", "failed"})
+
+
+@dataclass
+class DatasetGenerationRun(APIModel):
+    """A dataset-generation run — the async pipeline that fills a Dataset from a
+    schema + the experiment's trace taxonomy. The trigger / retry response populates
+    ``run_id`` / ``dataset_id`` / ``status`` / ``created_at``; the status endpoint
+    additionally reports progress (``items_generated`` / ``total_target``),
+    ``error_message`` (set when failed), and the source experiment / schema.
+
+    ``status`` is ongoing (``queued`` / ``planning`` / ``hydrating_fixtures`` /
+    ``generating`` / ...) or terminal (``completed`` = success, ``failed`` = read
+    ``error_message``). Use ``is_terminal`` / ``succeeded`` rather than comparing
+    the raw string.
+    """
+
+    run_id: str
+    dataset_id: Optional[str] = None
+    dataset_name: Optional[str] = None
+    status: Optional[str] = None
+    items_generated: Optional[int] = None
+    total_target: Optional[int] = None
+    error_message: Optional[str] = None
+    created_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    experiment_id: Optional[str] = None
+    experiment_name: Optional[str] = None
+    schema_id: Optional[str] = None
+    schema_name: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once the run has finished (``completed`` or ``failed``)."""
+        return self.status in _TERMINAL_GENERATION_STATUSES
+
+    @property
+    def succeeded(self) -> bool:
+        """True only for a ``completed`` run (a ``failed`` run is terminal but not
+        successful — read ``error_message``)."""
+        return self.status == "completed"

--- a/lucidicai/api/models/dataset.py
+++ b/lucidicai/api/models/dataset.py
@@ -1,0 +1,55 @@
+"""Typed response models for client.datasets v2 (LUC-918).
+
+Distinct from the SDK's grandfathered gen-3 dataset helpers (which return raw
+dicts). These model the v2 schemas / items / fixtures surface.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class DatasetSchema(APIModel):
+    """A reusable, org-scoped typed definition of the shape of a dataset item's
+    ``input`` — a required input to dataset generation. ``fields`` is a list of
+    typed field defs (``{key, type, description?, required?, options?, children?}``);
+    ``type`` is one of ``string`` / ``number`` / ``categorical`` / ``object``.
+    ``name`` is unique per org.
+    """
+
+    schema_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    fields: List[Any] = field(default_factory=list)
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass
+class DatasetItem(APIModel):
+    """One test case in a dataset — an ``input`` (matching the dataset's schema)
+    and its ``expected_output``, plus tags/metadata. Returned by
+    ``client.datasets.items(dataset_id)``."""
+
+    datasetitem_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    tags: List[Any] = field(default_factory=list)
+    input: Optional[Dict[str, Any]] = None
+    expected_output: Optional[Any] = None
+    metadata: Optional[Dict[str, Any]] = None
+    flag_overrides: Optional[Any] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class Fixture(APIModel):
+    """A hydrated mock-data fixture (a DuckDB blob in object storage) authored for
+    one ``(dataset, resource)`` pair. The create response returns its id, storage
+    key, byte size, and status (``COMPLETED`` for a row-authored fixture)."""
+
+    fixture_id: str
+    blob_key: Optional[str] = None
+    byte_size: Optional[int] = None
+    status: Optional[str] = None

--- a/lucidicai/api/models/evaluator.py
+++ b/lucidicai/api/models/evaluator.py
@@ -1,0 +1,33 @@
+"""Typed response model for client.evaluators reads (LUC-910).
+
+The per-result rows (``evaluators.evals()`` distribution and
+``evaluators.result()``) reuse the ``EvalResult`` model from ``models.session``
+— both endpoints serialize with the backend's ``EvaluatorResultSerializer``.
+"""
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Evaluator(APIModel):
+    """An evaluator (LLM / CODE / HUMAN / RUNTIME) — the definition of a scoring
+    criterion. ``list()`` returns the light shape; ``get()`` additionally
+    populates ``rubric_json`` + ``config`` (default ``None`` in a list result).
+    """
+
+    evaluator_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    icon: Optional[str] = None
+    type: Optional[str] = None
+    result_type: Optional[str] = None
+    is_default: bool = False
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    criteria: Optional[Any] = None
+
+    # detail-only (get)
+    rubric_json: Optional[Any] = None
+    config: Optional[Dict[str, Any]] = None

--- a/lucidicai/api/models/evosim.py
+++ b/lucidicai/api/models/evosim.py
@@ -1,0 +1,88 @@
+"""Typed response models for client.evosims run management (LUC-923)."""
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from .base import APIModel
+
+
+# A run's terminal statuses, for polling. NOTE this INCLUDES ``CANCELED`` — unlike
+# the backend's internal ``_TERMINAL_EVOSIM_STATUSES`` constant, which omits it (that
+# one exists only so the cancel path won't relabel an already-finished run). A
+# null/absent status means "iteration not yet materialized" — keep polling, not
+# terminal.
+_TERMINAL_EVOSIM_STATUSES = frozenset({"SUCCEEDED", "PARTIAL_SUCCESS", "FAILED", "CANCELED"})
+
+
+@dataclass
+class EvoSimIteration(APIModel):
+    """One optimization cycle of an EvoSim run, with its own rolled-up ``status``."""
+
+    evosimiteration_id: str
+    evosim_id: Optional[str] = None
+    iteration: Optional[int] = None
+    status: Optional[str] = None
+    failure_reason: Optional[str] = None
+    is_finished: Optional[bool] = None
+    hard_stop: Optional[Any] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass
+class EvoSim(APIModel):
+    """An EvoSim run (an evolutionary optimization of an agent). ``list`` returns the
+    light shape; ``get`` additionally rolls up the run ``status`` / ``failure_reason``,
+    the derived ``checkpoint_id`` (the checkpoint the run produced — null until one is
+    published, and always null for a FAILED / no-ready run), and its ``iterations``.
+
+    ``status`` is ``RUNNING`` (ongoing) / ``SUCCEEDED`` / ``PARTIAL_SUCCESS`` /
+    ``FAILED`` / ``CANCELED`` (terminal), or ``None`` before the first iteration
+    exists. Use ``is_terminal`` rather than comparing the raw string.
+    """
+
+    evosim_id: str
+    agent_id: Optional[str] = None
+    experiment_id: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    max_iterations: Optional[int] = None
+    hard_stop_seconds_per_iteration: Optional[int] = None
+    max_session_concurrency: Optional[int] = None
+    webhook_url: Optional[str] = None
+    temporal_workflow_id: Optional[str] = None
+    temporal_run_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    # detail-only (get): the rolled-up run status + produced checkpoint + iterations.
+    status: Optional[str] = None
+    failure_reason: Optional[str] = None
+    checkpoint_id: Optional[str] = None
+    iterations: List[EvoSimIteration] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data):
+        obj = super().from_dict(data)
+        if obj.iterations and isinstance(obj.iterations[0], dict):
+            setattr(obj, "iterations", EvoSimIteration.from_list(obj.iterations))
+        return obj
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once the run has finished (``SUCCEEDED`` / ``PARTIAL_SUCCESS`` /
+        ``FAILED`` / ``CANCELED``). A ``None`` status (no iteration yet) is not
+        terminal — keep polling."""
+        return self.status in _TERMINAL_EVOSIM_STATUSES
+
+
+@dataclass
+class TrainingModuleInstance(APIModel):
+    """One Training Module Instance (TMI) — a module's run within an EvoSim iteration.
+    ``status`` is ``BUILDING`` (ongoing) / ``READY`` / ``FAILED`` / ``ARCHIVED``."""
+
+    tmi_id: str
+    module_key: Optional[str] = None
+    module_artifact_key: Optional[str] = None
+    created_by: Optional[str] = None
+    status: Optional[str] = None
+    session_id: Optional[str] = None
+    created_at: Optional[str] = None

--- a/lucidicai/api/models/experiment.py
+++ b/lucidicai/api/models/experiment.py
@@ -35,3 +35,18 @@ class Experiment(APIModel):
     num_events_data_by_tag: Optional[Dict[str, Any]] = None
     event_failure_groups: List[Dict[str, Any]] = field(default_factory=list)
     analytics_session_count: Optional[int] = None
+
+
+@dataclass
+class FailureGroup(APIModel):
+    """One clustered failure mode in an experiment (LUC-922) — a named group of
+    failing events, produced by ``experiments.generate_failure_modes`` and read
+    back via ``experiments.failure_groups``. ``events`` is a list of
+    ``{event_id, session_id}``. Keyed by ``id`` (the backend serializes it plain,
+    not as ``failure_group_id``)."""
+
+    id: str
+    group_name: Optional[str] = None
+    group_description: Optional[str] = None
+    icon: Optional[str] = None
+    events: List[Dict[str, Any]] = field(default_factory=list)

--- a/lucidicai/api/models/experiment.py
+++ b/lucidicai/api/models/experiment.py
@@ -1,0 +1,37 @@
+"""Typed response model for client.experiments reads (LUC-908)."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Experiment(APIModel):
+    """An experiment — a group of sessions with aggregated metrics/insights.
+
+    ``client.experiments.list()`` returns the light shape (through
+    ``eval_metrics`` / ``num_sessions`` / ``tags``); ``get()`` additionally
+    populates the detail metrics + failure groups (the fields below default to
+    ``None`` / ``[]`` in a list result).
+    """
+
+    experiment_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    num_sessions: Optional[int] = None
+    tags: List[str] = field(default_factory=list)
+    eval_metrics: Optional[Any] = None
+
+    # detail-only (get) — aggregated analytics; kept as raw dicts/lists.
+    agent_id: Optional[str] = None
+    eval_metrics_by_tag: Optional[Dict[str, Any]] = None
+    time_data: Optional[Dict[str, Any]] = None
+    time_data_by_tag: Optional[Dict[str, Any]] = None
+    cost_data: Optional[Dict[str, Any]] = None
+    cost_data_by_tag: Optional[Dict[str, Any]] = None
+    num_events_data: Optional[Dict[str, Any]] = None
+    num_events_data_by_tag: Optional[Dict[str, Any]] = None
+    event_failure_groups: List[Dict[str, Any]] = field(default_factory=list)
+    analytics_session_count: Optional[int] = None

--- a/lucidicai/api/models/project.py
+++ b/lucidicai/api/models/project.py
@@ -1,0 +1,16 @@
+"""Typed response model for client.projects (LUC-913)."""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Project(APIModel):
+    """A project — an org-level grouping that agents can be filed under
+    (``Agent.project``). Org-scoped: a bound key still sees all of them."""
+
+    project_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    icon: Optional[str] = None

--- a/lucidicai/api/models/prompt.py
+++ b/lucidicai/api/models/prompt.py
@@ -1,0 +1,35 @@
+"""Typed response models for client.prompts reads (LUC-909).
+
+Distinct from the SDK's grandfathered ``Prompt`` dataclass
+(``api/resources/prompt.py``), which is a *rendered* prompt (content + metadata,
+returned by ``prompts.get()``). These model the prompt catalog + version history.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class PromptInfo(APIModel):
+    """A prompt (unique name per agent) as returned by ``client.prompts.list()``.
+    ``preview`` is a short excerpt of its latest content."""
+
+    prompt_id: str
+    name: Optional[str] = None
+    icon: Optional[str] = None
+    preview: Optional[str] = None
+
+
+@dataclass
+class PromptVersion(APIModel):
+    """One immutable version of a prompt — its content, the labels pointing at
+    it, and metadata. Returned by ``client.prompts.versions(name)``."""
+
+    promptversion_id: str
+    prompt_version_number: Optional[int] = None
+    prompt_content: Optional[str] = None
+    description: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    labels: List[str] = field(default_factory=list)

--- a/lucidicai/api/models/resource.py
+++ b/lucidicai/api/models/resource.py
@@ -1,0 +1,31 @@
+"""Typed response model for client.resources (LUC-917)."""
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Resource(APIModel):
+    """A SQL-substrate Resource — the org-scoped definition of an external service
+    the client mocks at runtime (``type`` ``SQL`` / ``API`` / ``CUSTOM``). Authored
+    once per org and attached to Datasets and Tools; ``spec`` is the parsed schema
+    that backs fixture hydration + runtime mocking. Org-scoped, so a bound key still
+    sees all of the org's resources.
+
+    ``name`` and ``tool_name`` are each unique per org. ``handler_type`` is derived
+    from ``type`` by the backend (read-only). The write-only ``ddl`` create input
+    is parsed into ``spec`` server-side and never returned.
+    """
+
+    resource_id: str
+    type: Optional[str] = None
+    dialect: Optional[str] = None
+    tool_name: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    spec: Optional[Dict[str, Any]] = None
+    handler_type: Optional[str] = None
+    hydration_config: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None

--- a/lucidicai/api/models/session.py
+++ b/lucidicai/api/models/session.py
@@ -1,0 +1,167 @@
+"""Typed response models for client.sessions v2 reads (LUC-907)."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class Event(APIModel):
+    """One event in a session's trace.
+
+    The list/trace (preview) shape omits ``payload``; the single-event detail
+    (``client.sessions.event``) includes ``payload`` and, for an offloaded
+    payload requested with ``raw=True``, a short-lived presigned ``blob_url``.
+    ``children`` is populated by ``SessionTrace.tree()`` — not sent by the
+    backend.
+    """
+
+    event_id: str
+    session_id: Optional[str] = None
+    parent_event_id: Optional[str] = None
+    type: Optional[str] = None
+    created_at: Optional[str] = None
+    occurred_at: Optional[str] = None
+    duration: Optional[float] = None
+    cost: Optional[float] = None
+    summary: Optional[str] = None
+    function_name: Optional[str] = None
+    model_name: Optional[str] = None
+    provider: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = None
+    num_time_travels: Optional[int] = None
+    has_blob: bool = False
+    payload: Optional[Any] = None       # detail only
+    blob_url: Optional[str] = None      # raw=True + offloaded payload
+    children: List["Event"] = field(default_factory=list, repr=False)  # from tree()
+
+
+@dataclass
+class Session(APIModel):
+    """A session — a full run/trace of an agent execution. Returned by
+    ``client.sessions.list()`` and as the ``.session`` of a detail (``get``)."""
+
+    session_id: str
+    custom_session_id: Optional[str] = None
+    name: Optional[str] = None
+    start_time: Optional[str] = None
+    duration: Optional[float] = None
+    is_finished: bool = False
+    production_monitoring: bool = False
+    task: Optional[str] = None
+    cost: Optional[float] = None
+    tags: List[str] = field(default_factory=list)
+    eval_previews: List[Dict[str, Any]] = field(default_factory=list)
+    num_events: Optional[int] = None
+    status: Optional[str] = None
+    datasetitem_id: Optional[str] = None
+
+
+@dataclass
+class SessionTrace(APIModel):
+    """A session detail: session meta + its flat, ``occurred_at``-ordered event
+    trace. Rebuild the parent/child tree with ``tree()`` (or group with
+    ``children_by_parent()``)."""
+
+    session: Session
+    events: List[Event] = field(default_factory=list)
+    num_events: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SessionTrace":
+        data = data if isinstance(data, dict) else {}
+        obj = cls(
+            session=Session.from_dict(data.get("session") or {}),
+            events=Event.from_list(data.get("events") or []),
+            num_events=data.get("num_events"),
+        )
+        object.__setattr__(obj, "_extra", {
+            k: v for k, v in data.items()
+            if k not in ("session", "events", "num_events")
+        })
+        return obj
+
+    def children_by_parent(self) -> Dict[Optional[str], List[Event]]:
+        """Group events by parent. Root events — no parent, a parent absent from
+        this event set (e.g. a purged or truncated-out parent), or a
+        self-reference — are bucketed under the ``None`` key so nothing is
+        silently dropped. Preserves the backend's ``occurred_at`` ordering.
+        """
+        known = {ev.event_id for ev in self.events}
+        by_parent: Dict[Optional[str], List[Event]] = {}
+        for ev in self.events:
+            pid = ev.parent_event_id
+            if pid is None or pid == ev.event_id or pid not in known:
+                pid = None  # true root, orphan, or self-cycle -> treat as root
+            by_parent.setdefault(pid, []).append(ev)
+        return by_parent
+
+    def tree(self) -> List[Event]:
+        """Rebuild the trace tree from ``parent_event_id``: returns the root
+        events, each with its ``children`` linked. Orphan events (parent not in
+        the returned set) surface as roots rather than vanishing."""
+        by_parent = self.children_by_parent()
+        for ev in self.events:
+            ev.children = by_parent.get(ev.event_id, [])
+        return by_parent.get(None, [])
+
+
+@dataclass
+class EvalResult(APIModel):
+    """One session-level evaluator result."""
+
+    eval_id: str
+    evaluator_id: Optional[str] = None
+    evaluator_name: Optional[str] = None
+    evaluator_type: Optional[str] = None
+    result: Optional[Any] = None
+    result_type: Optional[str] = None
+    description: Optional[str] = None
+    is_pending: bool = False
+    error_message: Optional[str] = None
+    execution_time_ms: Optional[int] = None
+    submitted_by: Optional[str] = None
+    evaluated_at: Optional[str] = None
+    last_updated: Optional[str] = None
+    created_at: Optional[str] = None
+    session_id: Optional[str] = None
+    criteria_results: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class EventEval(APIModel):
+    """One event-level eval mapping (``NewEventEval``)."""
+
+    eval_id: str
+    event_id: Optional[str] = None
+    session_id: Optional[str] = None
+    criteria_name: Optional[str] = None
+    result: Optional[Any] = None
+    description: Optional[str] = None
+    lucidic_created: bool = False
+    evaluator_failed: bool = False
+    criteria_failed: bool = False
+    last_updated: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+@dataclass
+class SessionEvaluatorResults(APIModel):
+    """A session's eval scores: session-level ``evals`` + event-level
+    ``event_evals``. Returned by ``client.sessions.evaluator_results``."""
+
+    evals: List[EvalResult] = field(default_factory=list)
+    event_evals: List[EventEval] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SessionEvaluatorResults":
+        data = data if isinstance(data, dict) else {}
+        obj = cls(
+            evals=EvalResult.from_list(data.get("evals") or []),
+            event_evals=EventEval.from_list(data.get("event_evals") or []),
+        )
+        object.__setattr__(obj, "_extra", {
+            k: v for k, v in data.items() if k not in ("evals", "event_evals")
+        })
+        return obj

--- a/lucidicai/api/models/taxonomy.py
+++ b/lucidicai/api/models/taxonomy.py
@@ -1,0 +1,50 @@
+"""Typed response models for client.experiments.taxonomy (LUC-922)."""
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .base import APIModel
+
+
+@dataclass
+class TaxonomyRun(APIModel):
+    """A trace-taxonomy run for an experiment. The trigger / ongoing shape carries
+    ``run_id`` / ``version`` / ``status`` / ``created_at``; the completed read
+    (``taxonomy.get``) adds ``completed_at`` and the ``taxonomy`` dimensions output.
+    ``status`` is ongoing (``queued`` / ``sampling`` / ``discovering_dimensions`` /
+    ... ) or terminal (``completed`` / ``failed``)."""
+
+    run_id: str
+    version: Optional[int] = None
+    status: Optional[str] = None
+    created_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    taxonomy: Optional[Any] = None
+
+
+@dataclass
+class TaxonomyStatus(APIModel):
+    """The poll target for taxonomy generation (``GET .../taxonomy/status``): the
+    experiment's in-flight run (``ongoing``, null when none) and its latest completed
+    taxonomy (``latest_completed``, null until one finishes). Terminal once no run is
+    ongoing — a run either completes (into ``latest_completed``) or fails (clears
+    ``ongoing`` without updating ``latest_completed``)."""
+
+    ongoing: Optional[TaxonomyRun] = None
+    latest_completed: Optional[TaxonomyRun] = None
+    evaluating_session_count: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data):
+        obj = super().from_dict(data)
+        # The two nested run objects arrive as raw dicts — type them.
+        for attr in ("ongoing", "latest_completed"):
+            value = getattr(obj, attr, None)
+            if isinstance(value, dict):
+                setattr(obj, attr, TaxonomyRun.from_dict(value))
+        return obj
+
+    @property
+    def is_terminal(self) -> bool:
+        """True once no taxonomy run is in progress (the triggered run finished —
+        successfully into ``latest_completed`` or by failing out of ``ongoing``)."""
+        return self.ongoing is None

--- a/lucidicai/api/models/usage.py
+++ b/lucidicai/api/models/usage.py
@@ -1,0 +1,48 @@
+"""Typed response model for client.usage (LUC-911).
+
+The usage endpoint returns a *dynamic* ``{stat_name: total}`` map (stat names
+are backend-normalized: spaces -> ``_``, ``/`` removed, lowercased), so — unlike
+the fixed-field ``APIModel`` models — ``Usage`` is a thin read-only mapping
+wrapper over the raw dict rather than a dataclass with declared fields.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, ItemsView, Iterator, KeysView
+
+
+@dataclass
+class Usage:
+    """Org-aggregated usage / quota counters as a read-only mapping.
+
+    Access counters by name — ``usage["num_sessions"]`` / ``usage.get("cost")``
+    — or reach the raw dict via ``.stats``. An org-less key yields an empty map.
+    """
+
+    stats: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Usage":
+        return cls(stats=dict(data) if isinstance(data, dict) else {})
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.stats.get(key, default)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self.stats)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.stats[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.stats
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.stats)
+
+    def __len__(self) -> int:
+        return len(self.stats)
+
+    def keys(self) -> KeysView[str]:
+        return self.stats.keys()
+
+    def items(self) -> ItemsView[str, Any]:
+        return self.stats.items()

--- a/lucidicai/api/pagination.py
+++ b/lucidicai/api/pagination.py
@@ -1,0 +1,56 @@
+"""Cursor-pagination iteration for the SDK read surface (LUC-902).
+
+v2 list endpoints return ``{"results": [...], "next": <url|null>,
+"previous": <url|null>}`` with ``?page_size`` (default 50, max 200),
+``?cursor``, and an allow-listed ``?ordering``. ``paginate`` / ``apaginate``
+return a lazy iterator that transparently follows ``next``, yielding typed
+items so callers can write ``for agent in client.agents.list(...)``.
+
+Following ``next`` re-issues the page request through the authed
+``HttpClient`` (the ``fetch`` callback extracts and forwards the ``cursor``)
+rather than hitting the raw ``next`` URL directly, so auth headers, retry, and
+base-URL handling are all preserved. For single-page / manual control, call
+the endpoint once and wrap the body with ``CursorPage.from_body``.
+"""
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Iterator, Optional, Type
+
+from .models.base import APIModel, CursorPage, _extract_cursor
+
+__all__ = ["paginate", "apaginate", "CursorPage"]
+
+# fetch(cursor) -> raw page body. cursor is None for the first page.
+_SyncFetch = Callable[[Optional[str]], Dict[str, Any]]
+_AsyncFetch = Callable[[Optional[str]], Awaitable[Dict[str, Any]]]
+
+
+def _convert(item: Any, model: Optional[Type[APIModel]]) -> Any:
+    return model.from_dict(item) if model is not None else item
+
+
+def paginate(fetch: _SyncFetch, *, model: Optional[Type[APIModel]] = None) -> Iterator[Any]:
+    """Lazily yield every item across all pages.
+
+    ``fetch(cursor)`` performs one page request (``cursor=None`` first) and
+    returns the raw ``{results, next, previous}`` body. Each item is converted
+    via ``model.from_dict`` when a ``model`` is given, else yielded raw.
+    """
+    cursor: Optional[str] = None
+    while True:
+        body = fetch(cursor)
+        for item in (body.get("results", []) if isinstance(body, dict) else []):
+            yield _convert(item, model)
+        cursor = _extract_cursor(body.get("next") if isinstance(body, dict) else None)
+        if cursor is None:
+            return
+
+
+async def apaginate(fetch: _AsyncFetch, *, model: Optional[Type[APIModel]] = None) -> AsyncIterator[Any]:
+    """Async sibling of ``paginate`` — ``async for item in apaginate(...)``."""
+    cursor: Optional[str] = None
+    while True:
+        body = await fetch(cursor)
+        for item in (body.get("results", []) if isinstance(body, dict) else []):
+            yield _convert(item, model)
+        cursor = _extract_cursor(body.get("next") if isinstance(body, dict) else None)
+        if cursor is None:
+            return

--- a/lucidicai/api/polling.py
+++ b/lucidicai/api/polling.py
@@ -1,0 +1,85 @@
+"""Generic trigger-then-poll ``wait_for`` primitive (LUC-920).
+
+The reusable poll loop behind the SDK's async, workflow-backed resources (dataset
+generation, taxonomy / failure-modes, evosim runs, training-module inference). A
+resource triggers a backend workflow, then blocks on ``wait_for`` — polling a
+status callable on a fixed interval until it reports a terminal state or a deadline
+elapses.
+
+This owns only the loop mechanics (deadline, interval, optional pre-fetched initial
+state, final-sleep clamping). Terminal-state *interpretation* — which states are
+terminal, and whether a terminal state means success or failure — stays with the
+caller via ``is_terminal`` and its handling of the returned state.
+"""
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, TypeVar
+
+from ..core.errors import WaitTimeout
+
+T = TypeVar("T")
+
+# Distinguishes "no initial state supplied" from a legitimately falsy/None state.
+_UNSET: Any = object()
+
+
+def wait_for(
+    poll: Callable[[], T],
+    *,
+    is_terminal: Callable[[T], bool],
+    timeout: float,
+    interval: float,
+    initial: Any = _UNSET,
+) -> T:
+    """Poll ``poll()`` until ``is_terminal(state)`` is true or the ``timeout``
+    deadline elapses.
+
+    Returns the first terminal state. Raises :class:`WaitTimeout` (carrying the
+    last polled state) if the deadline elapses first. ``poll`` is called once up
+    front unless an ``initial`` state is supplied (e.g. a trigger response already
+    carries the first status), then once per ``interval`` thereafter. The final
+    sleep is clamped so polling never overshoots the deadline.
+
+    Args:
+        poll: Zero-arg callable returning the current state.
+        is_terminal: Predicate — true when a state should stop the loop.
+        timeout: Total budget in seconds (clamped to >= 0).
+        interval: Seconds to sleep between polls (clamped to >= 0). Note: ``0``
+            busy-polls with no delay between calls — pass a real interval (e.g.
+            a couple of seconds) for anything backed by a network status request.
+        initial: A state already in hand; when given, ``poll`` is not called until
+            after the first interval.
+    """
+    budget = max(0.0, timeout)
+    deadline = time.monotonic() + budget
+    state: T = poll() if initial is _UNSET else initial
+    while not is_terminal(state):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WaitTimeout(state, budget)
+        time.sleep(min(max(0.0, interval), remaining))
+        state = poll()
+    return state
+
+
+async def await_for(
+    poll: Callable[[], Awaitable[T]],
+    *,
+    is_terminal: Callable[[T], bool],
+    timeout: float,
+    interval: float,
+    initial: Any = _UNSET,
+) -> T:
+    """Async sibling of :func:`wait_for` — ``poll`` is an ``async`` callable and the
+    inter-poll wait uses ``asyncio.sleep``. Same semantics otherwise (including the
+    ``interval=0`` busy-poll caveat)."""
+    budget = max(0.0, timeout)
+    deadline = time.monotonic() + budget
+    state: T = (await poll()) if initial is _UNSET else initial
+    while not is_terminal(state):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WaitTimeout(state, budget)
+        await asyncio.sleep(min(max(0.0, interval), remaining))
+        state = await poll()
+    return state

--- a/lucidicai/api/resources/agent_tools_sync.py
+++ b/lucidicai/api/resources/agent_tools_sync.py
@@ -19,10 +19,7 @@ Backend contract (``api/views/sdk_agent_tools.py``, frozen):
 import logging
 from typing import Any, Dict, List
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import LucidicError
 
 logger = logging.getLogger("Lucidic")
 
@@ -52,21 +49,17 @@ class SyncAgentToolsResource:
         "drift_count": int, ...}}`` (exact shape is informational; the
         SDK only checks synced=True).
 
-        Raises ``LucidicError`` on any non-2xx. The validation-failure
-        path (422) carries a structured error body in
-        ``exc.response.json()["errors"]`` — surfaced inline in the
-        exception message so callers see the bad payload field without
-        manual parsing.
+        Raises a typed ``LucidicError`` on any non-2xx. A 422 validation
+        failure surfaces as ``ValidationError`` with the ``{<field>: [...]}}``
+        payload on ``.details``; a 503 (lock contention) is retried by the
+        transport first, then raised as ``ServiceUnavailableError``.
         """
         body = {"agent_id": agent_id, "tools": tools}
         logger.debug(
             "[SyncAgentToolsResource] syncing %d tool(s) for agent %s",
             len(tools), agent_id[:8] + "...",
         )
-        try:
-            return self.http.post("sdk/agent-tools/sync", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_sync_error(exc)) from exc
+        return self.http.post("sdk/agent-tools/sync", body)
 
     async def async_sync(
         self,
@@ -76,26 +69,4 @@ class SyncAgentToolsResource:
     ) -> Dict[str, Any]:
         """Async sibling of ``sync``."""
         body = {"agent_id": agent_id, "tools": tools}
-        try:
-            return await self.http.apost("sdk/agent-tools/sync", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_sync_error(exc)) from exc
-
-
-def _format_sync_error(exc: httpx.HTTPStatusError) -> str:
-    """Best-effort human-readable error from a non-2xx /sdk/agent-tools/sync.
-
-    422 carries ``{"errors": {<field>: [...messages]}}`` from
-    Tool.clean; 503 carries ``{"error": <str>}``; other shapes fall
-    back to status + raw body.
-    """
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
-    if isinstance(body, dict):
-        if "errors" in body:
-            return f"HTTP {exc.response.status_code} validation: {body['errors']}"
-        if "error" in body:
-            return f"HTTP {exc.response.status_code}: {body['error']}"
-    return f"HTTP {exc.response.status_code}: {body!r}"
+        return await self.http.apost("sdk/agent-tools/sync", body)

--- a/lucidicai/api/resources/agents.py
+++ b/lucidicai/api/resources/agents.py
@@ -1,0 +1,127 @@
+"""client.agents — agent reads (LUC-906).
+
+Read the org's agents: ``list`` them (discover / enumerate ``agent_id`` s),
+``get`` one back, or inspect an agent's ``tool_catalog``.
+
+(A brand-new caller with *no* ``agent_id`` at all still can't construct the
+client to reach ``list`` — ``LucidicAI`` requires one today; a read-only /
+bootstrap construction mode is a planned follow-up. With any existing key +
+``agent_id`` you can enumerate the rest.)
+
+Reads are data-bearing, so — unlike the telemetry-write resources — they do
+NOT swallow errors in production: a failure raises the typed ``LucidicError``
+subclass the transport decoded (``NotFoundError``, ``InsufficientScopeError``,
+…). Every method has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.agent import Agent, AgentToolCatalog
+from ..models.base import CursorPage
+from ..pagination import apaginate, paginate
+
+_AGENTS = "sdk/v2/agents"
+
+
+class AgentsResource:
+    """Handle for the ``/sdk/v2/agents`` read endpoints."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    # ==================== list ====================
+
+    def list(
+        self, *, page_size: Optional[int] = None, ordering: Optional[str] = None
+    ) -> Iterator[Agent]:
+        """Lazily iterate the org's agents (backend default order: newest first),
+        following pages.
+
+        ``for agent in client.agents.list(): ...`` — a bound key sees only its
+        one agent. ``ordering`` accepts ``id`` / ``-id`` (the only
+        client-selectable ordering field).
+
+        Note: this is a lazy generator — request errors (403/etc.) surface on
+        the first iteration, not at the ``list()`` call. Use ``list_page`` for
+        an eager single-page fetch.
+        """
+        return paginate(
+            lambda cursor: self._page(cursor, page_size, ordering), model=Agent
+        )
+
+    def alist(
+        self, *, page_size: Optional[int] = None, ordering: Optional[str] = None
+    ) -> AsyncIterator[Agent]:
+        """Async sibling of ``list`` — ``async for agent in client.agents.alist()``."""
+        return apaginate(
+            lambda cursor: self._apage(cursor, page_size, ordering), model=Agent
+        )
+
+    def list_page(
+        self,
+        *,
+        cursor: Optional[str] = None,
+        page_size: Optional[int] = None,
+        ordering: Optional[str] = None,
+    ) -> CursorPage:
+        """Fetch a single page of agents (manual pagination control)."""
+        return CursorPage.from_body(self._page(cursor, page_size, ordering), model=Agent)
+
+    async def alist_page(
+        self,
+        *,
+        cursor: Optional[str] = None,
+        page_size: Optional[int] = None,
+        ordering: Optional[str] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage(cursor, page_size, ordering)
+        return CursorPage.from_body(body, model=Agent)
+
+    # ==================== get ====================
+
+    def get(self, agent_id: str) -> Agent:
+        """Read one agent by id. Raises ``NotFoundError`` if it doesn't exist
+        or the (bound) key can't see it."""
+        return Agent.from_dict(self.http.get(f"{_AGENTS}/{agent_id}"))
+
+    async def aget(self, agent_id: str) -> Agent:
+        """Async sibling of ``get``."""
+        return Agent.from_dict(await self.http.aget(f"{_AGENTS}/{agent_id}"))
+
+    # ==================== tool catalog ====================
+
+    def tool_catalog(self, agent_id: str) -> AgentToolCatalog:
+        """Read the agent's tool catalog: per-tool tier/impl/drift + denormalized
+        usage (``call_count`` / ``last_called_at``) and the reachable Resources."""
+        return AgentToolCatalog.from_dict(self.http.get(f"{_AGENTS}/{agent_id}/tool-catalog"))
+
+    async def atool_catalog(self, agent_id: str) -> AgentToolCatalog:
+        """Async sibling of ``tool_catalog``."""
+        body = await self.http.aget(f"{_AGENTS}/{agent_id}/tool-catalog")
+        return AgentToolCatalog.from_dict(body)
+
+    # ==================== internals ====================
+
+    @staticmethod
+    def _params(
+        cursor: Optional[str], page_size: Optional[int], ordering: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        if page_size is not None:
+            params["page_size"] = page_size
+        if ordering is not None:
+            params["ordering"] = ordering
+        return params or None
+
+    def _page(
+        self, cursor: Optional[str], page_size: Optional[int], ordering: Optional[str]
+    ) -> Dict[str, Any]:
+        return self.http.get(_AGENTS, self._params(cursor, page_size, ordering))
+
+    async def _apage(
+        self, cursor: Optional[str], page_size: Optional[int], ordering: Optional[str]
+    ) -> Dict[str, Any]:
+        return await self.http.aget(_AGENTS, self._params(cursor, page_size, ordering))

--- a/lucidicai/api/resources/agents.py
+++ b/lucidicai/api/resources/agents.py
@@ -1,17 +1,16 @@
-"""client.agents — agent reads (LUC-906).
+"""client.agents — agent reads + writes (LUC-906 / LUC-912).
 
-Read the org's agents: ``list`` them (discover / enumerate ``agent_id`` s),
-``get`` one back, or inspect an agent's ``tool_catalog``.
+Read the org's agents (``list`` / ``get`` / ``tool_catalog``) and provision them
+(``create`` / ``update``). ``create`` is the SDK-first bootstrap — since LUC-926
+a client needs only an api_key to construct, so ``client.agents.create(...)``
+can mint an org's first agent purely from code. There is no ``delete`` (that
+cascades to every session/event/tool/prompt under the agent — dashboard-only).
 
-(A brand-new caller with *no* ``agent_id`` at all still can't construct the
-client to reach ``list`` — ``LucidicAI`` requires one today; a read-only /
-bootstrap construction mode is a planned follow-up. With any existing key +
-``agent_id`` you can enumerate the rest.)
-
-Reads are data-bearing, so — unlike the telemetry-write resources — they do
-NOT swallow errors in production: a failure raises the typed ``LucidicError``
-subclass the transport decoded (``NotFoundError``, ``InsufficientScopeError``,
-…). Every method has an ``a``-prefixed async sibling.
+Both reads and writes are data-bearing, so — unlike the telemetry resources —
+they do NOT swallow errors in production: a failure raises the typed
+``LucidicError`` subclass the transport decoded (``NotFoundError``,
+``InsufficientScopeError``, ``ValidationError``, …). Every method has an
+``a``-prefixed async sibling.
 """
 from typing import Any, AsyncIterator, Dict, Iterator, Optional
 
@@ -88,6 +87,74 @@ class AgentsResource:
     async def aget(self, agent_id: str) -> Agent:
         """Async sibling of ``get``."""
         return Agent.from_dict(await self.http.aget(f"{_AGENTS}/{agent_id}"))
+
+    # ==================== write (LUC-912) ====================
+
+    def create(
+        self, name: str, *, icon: Optional[str] = None, project_id: Optional[str] = None,
+    ) -> Agent:
+        """Create an agent in the key's org — the SDK-first bootstrap.
+
+        Needs ``agent:write``. An agent-**bound** key can't create agents (it
+        could only ever see its one agent) → the backend returns 403 →
+        ``InsufficientScopeError`` (a binding restriction, not a missing scope;
+        see that error's docs). ``icon`` defaults backend-side ("compass") when
+        omitted; ``project_id`` optionally files the new agent under a project.
+        """
+        return Agent.from_dict(self.http.post(_AGENTS, self._create_body(name, icon, project_id)))
+
+    async def acreate(
+        self, name: str, *, icon: Optional[str] = None, project_id: Optional[str] = None,
+    ) -> Agent:
+        """Async sibling of ``create``."""
+        body = self._create_body(name, icon, project_id)
+        return Agent.from_dict(await self.http.apost(_AGENTS, body))
+
+    def update(
+        self, agent_id: str, *, name: Optional[str] = None, icon: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> Agent:
+        """Update an agent's name / icon / project (e.g. move it between
+        projects). Only the fields you pass change; ``None`` leaves a field
+        untouched. An over-length name/icon → ``ValidationError``."""
+        return Agent.from_dict(
+            self.http.put(f"{_AGENTS}/{agent_id}", self._update_body(name, icon, project_id))
+        )
+
+    async def aupdate(
+        self, agent_id: str, *, name: Optional[str] = None, icon: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> Agent:
+        """Async sibling of ``update``."""
+        return Agent.from_dict(
+            await self.http.aput(f"{_AGENTS}/{agent_id}", self._update_body(name, icon, project_id))
+        )
+
+    @staticmethod
+    def _create_body(
+        name: str, icon: Optional[str], project_id: Optional[str]
+    ) -> Dict[str, Any]:
+        # Omit unset optional fields uniformly (like _update_body) so the backend
+        # owns their defaults — don't hardcode "compass" here.
+        body: Dict[str, Any] = {"name": name}
+        if icon is not None:
+            body["icon"] = icon
+        if project_id is not None:
+            body["project_id"] = project_id
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], icon: Optional[str], project_id: Optional[str]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if icon is not None:
+            body["icon"] = icon
+        if project_id is not None:
+            body["project_id"] = project_id
+        return body
 
     # ==================== tool catalog ====================
 

--- a/lucidicai/api/resources/dataset.py
+++ b/lucidicai/api/resources/dataset.py
@@ -4,13 +4,15 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
 from ..models.base import CursorPage
-from ..models.dataset import DatasetItem, DatasetSchema, Fixture
+from ..models.dataset import DatasetGenerationRun, DatasetItem, DatasetSchema, Fixture
 from ..pagination import apaginate, paginate
+from ..polling import await_for, wait_for
 
 logger = logging.getLogger("Lucidic")
 
 _SCHEMAS = "sdk/v2/datasets/schemas"
 _FIXTURES = "sdk/v2/fixtures"
+_GENERATE = "sdk/v2/datasets/generate"
 
 
 class DatasetResource:
@@ -99,6 +101,122 @@ class DatasetResource:
         if cursor:
             params["cursor"] = cursor
         return await self.http.aget(path, params or None)
+
+    # ==================== generation (LUC-921) ====================
+    #
+    # The async dataset-generation pipeline: trigger → poll → (retry). Trigger and
+    # retry kick off a Temporal workflow and return the run; status reads its
+    # progress; wait_for_generation blocks on the LUC-920 poll helper until the run
+    # is terminal. Org-scoped by the key; agent-bound via the run's experiment.
+
+    def generate(
+        self, *, agent_id: str, experiment_id: str, schema_id: str, dataset_name: str,
+        dataset_description: Optional[str] = None, target_count: Optional[int] = None,
+        combo_cap: Optional[int] = None, selected_dimension_ids: Optional[List[str]] = None,
+        resource_ids: Optional[List[str]] = None,
+    ) -> DatasetGenerationRun:
+        """Trigger dataset generation (POST /sdk/v2/datasets/generate; needs
+        ``dataset:generate``). Fills a new dataset from ``schema_id`` using the
+        ``experiment_id``'s trace taxonomy (the experiment must belong to
+        ``agent_id`` and have a completed taxonomy run). ``target_count`` (default
+        50, 1–500) and ``combo_cap`` (default 50, 1–200) bound the output; omit to
+        take the backend defaults. Returns the created run (``run_id`` +
+        ``dataset_id`` + initial ``"queued"`` status) — poll it with
+        ``generation_status`` / ``wait_for_generation``.
+
+        Raises ``ValidationError`` (bad refs / no taxonomy / unknown dimensions),
+        ``NotFoundError`` (agent / experiment / schema not visible to the key), or
+        ``ServiceUnavailableError`` (503 — the workflow couldn't start; retry)."""
+        return DatasetGenerationRun.from_dict(self.http.post(_GENERATE, self._generate_body(
+            agent_id, experiment_id, schema_id, dataset_name, dataset_description,
+            target_count, combo_cap, selected_dimension_ids, resource_ids)))
+
+    async def agenerate(
+        self, *, agent_id: str, experiment_id: str, schema_id: str, dataset_name: str,
+        dataset_description: Optional[str] = None, target_count: Optional[int] = None,
+        combo_cap: Optional[int] = None, selected_dimension_ids: Optional[List[str]] = None,
+        resource_ids: Optional[List[str]] = None,
+    ) -> DatasetGenerationRun:
+        """Async sibling of ``generate``."""
+        return DatasetGenerationRun.from_dict(await self.http.apost(_GENERATE, self._generate_body(
+            agent_id, experiment_id, schema_id, dataset_name, dataset_description,
+            target_count, combo_cap, selected_dimension_ids, resource_ids)))
+
+    def generation_status(self, run_id: str) -> DatasetGenerationRun:
+        """Read a generation run's status + progress (GET
+        /sdk/v2/datasets/generate/{run_id}/status; needs ``dataset:read``). Unknown
+        / cross-org / out-of-binding run → ``NotFoundError``."""
+        return DatasetGenerationRun.from_dict(self.http.get(f"{_GENERATE}/{run_id}/status"))
+
+    async def ageneration_status(self, run_id: str) -> DatasetGenerationRun:
+        """Async sibling of ``generation_status``."""
+        return DatasetGenerationRun.from_dict(await self.http.aget(f"{_GENERATE}/{run_id}/status"))
+
+    def retry_generation(self, run_id: str) -> DatasetGenerationRun:
+        """Retry a **failed** generation run (POST
+        /sdk/v2/datasets/generate/{run_id}/retry; needs ``dataset:generate``). Only
+        a run whose status is ``"failed"`` can be retried (else ``ValidationError``);
+        this clones a brand-new dataset + run (the failed one is left in place) and
+        returns the new run (new ``run_id`` / ``dataset_id``). May 503 like
+        ``generate``."""
+        return DatasetGenerationRun.from_dict(self.http.post(f"{_GENERATE}/{run_id}/retry"))
+
+    async def aretry_generation(self, run_id: str) -> DatasetGenerationRun:
+        """Async sibling of ``retry_generation``."""
+        return DatasetGenerationRun.from_dict(await self.http.apost(f"{_GENERATE}/{run_id}/retry"))
+
+    def wait_for_generation(
+        self, run_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> DatasetGenerationRun:
+        """Block until a generation run is terminal (``completed`` or ``failed``) or
+        ``timeout`` seconds elapse, polling ``generation_status`` every ``interval``
+        seconds. Returns the terminal run — inspect ``.succeeded`` / ``.status`` /
+        ``.error_message`` (a **failed** run is returned, not raised; retry it with
+        ``retry_generation``). Raises ``WaitTimeout`` if the deadline passes first.
+
+        The default ``timeout`` (30 min) matches the backend's own generation budget
+        so a full-length healthy run isn't cut off client-side; raise it only if that
+        server budget has been raised."""
+        return wait_for(
+            lambda: self.generation_status(run_id),
+            is_terminal=lambda run: run.is_terminal,
+            timeout=timeout, interval=interval,
+        )
+
+    async def await_for_generation(
+        self, run_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> DatasetGenerationRun:
+        """Async sibling of ``wait_for_generation``."""
+        return await await_for(
+            lambda: self.ageneration_status(run_id),
+            is_terminal=lambda run: run.is_terminal,
+            timeout=timeout, interval=interval,
+        )
+
+    @staticmethod
+    def _generate_body(
+        agent_id: str, experiment_id: str, schema_id: str, dataset_name: str,
+        dataset_description: Optional[str], target_count: Optional[int],
+        combo_cap: Optional[int], selected_dimension_ids: Optional[List[str]],
+        resource_ids: Optional[List[str]],
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "agent_id": agent_id, "experiment_id": experiment_id,
+            "schema_id": schema_id, "dataset_name": dataset_name,
+        }
+        # omit-None: let the backend apply its defaults (dataset_description="",
+        # target_count=50, combo_cap=50, selected_dimension_ids=[], resource_ids=[]).
+        if dataset_description is not None:
+            body["dataset_description"] = dataset_description
+        if target_count is not None:
+            body["target_count"] = target_count
+        if combo_cap is not None:
+            body["combo_cap"] = combo_cap
+        if selected_dimension_ids is not None:
+            body["selected_dimension_ids"] = selected_dimension_ids
+        if resource_ids is not None:
+            body["resource_ids"] = resource_ids
+        return body
 
     # ==================== Dataset Methods ====================
 

--- a/lucidicai/api/resources/dataset.py
+++ b/lucidicai/api/resources/dataset.py
@@ -1,10 +1,16 @@
 """Dataset resource API operations."""
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.dataset import DatasetItem, DatasetSchema, Fixture
+from ..pagination import apaginate, paginate
 
 logger = logging.getLogger("Lucidic")
+
+_SCHEMAS = "sdk/v2/datasets/schemas"
+_FIXTURES = "sdk/v2/fixtures"
 
 
 class DatasetResource:
@@ -26,6 +32,73 @@ class DatasetResource:
         self.http = http
         self._agent_id = agent_id
         self._production = production
+        # v2 sub-namespaces (LUC-918): client.datasets.schemas / .fixtures.
+        # Stateless (ids passed per call), so one instance each is reused.
+        self._schemas = DatasetSchemasResource(http)
+        self._fixtures = DatasetFixturesResource(http)
+
+    # ==================== v2 surface (LUC-918) ====================
+    #
+    # Data-bearing v2 reads/writes: they do NOT swallow in production (typed
+    # transport errors propagate), unlike the gen-3 methods below. ``items`` is a
+    # cursor-paginated read of a dataset's items; ``schemas`` / ``fixtures`` are
+    # sub-namespaces. Each has an async sibling.
+
+    @property
+    def schemas(self) -> "DatasetSchemasResource":
+        """Dataset schema CRUD — ``client.datasets.schemas.list()`` /
+        ``create`` / ``get`` / ``update`` / ``delete`` (org-scoped typed
+        definitions of a dataset item's ``input`` shape)."""
+        return self._schemas
+
+    @property
+    def fixtures(self) -> "DatasetFixturesResource":
+        """Fixture authoring — ``client.datasets.fixtures.create(...)`` builds a
+        base DuckDB fixture for a ``(dataset, resource)`` pair from JSON rows."""
+        return self._fixtures
+
+    def items(self, dataset_id: str, *, page_size: Optional[int] = None) -> Iterator[DatasetItem]:
+        """Lazily iterate a dataset's items, newest first (GET
+        /sdk/v2/datasets/{id}/items; needs ``dataset-item:read``). Cursor-paginated
+        — transparently walks every page. Unknown / cross-org dataset →
+        ``NotFoundError`` on first iteration."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        path = f"sdk/v2/datasets/{dataset_id}/items"
+        return paginate(lambda c: self._v2_page_get(path, base, c), model=DatasetItem)
+
+    def aitems(self, dataset_id: str, *, page_size: Optional[int] = None) -> AsyncIterator[DatasetItem]:
+        """Async sibling of ``items``."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        path = f"sdk/v2/datasets/{dataset_id}/items"
+        return apaginate(lambda c: self._v2_apage_get(path, base, c), model=DatasetItem)
+
+    def items_page(
+        self, dataset_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of a dataset's items."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        body = self._v2_page_get(f"sdk/v2/datasets/{dataset_id}/items", base, cursor)
+        return CursorPage.from_body(body, model=DatasetItem)
+
+    async def aitems_page(
+        self, dataset_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``items_page``."""
+        base = {"page_size": page_size} if page_size is not None else {}
+        body = await self._v2_apage_get(f"sdk/v2/datasets/{dataset_id}/items", base, cursor)
+        return CursorPage.from_body(body, model=DatasetItem)
+
+    def _v2_page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params or None)
+
+    async def _v2_apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params or None)
 
     # ==================== Dataset Methods ====================
 
@@ -530,3 +603,188 @@ class DatasetResource:
                 logger.error(f"[DatasetResource] Failed to list item sessions: {e}")
                 return {"num_sessions": 0, "sessions": []}
             raise
+
+
+class DatasetSchemasResource:
+    """``client.datasets.schemas`` — dataset schema CRUD (LUC-918).
+
+    A dataset schema is an org-scoped typed definition of a dataset item's ``input``
+    shape (required for dataset generation). Org-scoped: a bound key reaches them
+    all. Data-bearing — no production swallow. Each method has an async sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def list(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> Iterator[DatasetSchema]:
+        """Lazily iterate the org's dataset schemas, newest first. ``ordering``
+        accepts ``id`` (± prefix)."""
+        base = self._params(ordering, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=DatasetSchema)
+
+    def alist(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> AsyncIterator[DatasetSchema]:
+        """Async sibling of ``list``."""
+        base = self._params(ordering, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=DatasetSchema)
+
+    def list_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of dataset schemas."""
+        return CursorPage.from_body(
+            self._page_get(self._params(ordering, page_size), cursor), model=DatasetSchema
+        )
+
+    async def alist_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=DatasetSchema)
+
+    def get(self, schema_id: str) -> DatasetSchema:
+        """Read one schema by id (raises ``NotFoundError`` if absent/cross-org)."""
+        return DatasetSchema.from_dict(self.http.get(f"{_SCHEMAS}/{schema_id}"))
+
+    async def aget(self, schema_id: str) -> DatasetSchema:
+        """Async sibling of ``get``."""
+        return DatasetSchema.from_dict(await self.http.aget(f"{_SCHEMAS}/{schema_id}"))
+
+    def create(
+        self, name: str, *, fields: List[Dict[str, Any]], description: Optional[str] = None
+    ) -> DatasetSchema:
+        """Create a dataset schema in the key's org (POST /sdk/v2/datasets/schemas;
+        needs ``dataset-schema:write``). ``fields`` is a non-empty list of typed
+        field defs — each ``{key, type, description?, required?, options?,
+        children?}`` where ``type`` is ``string`` / ``number`` / ``categorical`` /
+        ``object`` (``categorical`` needs ``options``; ``object`` needs
+        ``children``). ``name`` is unique per org — a duplicate → ``ConflictError``;
+        a malformed field → ``ValidationError``."""
+        return DatasetSchema.from_dict(
+            self.http.post(_SCHEMAS, self._create_body(name, fields, description))
+        )
+
+    async def acreate(
+        self, name: str, *, fields: List[Dict[str, Any]], description: Optional[str] = None
+    ) -> DatasetSchema:
+        """Async sibling of ``create``."""
+        return DatasetSchema.from_dict(
+            await self.http.apost(_SCHEMAS, self._create_body(name, fields, description))
+        )
+
+    def update(
+        self, schema_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, fields: Optional[List[Dict[str, Any]]] = None,
+    ) -> DatasetSchema:
+        """Partially update a schema (PUT /sdk/v2/datasets/schemas/{id}; needs
+        ``dataset-schema:write``). Send only the fields to change. A rename
+        collision → ``ConflictError``."""
+        return DatasetSchema.from_dict(
+            self.http.put(f"{_SCHEMAS}/{schema_id}", self._update_body(name, description, fields))
+        )
+
+    async def aupdate(
+        self, schema_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, fields: Optional[List[Dict[str, Any]]] = None,
+    ) -> DatasetSchema:
+        """Async sibling of ``update``."""
+        return DatasetSchema.from_dict(
+            await self.http.aput(f"{_SCHEMAS}/{schema_id}", self._update_body(name, description, fields))
+        )
+
+    def delete(self, schema_id: str) -> None:
+        """Delete a schema (DELETE /sdk/v2/datasets/schemas/{id}; needs
+        ``dataset-schema:delete``). Datasets/generation runs pointing at it are
+        un-linked (their schema pointer is set null), not deleted. A missing /
+        cross-org id → ``NotFoundError``."""
+        self.http.delete(f"{_SCHEMAS}/{schema_id}")
+
+    async def adelete(self, schema_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_SCHEMAS}/{schema_id}")
+
+    # ---- internals ----
+
+    @staticmethod
+    def _params(ordering: Optional[str], page_size: Optional[int]) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params or None
+
+    def _page_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_SCHEMAS, params or None)
+
+    async def _apage_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_SCHEMAS, params or None)
+
+    @staticmethod
+    def _create_body(
+        name: str, fields: List[Dict[str, Any]], description: Optional[str]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {"name": name, "fields": fields}
+        if description is not None:
+            body["description"] = description
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], description: Optional[str], fields: Optional[List[Dict[str, Any]]]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if fields is not None:
+            body["fields"] = fields
+        return body
+
+
+class DatasetFixturesResource:
+    """``client.datasets.fixtures`` — author base fixtures from JSON rows (LUC-918).
+
+    A fixture is the hydrated mock data (a DuckDB blob) for one ``(dataset,
+    resource)`` pair. ``create`` builds one from explicit rows. Data-bearing — no
+    production swallow. Has an async sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def create(
+        self, *, resource_id: str, dataset_id: str, tables: List[Dict[str, Any]]
+    ) -> Fixture:
+        """Author a base fixture from JSON rows (POST /sdk/v2/fixtures; needs
+        ``fixture:write``). ``tables`` is a list of ``{"name": <table>, "rows":
+        [<row dict>, ...]}`` validated against the resource's ``spec``. Exactly one
+        fixture may exist per ``(dataset, resource)`` — a duplicate →
+        ``ConflictError``; a row/spec mismatch → ``ValidationError``. Unknown
+        resource or dataset → ``NotFoundError``."""
+        return Fixture.from_dict(self.http.post(_FIXTURES, self._body(resource_id, dataset_id, tables)))
+
+    async def acreate(
+        self, *, resource_id: str, dataset_id: str, tables: List[Dict[str, Any]]
+    ) -> Fixture:
+        """Async sibling of ``create``."""
+        return Fixture.from_dict(
+            await self.http.apost(_FIXTURES, self._body(resource_id, dataset_id, tables))
+        )
+
+    @staticmethod
+    def _body(resource_id: str, dataset_id: str, tables: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {"resource_id": resource_id, "dataset_id": dataset_id, "tables": tables}

--- a/lucidicai/api/resources/evaluator_results.py
+++ b/lucidicai/api/resources/evaluator_results.py
@@ -1,0 +1,28 @@
+"""client.evaluator_results — a single evaluator result by id (LUC-910).
+
+A small namespace keyed by an ``EvaluatorResult`` id (distinct from an evaluator
+id), so ``evaluator_results.get(eval_id)`` can't be confused with the
+evaluator-keyed reads on ``client.evaluators``. Reuses the ``EvalResult`` model
+(the ``EvaluatorResultSerializer`` shape). Data-bearing read — does NOT swallow
+in production.
+"""
+from ..client import HttpClient
+from ..models.session import EvalResult
+
+_EVAL_RESULTS = "sdk/v2/evaluator-results"
+
+
+class EvaluatorResultsResource:
+    """Handle for the ``/sdk/v2/evaluator-results`` read endpoint."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def get(self, eval_id: str) -> EvalResult:
+        """Read one evaluator result by its id (a CODE result is synced from S3
+        on read). ``eval_id`` is an ``EvalResult.eval_id``."""
+        return EvalResult.from_dict(self.http.get(f"{_EVAL_RESULTS}/{eval_id}"))
+
+    async def aget(self, eval_id: str) -> EvalResult:
+        """Async sibling of ``get``."""
+        return EvalResult.from_dict(await self.http.aget(f"{_EVAL_RESULTS}/{eval_id}"))

--- a/lucidicai/api/resources/evaluators.py
+++ b/lucidicai/api/resources/evaluators.py
@@ -15,6 +15,7 @@ from ..models.base import CursorPage
 from ..models.evaluator import Evaluator
 from ..models.session import EvalResult
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 _EVALUATORS = "sdk/v2/evaluators"
 
@@ -120,10 +121,9 @@ class EvaluatorsResource:
     def _agent_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
     ) -> Dict[str, Any]:
-        resolved = agent_id or self._agent_id
-        params: Dict[str, Any] = {}
-        if resolved is not None:
-            params["agent_id"] = resolved
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "evaluators.list"),
+        }
         if ordering is not None:
             params["ordering"] = ordering
         if page_size is not None:

--- a/lucidicai/api/resources/evaluators.py
+++ b/lucidicai/api/resources/evaluators.py
@@ -1,21 +1,22 @@
-"""client.evaluators — evaluator reads (LUC-910).
+"""client.evaluators — evaluator reads (LUC-910) + writes (LUC-916).
 
 A new namespace (today only ``client.evals.emit`` — a different concept, ad-hoc
 score submission — exists). Reads the agent's evaluator definitions, one
 evaluator's eval distribution across runs, and a single evaluator result by id.
+Writes create / update / delete evaluator definitions.
 
 The per-result reads reuse the ``EvalResult`` model (both endpoints serialize
-with the backend's ``EvaluatorResultSerializer``). Data-bearing reads — they do
-NOT swallow in production. Each has an ``a``-prefixed async sibling.
+with the backend's ``EvaluatorResultSerializer``). Data-bearing reads + writes —
+they do NOT swallow in production. Each has an ``a``-prefixed async sibling.
 """
-from typing import Any, AsyncIterator, Dict, Iterator, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.evaluator import Evaluator
 from ..models.session import EvalResult
 from ..pagination import apaginate, paginate
-from ...core.errors import require_agent_id
+from ...core.errors import InvalidOperationError, require_agent_id
 
 _EVALUATORS = "sdk/v2/evaluators"
 
@@ -70,6 +71,92 @@ class EvaluatorsResource:
         """Async sibling of ``get``."""
         return Evaluator.from_dict(await self.http.aget(f"{_EVALUATORS}/{evaluator_id}"))
 
+    # ==================== writes (LUC-916) ====================
+    #
+    # create / update / delete evaluator definitions. Data-bearing writes → no
+    # production swallow. Each has an async sibling. ``create`` is LLM/rubric only
+    # (CODE creation is deferred backend-side, LUC-829) and rejects a non-LLM
+    # ``type`` client-side, since the backend silently coerces every create to LLM.
+
+    def create(
+        self, name: str, *, criteria: List[Dict[str, Any]], result_type: str,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: bool = False, type: str = "llm", agent_id: Optional[str] = None,
+    ) -> Evaluator:
+        """Create an LLM (rubric) evaluator (POST /sdk/v2/evaluators; needs
+        ``evaluator:write``). ``result_type`` is ``"boolean"`` (pass/fail) or
+        ``"number"`` (score); ``criteria`` is a non-empty list whose per-item shape
+        depends on ``result_type`` — boolean: ``{name, pass_definition,
+        fail_definition, pass_definition_details?, fail_definition_details?}``;
+        number: ``{name, weight?, score_definitions:[{score, definition}]}``. The
+        backend builds the rubric from ``criteria`` (don't pass ``rubric_json``). A
+        duplicate ``name`` for the agent → ``ConflictError``; a malformed criterion
+        or unsupported ``result_type`` → ``ValidationError``. Returns the created
+        evaluator in **list shape** — ``criteria`` is populated, but ``rubric_json``
+        / ``config`` are not (call ``get(id)`` for the full built rubric).
+
+        Only LLM/rubric evaluators can be created from the SDK — CODE creation is
+        deferred (LUC-829). Passing any ``type`` other than ``"llm"`` raises
+        ``InvalidOperationError`` (create CODE evaluators in the dashboard)."""
+        self._reject_non_llm(type)
+        return Evaluator.from_dict(self.http.post(
+            _EVALUATORS,
+            self._create_body(name, criteria, result_type, description, icon, is_default, agent_id),
+        ))
+
+    async def acreate(
+        self, name: str, *, criteria: List[Dict[str, Any]], result_type: str,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: bool = False, type: str = "llm", agent_id: Optional[str] = None,
+    ) -> Evaluator:
+        """Async sibling of ``create``."""
+        self._reject_non_llm(type)
+        return Evaluator.from_dict(await self.http.apost(
+            _EVALUATORS,
+            self._create_body(name, criteria, result_type, description, icon, is_default, agent_id),
+        ))
+
+    def update(
+        self, evaluator_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: Optional[bool] = None, criteria: Optional[List[Dict[str, Any]]] = None,
+        result_type: Optional[str] = None, config: Optional[Dict[str, Any]] = None,
+    ) -> Evaluator:
+        """Partially update an evaluator (PUT /sdk/v2/evaluators/{id}; needs
+        ``evaluator:write``). Send only the fields to change: ``name`` /
+        ``description`` / ``icon`` / ``is_default`` apply to any type; ``criteria``
+        applies to LLM evaluators; ``result_type`` / ``config`` (incl.
+        ``config["user_code"]``) apply to CODE evaluators — fields inapplicable to
+        the evaluator's type are ignored, so a round-tripped detail body is safe.
+        A rename collision → ``ConflictError``. Returns the updated evaluator
+        (detail shape, incl. ``rubric_json`` / ``config``)."""
+        return Evaluator.from_dict(self.http.put(
+            f"{_EVALUATORS}/{evaluator_id}",
+            self._update_body(name, description, icon, is_default, criteria, result_type, config),
+        ))
+
+    async def aupdate(
+        self, evaluator_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+        is_default: Optional[bool] = None, criteria: Optional[List[Dict[str, Any]]] = None,
+        result_type: Optional[str] = None, config: Optional[Dict[str, Any]] = None,
+    ) -> Evaluator:
+        """Async sibling of ``update``."""
+        return Evaluator.from_dict(await self.http.aput(
+            f"{_EVALUATORS}/{evaluator_id}",
+            self._update_body(name, description, icon, is_default, criteria, result_type, config),
+        ))
+
+    def delete(self, evaluator_id: str) -> None:
+        """Hard-delete an evaluator (DELETE /sdk/v2/evaluators/{id}; needs
+        ``evaluator:delete``). This also removes its historical evaluator results.
+        Unknown / cross-org / out-of-binding id → ``NotFoundError``."""
+        self.http.delete(f"{_EVALUATORS}/{evaluator_id}")
+
+    async def adelete(self, evaluator_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_EVALUATORS}/{evaluator_id}")
+
     # ==================== one evaluator's eval distribution ====================
 
     def evals(
@@ -117,6 +204,67 @@ class EvaluatorsResource:
     # evaluator-keyed reads above.
 
     # ==================== internals ====================
+
+    @staticmethod
+    def _reject_non_llm(type_: str) -> None:
+        """Guard: the SDK creates LLM evaluators only. The backend has no ``type``
+        field and silently coerces every create to LLM, so a CODE ``type`` would
+        otherwise be honored as an LLM create — reject it here instead. A non-string
+        or whitespace-padded value is normalized rather than crashing on ``.lower()``."""
+        normalized = type_.strip().lower() if isinstance(type_, str) else type_
+        if normalized != "llm":
+            raise InvalidOperationError(
+                f"creating a '{type_}' evaluator from the SDK is not supported — only "
+                "LLM/rubric evaluators can be created (CODE creation is deferred, "
+                "LUC-829; create CODE evaluators in the dashboard)."
+            )
+
+    def _create_body(
+        self, name: str, criteria: List[Dict[str, Any]], result_type: str,
+        description: Optional[str], icon: Optional[str], is_default: bool,
+        agent_id: Optional[str],
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "evaluators.create"),
+            "name": name, "result_type": result_type, "criteria": criteria,
+            "is_default": is_default,
+        }
+        # omit-None: let the backend default description/icon (icon="compass").
+        if description is not None:
+            body["description"] = description
+        if icon is not None:
+            body["icon"] = icon
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], description: Optional[str], icon: Optional[str],
+        is_default: Optional[bool], criteria: Optional[List[Dict[str, Any]]],
+        result_type: Optional[str], config: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        # omit-None: PUT is a partial update — send only the fields being changed.
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if icon is not None:
+            body["icon"] = icon
+        if is_default is not None:
+            body["is_default"] = is_default
+        if criteria is not None:
+            body["criteria"] = criteria
+        if result_type is not None:
+            body["result_type"] = result_type
+        if config is not None:
+            body["config"] = config
+        # An all-None update would send an empty body and silently no-op server-side;
+        # surface the likely caller mistake instead.
+        if not body:
+            raise InvalidOperationError(
+                "evaluators.update requires at least one field to change."
+            )
+        return body
 
     def _agent_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]

--- a/lucidicai/api/resources/evaluators.py
+++ b/lucidicai/api/resources/evaluators.py
@@ -1,0 +1,152 @@
+"""client.evaluators — evaluator reads (LUC-910).
+
+A new namespace (today only ``client.evals.emit`` — a different concept, ad-hoc
+score submission — exists). Reads the agent's evaluator definitions, one
+evaluator's eval distribution across runs, and a single evaluator result by id.
+
+The per-result reads reuse the ``EvalResult`` model (both endpoints serialize
+with the backend's ``EvaluatorResultSerializer``). Data-bearing reads — they do
+NOT swallow in production. Each has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.evaluator import Evaluator
+from ..models.session import EvalResult
+from ..pagination import apaginate, paginate
+
+_EVALUATORS = "sdk/v2/evaluators"
+
+
+class EvaluatorsResource:
+    """Handle for the ``/sdk/v2/evaluators`` read endpoints."""
+
+    def __init__(self, http: HttpClient, agent_id: Optional[str] = None):
+        self.http = http
+        self._agent_id = agent_id
+
+    # ==================== evaluators (definitions) ====================
+
+    def list(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[Evaluator]:
+        """Lazily iterate the agent's evaluators, newest first. ``agent_id``
+        defaults to the configured agent; ``ordering`` accepts ``id`` (± prefix)."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return paginate(lambda c: self._page_get(_EVALUATORS, base, c), model=Evaluator)
+
+    def alist(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[Evaluator]:
+        """Async sibling of ``list``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return apaginate(lambda c: self._apage_get(_EVALUATORS, base, c), model=Evaluator)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of evaluators."""
+        body = self._page_get(_EVALUATORS, self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(_EVALUATORS, self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    def get(self, evaluator_id: str) -> Evaluator:
+        """Read one evaluator's detail (incl. ``rubric_json`` / ``config``)."""
+        return Evaluator.from_dict(self.http.get(f"{_EVALUATORS}/{evaluator_id}"))
+
+    async def aget(self, evaluator_id: str) -> Evaluator:
+        """Async sibling of ``get``."""
+        return Evaluator.from_dict(await self.http.aget(f"{_EVALUATORS}/{evaluator_id}"))
+
+    # ==================== one evaluator's eval distribution ====================
+
+    def evals(
+        self, evaluator_id: str, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[EvalResult]:
+        """Lazily iterate one evaluator's results across runs (the metric's
+        distribution). Returns ``EvalResult`` items."""
+        base = self._page_params(ordering, page_size)
+        return paginate(
+            lambda c: self._page_get(f"{_EVALUATORS}/{evaluator_id}/evals", base, c),
+            model=EvalResult,
+        )
+
+    def aevals(
+        self, evaluator_id: str, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[EvalResult]:
+        """Async sibling of ``evals``."""
+        base = self._page_params(ordering, page_size)
+        return apaginate(
+            lambda c: self._apage_get(f"{_EVALUATORS}/{evaluator_id}/evals", base, c),
+            model=EvalResult,
+        )
+
+    def evals_page(
+        self, evaluator_id: str, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of one evaluator's results."""
+        body = self._page_get(f"{_EVALUATORS}/{evaluator_id}/evals", self._page_params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=EvalResult)
+
+    async def aevals_page(
+        self, evaluator_id: str, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``evals_page``."""
+        body = await self._apage_get(f"{_EVALUATORS}/{evaluator_id}/evals", self._page_params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=EvalResult)
+
+    # NOTE: a *single* evaluator result by its own id lives on the separate
+    # ``client.evaluator_results`` namespace (get(eval_id)) — keying it off an
+    # EvalResult id, not an evaluator id, so it isn't confused with the
+    # evaluator-keyed reads above.
+
+    # ==================== internals ====================
+
+    def _agent_params(
+        self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
+    ) -> Dict[str, Any]:
+        resolved = agent_id or self._agent_id
+        params: Dict[str, Any] = {}
+        if resolved is not None:
+            params["agent_id"] = resolved
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    @staticmethod
+    def _page_params(ordering: Optional[str], page_size: Optional[int]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params or None)
+
+    async def _apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params or None)

--- a/lucidicai/api/resources/evosim.py
+++ b/lucidicai/api/resources/evosim.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from ..client import HttpClient
-from ...core.errors import LucidicError
+from ...core.errors import LucidicError, require_agent_id
 
 logger = logging.getLogger("Lucidic")
 
@@ -43,10 +43,11 @@ class EvoSimResource:
         Returns:
             Backend response describing the run (successful or failed)
         """
+        # LUC-926: a training run needs an agent; raise before the swallow.
+        require_agent_id(self._agent_id, "evosim.train")
         try:
             payload = _load_training_config(config_json_file)
-            if self._agent_id:
-                payload.setdefault("agent_id", self._agent_id)
+            payload.setdefault("agent_id", self._agent_id)
             return self.http.post("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:
@@ -56,10 +57,10 @@ class EvoSimResource:
 
     async def atrain(self, config_json_file: Union[str, Path]) -> Dict[str, Any]:
         """Async sibling of ``train``."""
+        require_agent_id(self._agent_id, "evosim.train")
         try:
             payload = _load_training_config(config_json_file)
-            if self._agent_id:
-                payload.setdefault("agent_id", self._agent_id)
+            payload.setdefault("agent_id", self._agent_id)
             return await self.http.apost("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:

--- a/lucidicai/api/resources/evosim.py
+++ b/lucidicai/api/resources/evosim.py
@@ -1,17 +1,33 @@
-"""EvoSim resource API operations."""
+"""EvoSim resource API operations (LUC-923 run management).
+
+``client.evosims`` manages EvoSim runs: kick one off (``train``), list / read runs,
+cancel a run, inspect an iteration's Training Module Instances, and block until a
+run is terminal (``wait_for``). These hit the gen-3 ``/sdk/...`` paths (there is no
+``/sdk/v2/evosim*`` surface).
+
+``train`` / ``atrain`` swallow in production (a kickoff convenience); the
+run-management reads/writes are data-bearing and do NOT swallow. Each has an
+``a``-prefixed async sibling.
+"""
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.evosim import EvoSim, TrainingModuleInstance
+from ..pagination import apaginate, paginate
+from ..polling import await_for, wait_for
 from ...core.errors import LucidicError, require_agent_id
 
 logger = logging.getLogger("Lucidic")
 
+_EVOSIMS = "sdk/evosims"
 
-class EvoSimResource:
-    """Handle EvoSim-related API operations."""
+
+class EvoSimsResource:
+    """Handle EvoSim run-management API operations."""
 
     def __init__(
         self,
@@ -23,12 +39,14 @@ class EvoSimResource:
 
         Args:
             http: HTTP client instance
-            agent_id: Default agent ID for training runs
-            production: Whether to suppress errors in production mode
+            agent_id: Default agent ID for training runs / listing
+            production: Whether to suppress errors in production mode (train only)
         """
         self.http = http
         self._agent_id = agent_id
         self._production = production
+
+    # ==================== kickoff (gen-3, swallows) ====================
 
     def train(self, config_json_file: Union[str, Path]) -> Dict[str, Any]:
         """Start an EvoSim training run from a JSON config file.
@@ -51,7 +69,7 @@ class EvoSimResource:
             return self.http.post("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:
-                logger.error(f"[EvoSimResource] Failed to start training run: {e}")
+                logger.error(f"[EvoSimsResource] Failed to start training run: {e}")
                 return {"status": "failed", "error": str(e)}
             raise
 
@@ -64,9 +82,128 @@ class EvoSimResource:
             return await self.http.apost("sdk/evosim/training-run", payload)
         except Exception as e:
             if self._production:
-                logger.error(f"[EvoSimResource] Failed to start training run: {e}")
+                logger.error(f"[EvoSimsResource] Failed to start training run: {e}")
                 return {"status": "failed", "error": str(e)}
             raise
+
+    # ==================== run management (LUC-923, no swallow) ====================
+
+    def list(self, agent_id: Optional[str] = None, *, page_size: Optional[int] = None) -> Iterator[EvoSim]:
+        """Lazily iterate an agent's EvoSim runs, newest first (GET /sdk/evosims;
+        needs ``evosim:read``). ``agent_id`` defaults to the configured agent. List
+        items are the light shape (no rolled-up ``status`` — call ``get`` for that)."""
+        base = self._list_params(agent_id, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=EvoSim)
+
+    def alist(self, agent_id: Optional[str] = None, *, page_size: Optional[int] = None) -> AsyncIterator[EvoSim]:
+        """Async sibling of ``list``."""
+        base = self._list_params(agent_id, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=EvoSim)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of an agent's EvoSim runs."""
+        return CursorPage.from_body(self._page_get(self._list_params(agent_id, page_size), cursor), model=EvoSim)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._list_params(agent_id, page_size), cursor)
+        return CursorPage.from_body(body, model=EvoSim)
+
+    def get(self, evosim_id: str) -> EvoSim:
+        """Read one EvoSim run with its rolled-up ``status`` / ``failure_reason``,
+        derived ``checkpoint_id``, and ``iterations`` (GET /sdk/evosims/{id}; needs
+        ``evosim:read``). Unknown / cross-org / out-of-binding id → ``NotFoundError``."""
+        return self._detail(self.http.get(f"{_EVOSIMS}/{evosim_id}"))
+
+    async def aget(self, evosim_id: str) -> EvoSim:
+        """Async sibling of ``get``."""
+        return self._detail(await self.http.aget(f"{_EVOSIMS}/{evosim_id}"))
+
+    def cancel(self, evosim_id: str) -> Optional[str]:
+        """Cancel an EvoSim run (POST /sdk/evosims/{id}/cancel; needs
+        ``evosim:delete``). A kill switch — terminates the Temporal workflow and
+        projects ``CANCELED`` onto the run. Idempotent: cancelling an already-terminal
+        run leaves it untouched. Returns the effective status (e.g. ``"CANCELED"``, or
+        the run's terminal status if it finished first). Raises
+        ``ServiceUnavailableError`` (503) if Temporal is unavailable — retry."""
+        resp = self.http.post(f"{_EVOSIMS}/{evosim_id}/cancel")
+        return resp.get("status")
+
+    async def acancel(self, evosim_id: str) -> Optional[str]:
+        """Async sibling of ``cancel``."""
+        resp = await self.http.apost(f"{_EVOSIMS}/{evosim_id}/cancel")
+        return resp.get("status")
+
+    def iteration_instances(self, iteration_id: str) -> List[TrainingModuleInstance]:
+        """List the Training Module Instances (TMIs) of an EvoSim iteration (GET
+        /sdk/evosim-iterations/{id}/instances; needs ``evosim:read``). Iteration ids
+        come from ``get(evosim_id).iterations``. Not paginated."""
+        resp = self.http.get(f"sdk/evosim-iterations/{iteration_id}/instances")
+        return TrainingModuleInstance.from_list(resp.get("training_module_instances", []))
+
+    async def aiteration_instances(self, iteration_id: str) -> List[TrainingModuleInstance]:
+        """Async sibling of ``iteration_instances``."""
+        resp = await self.http.aget(f"sdk/evosim-iterations/{iteration_id}/instances")
+        return TrainingModuleInstance.from_list(resp.get("training_module_instances", []))
+
+    def wait_for(self, evosim_id: str, *, timeout: float = 3600.0, interval: float = 10.0) -> EvoSim:
+        """Block until an EvoSim run reaches a terminal status (``SUCCEEDED`` /
+        ``PARTIAL_SUCCESS`` / ``FAILED`` / ``CANCELED``) or ``timeout`` elapses,
+        polling ``get`` every ``interval`` seconds. Returns the terminal run — inspect
+        ``.status`` / ``.failure_reason`` / ``.checkpoint_id``. Raises ``WaitTimeout``
+        if the deadline passes first.
+
+        EvoSim runs are long (up to ``max_iterations`` ×
+        ``hard_stop_seconds_per_iteration`` — the defaults allow multiple hours), so
+        the default ``timeout`` (1 h) may be too short for a big run; pass a larger
+        value, or poll ``get`` yourself."""
+        return wait_for(
+            lambda: self.get(evosim_id),
+            is_terminal=lambda run: run.is_terminal, timeout=timeout, interval=interval)
+
+    async def await_for(self, evosim_id: str, *, timeout: float = 3600.0, interval: float = 10.0) -> EvoSim:
+        """Async sibling of ``wait_for``."""
+        return await await_for(
+            lambda: self.aget(evosim_id),
+            is_terminal=lambda run: run.is_terminal, timeout=timeout, interval=interval)
+
+    # ==================== internals ====================
+
+    def _list_params(self, agent_id: Optional[str], page_size: Optional[int]) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "evosims.list"),
+        }
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_EVOSIMS, params)
+
+    async def _apage_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_EVOSIMS, params)
+
+    @staticmethod
+    def _detail(resp: Dict[str, Any]) -> EvoSim:
+        """Flatten the detail envelope ``{evosim, iterations, status, failure_reason,
+        checkpoint_id}`` into a single typed ``EvoSim`` (the run id lives nested under
+        ``evosim``, the rolled-up status at the top level)."""
+        data = dict(resp.get("evosim") or {})
+        data["status"] = resp.get("status")
+        data["failure_reason"] = resp.get("failure_reason")
+        data["checkpoint_id"] = resp.get("checkpoint_id")
+        data["iterations"] = resp.get("iterations", [])
+        return EvoSim.from_dict(data)
 
 
 def _load_training_config(config_json_file: Union[str, Path]) -> Dict[str, Any]:

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -6,6 +6,7 @@ from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.experiment import Experiment
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 logger = logging.getLogger("Lucidic")
 
@@ -56,6 +57,9 @@ class ExperimentResource:
         if LLM_numeric_evaluators:
             evaluator_names.extend(LLM_numeric_evaluators)
 
+        # LUC-926: an experiment must belong to an agent — raise before the
+        # swallow rather than POST a null agent_id.
+        require_agent_id(self._agent_id, "experiments.create")
         try:
             response = self.http.post(
                 "createexperiment",
@@ -92,6 +96,8 @@ class ExperimentResource:
         if LLM_numeric_evaluators:
             evaluator_names.extend(LLM_numeric_evaluators)
 
+        # LUC-926: same guard as create() — raise before the swallow.
+        require_agent_id(self._agent_id, "experiments.create")
         try:
             response = await self.http.apost(
                 "createexperiment",
@@ -176,7 +182,9 @@ class ExperimentResource:
     def _list_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
     ) -> Dict[str, Any]:
-        params: Dict[str, Any] = {"agent_id": agent_id or self._agent_id}
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._agent_id, "experiments.list"),
+        }
         if ordering is not None:
             params["ordering"] = ordering
         if page_size is not None:

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -1,8 +1,11 @@
 """Experiment resource API operations."""
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.experiment import Experiment
+from ..pagination import apaginate, paginate
 
 logger = logging.getLogger("Lucidic")
 
@@ -106,3 +109,88 @@ class ExperimentResource:
                 logger.error(f"[ExperimentResource] Failed to create experiment: {e}")
                 return None
             raise
+
+    # ==================== v2 reads (LUC-908) ====================
+    #
+    # Data-bearing reads: they do NOT swallow in production (they surface the
+    # typed transport error), unlike create/acreate above. ``agent_id`` defaults
+    # to the resource's configured agent. Each read has an async sibling.
+
+    def list(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[Experiment]:
+        """Lazily iterate an agent's experiments, newest first (LUC-816).
+
+        ``ordering`` accepts ``created_at`` / ``id`` (± prefix). Lazy generator —
+        errors surface on first iteration; use ``count()`` for a cheap total.
+        """
+        base = self._list_params(agent_id, ordering, page_size)
+        return paginate(lambda cursor: self._page_get(base, cursor), model=Experiment)
+
+    def alist(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[Experiment]:
+        """Async sibling of ``list``."""
+        base = self._list_params(agent_id, ordering, page_size)
+        return apaginate(lambda cursor: self._apage_get(base, cursor), model=Experiment)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of experiments (manual pagination control)."""
+        body = self._page_get(self._list_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Experiment)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._list_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Experiment)
+
+    def count(self, agent_id: Optional[str] = None) -> int:
+        """Cheap total of the agent's experiments via HEAD (``X-Total-Count``)."""
+        headers = self.http.head("sdk/v2/experiments", self._list_params(agent_id, None, None))
+        return int(headers.get("X-Total-Count") or 0)
+
+    async def acount(self, agent_id: Optional[str] = None) -> int:
+        """Async sibling of ``count``."""
+        headers = await self.http.ahead("sdk/v2/experiments", self._list_params(agent_id, None, None))
+        return int(headers.get("X-Total-Count") or 0)
+
+    def get(self, experiment_id: str) -> Experiment:
+        """Read one experiment's detail (metrics + failure groups). Raises
+        ``NotFoundError`` if it doesn't exist or the (bound) key can't see it."""
+        return Experiment.from_dict(self.http.get(f"sdk/v2/experiments/{experiment_id}"))
+
+    async def aget(self, experiment_id: str) -> Experiment:
+        """Async sibling of ``get``."""
+        return Experiment.from_dict(await self.http.aget(f"sdk/v2/experiments/{experiment_id}"))
+
+    # ---- internals ----
+
+    def _list_params(
+        self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"agent_id": agent_id or self._agent_id}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get("sdk/v2/experiments", params)
+
+    async def _apage_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget("sdk/v2/experiments", params)

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -5,8 +5,10 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.evaluator import Evaluator
-from ..models.experiment import Experiment
+from ..models.experiment import Experiment, FailureGroup
+from ..models.taxonomy import TaxonomyRun, TaxonomyStatus
 from ..pagination import apaginate, paginate
+from ..polling import await_for, wait_for
 from ...core.errors import require_agent_id
 
 logger = logging.getLogger("Lucidic")
@@ -31,10 +33,11 @@ class ExperimentResource:
         self.http = http
         self._agent_id = agent_id
         self._production = production
-        # client.experiments.evaluators — attach/detach/list evaluators on an
-        # experiment. Stateless (experiment id is passed per call), so one instance
-        # is reused across calls.
+        # Sub-namespaces (stateless — experiment id passed per call, one instance each).
+        # client.experiments.evaluators — attach/detach/list evaluators (LUC-915).
         self._evaluators = ExperimentEvaluatorsResource(http)
+        # client.experiments.taxonomy — trace-taxonomy generation (LUC-922).
+        self._taxonomy = ExperimentTaxonomyResource(http)
 
     @property
     def evaluators(self) -> "ExperimentEvaluatorsResource":
@@ -42,6 +45,14 @@ class ExperimentResource:
         ``client.experiments.evaluators.attach(experiment_id, ["accuracy"])`` /
         ``.list(experiment_id)`` / ``.detach(experiment_id, evaluator_id)``."""
         return self._evaluators
+
+    @property
+    def taxonomy(self) -> "ExperimentTaxonomyResource":
+        """Trace-taxonomy generation on an experiment — e.g.
+        ``client.experiments.taxonomy.generate(experiment_id)`` /
+        ``.status(experiment_id)`` / ``.wait_for(experiment_id)`` /
+        ``.get(experiment_id)``."""
+        return self._taxonomy
 
     def create(
         self,
@@ -211,6 +222,40 @@ class ExperimentResource:
             f"sdk/v2/experiments/{experiment_id}", data={"delete_sessions": delete_sessions}
         )
 
+    # ==================== failure modes (LUC-922) ====================
+    #
+    # Async failure-mode analysis: generate_failure_modes triggers a Temporal run
+    # (fire-and-forget — there is NO status endpoint), failure_groups reads the
+    # result. Data-bearing → no production swallow. Each has an async sibling.
+    # (Taxonomy generation is the client.experiments.taxonomy sub-namespace.)
+
+    def generate_failure_modes(self, experiment_id: str) -> None:
+        """Trigger failure-mode analysis for an experiment (POST
+        /sdk/v2/experiments/{id}/failure-modes; needs ``failure-group:generate``).
+        Clears the prior groups and recomputes them asynchronously; poll
+        ``failure_groups`` for the result. Note there is **no status endpoint** — an
+        experiment with no failures completes with zero groups, so treat a persistently
+        empty list as "no failure modes found", not "still running". Needs at least one
+        session (→ ``ValidationError``). May raise ``ServiceUnavailableError`` (503) if
+        the calculation can't start — retry."""
+        self.http.post(f"sdk/v2/experiments/{experiment_id}/failure-modes")
+
+    async def agenerate_failure_modes(self, experiment_id: str) -> None:
+        """Async sibling of ``generate_failure_modes``."""
+        await self.http.apost(f"sdk/v2/experiments/{experiment_id}/failure-modes")
+
+    def failure_groups(self, experiment_id: str) -> List[FailureGroup]:
+        """Read an experiment's failure-mode groups (GET
+        /sdk/v2/experiments/{id}/failure-groups; needs ``failure-group:read``) — the
+        result of ``generate_failure_modes``. Not paginated (returns the full set)."""
+        resp = self.http.get(f"sdk/v2/experiments/{experiment_id}/failure-groups")
+        return FailureGroup.from_list(resp.get("event_failure_groups", []))
+
+    async def afailure_groups(self, experiment_id: str) -> List[FailureGroup]:
+        """Async sibling of ``failure_groups``."""
+        resp = await self.http.aget(f"sdk/v2/experiments/{experiment_id}/failure-groups")
+        return FailureGroup.from_list(resp.get("event_failure_groups", []))
+
     # ---- internals ----
 
     def _list_params(
@@ -323,3 +368,105 @@ class ExperimentEvaluatorsResource:
         if cursor:
             params["cursor"] = cursor
         return await self.http.aget(path, params or None)
+
+
+class ExperimentTaxonomyResource:
+    """``client.experiments.taxonomy`` — trace-taxonomy generation (LUC-922).
+
+    Trigger a taxonomy run over an experiment's finished sessions, read the latest
+    completed taxonomy, and poll generation to completion. A taxonomy is the required
+    input to dataset generation (``client.datasets.generate``). The experiment id is
+    passed per call. Data-bearing → no production swallow. Each method has an async
+    sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def _base(self, experiment_id: str) -> str:
+        return f"sdk/v2/experiments/{experiment_id}/taxonomy"
+
+    def generate(
+        self, experiment_id: str, *,
+        seed_dimensions: Optional[List[Dict[str, Any]]] = None,
+        use_previous: Optional[bool] = None,
+    ) -> TaxonomyRun:
+        """Trigger a taxonomy run (POST /sdk/v2/experiments/{id}/taxonomy; needs
+        ``taxonomy:generate``). ``seed_dimensions`` (≤20 ``{name, description?}``) and
+        ``use_previous`` (warm-start from the last completed run) are optional. Needs
+        ≥20 finished sessions (→ ``ValidationError``) and no run already in progress
+        (→ ``ConflictError``). Returns the created run (``run_id`` + ``"queued"``
+        status). May raise ``ServiceUnavailableError`` (503) — retry."""
+        return TaxonomyRun.from_dict(
+            self.http.post(self._base(experiment_id), self._generate_body(seed_dimensions, use_previous)))
+
+    async def agenerate(
+        self, experiment_id: str, *,
+        seed_dimensions: Optional[List[Dict[str, Any]]] = None,
+        use_previous: Optional[bool] = None,
+    ) -> TaxonomyRun:
+        """Async sibling of ``generate``."""
+        return TaxonomyRun.from_dict(
+            await self.http.apost(self._base(experiment_id), self._generate_body(seed_dimensions, use_previous)))
+
+    def get(self, experiment_id: str) -> TaxonomyRun:
+        """Read the latest **completed** taxonomy (GET /sdk/v2/experiments/{id}/
+        taxonomy; needs ``taxonomy:read``) — its dimensions are in ``.taxonomy``.
+        Raises ``NotFoundError`` until a run has completed (in-flight state isn't
+        surfaced here — use ``status`` / ``wait_for``)."""
+        return TaxonomyRun.from_dict(self.http.get(self._base(experiment_id)))
+
+    async def aget(self, experiment_id: str) -> TaxonomyRun:
+        """Async sibling of ``get``."""
+        return TaxonomyRun.from_dict(await self.http.aget(self._base(experiment_id)))
+
+    def status(self, experiment_id: str) -> TaxonomyStatus:
+        """Read taxonomy generation status (GET /sdk/v2/experiments/{id}/taxonomy/
+        status; needs ``taxonomy:read``) — the ``ongoing`` run (if any) and the
+        ``latest_completed`` taxonomy."""
+        return TaxonomyStatus.from_dict(self.http.get(f"{self._base(experiment_id)}/status"))
+
+    async def astatus(self, experiment_id: str) -> TaxonomyStatus:
+        """Async sibling of ``status``."""
+        return TaxonomyStatus.from_dict(await self.http.aget(f"{self._base(experiment_id)}/status"))
+
+    def wait_for(
+        self, experiment_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> TaxonomyStatus:
+        """Block until no taxonomy run is in progress (or ``timeout`` elapses),
+        polling ``status`` every ``interval`` seconds. Call this after ``generate``.
+        Returns the terminal ``TaxonomyStatus``.
+
+        To tell whether **your** run succeeded, compare the returned
+        ``.latest_completed.run_id`` (or ``.version``) against the run ``generate``
+        returned: on success they match. A **failed** run clears ``.ongoing`` without
+        updating ``.latest_completed`` — so ``.latest_completed`` is then either a
+        *prior* completed taxonomy (a run_id/version that is NOT yours — do not treat
+        it as your result, and don't feed its stale dimensions into
+        ``datasets.generate``) or ``None`` (no taxonomy ever completed). The failure
+        reason itself isn't exposed by this endpoint. Raises ``WaitTimeout`` if the
+        deadline passes first."""
+        return wait_for(
+            lambda: self.status(experiment_id),
+            is_terminal=lambda s: s.is_terminal, timeout=timeout, interval=interval)
+
+    async def await_for(
+        self, experiment_id: str, *, timeout: float = 1800.0, interval: float = 3.0
+    ) -> TaxonomyStatus:
+        """Async sibling of ``wait_for``."""
+        return await await_for(
+            lambda: self.astatus(experiment_id),
+            is_terminal=lambda s: s.is_terminal, timeout=timeout, interval=interval)
+
+    @staticmethod
+    def _generate_body(
+        seed_dimensions: Optional[List[Dict[str, Any]]], use_previous: Optional[bool]
+    ) -> Dict[str, Any]:
+        # omit-None: both fields are optional (backend defaults seed_dimensions=[],
+        # use_previous=False).
+        body: Dict[str, Any] = {}
+        if seed_dimensions is not None:
+            body["seed_dimensions"] = seed_dimensions
+        if use_previous is not None:
+            body["use_previous"] = use_previous
+        return body

--- a/lucidicai/api/resources/experiment.py
+++ b/lucidicai/api/resources/experiment.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 from ..client import HttpClient
 from ..models.base import CursorPage
+from ..models.evaluator import Evaluator
 from ..models.experiment import Experiment
 from ..pagination import apaginate, paginate
 from ...core.errors import require_agent_id
@@ -30,6 +31,17 @@ class ExperimentResource:
         self.http = http
         self._agent_id = agent_id
         self._production = production
+        # client.experiments.evaluators — attach/detach/list evaluators on an
+        # experiment. Stateless (experiment id is passed per call), so one instance
+        # is reused across calls.
+        self._evaluators = ExperimentEvaluatorsResource(http)
+
+    @property
+    def evaluators(self) -> "ExperimentEvaluatorsResource":
+        """Wire evaluators onto experiments — e.g.
+        ``client.experiments.evaluators.attach(experiment_id, ["accuracy"])`` /
+        ``.list(experiment_id)`` / ``.detach(experiment_id, evaluator_id)``."""
+        return self._evaluators
 
     def create(
         self,
@@ -177,6 +189,28 @@ class ExperimentResource:
         """Async sibling of ``get``."""
         return Experiment.from_dict(await self.http.aget(f"sdk/v2/experiments/{experiment_id}"))
 
+    # ==================== v2 writes (LUC-915) ====================
+    #
+    # Data-bearing (destructive) write → no production swallow, unlike the gen-3
+    # create/acreate above. Each has an async sibling.
+
+    def delete(self, experiment_id: str, delete_sessions: bool = False) -> None:
+        """Delete an experiment (DELETE /sdk/v2/experiments/{id}; needs
+        ``experiment:delete``). The experiment row is hard-deleted and its
+        surviving sessions are detached (their ``experiment`` is set to null).
+        ``delete_sessions=True`` instead SOFT-deletes those sessions — hidden but
+        recoverable via the retention sweep — and is sent as a JSON body flag.
+        An unknown / cross-org / out-of-binding id → ``NotFoundError``."""
+        self.http.delete(
+            f"sdk/v2/experiments/{experiment_id}", data={"delete_sessions": delete_sessions}
+        )
+
+    async def adelete(self, experiment_id: str, delete_sessions: bool = False) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(
+            f"sdk/v2/experiments/{experiment_id}", data={"delete_sessions": delete_sessions}
+        )
+
     # ---- internals ----
 
     def _list_params(
@@ -202,3 +236,90 @@ class ExperimentResource:
         if cursor:
             params["cursor"] = cursor
         return await self.http.aget("sdk/v2/experiments", params)
+
+
+class ExperimentEvaluatorsResource:
+    """``client.experiments.evaluators`` — wire evaluators onto an experiment (LUC-915).
+
+    Attach / detach / list the evaluator definitions bound to an experiment. Attach
+    is **config-only**: it links evaluators so FUTURE sessions in the experiment
+    inherit them at session-init — it does NOT re-score existing sessions or
+    recompute metrics. The experiment id is passed per call. Data-bearing writes →
+    no production swallow. Each method has an async sibling.
+    """
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def list(self, experiment_id: str, *, page_size: Optional[int] = None) -> Iterator[Evaluator]:
+        """Lazily iterate the evaluators attached to an experiment (the endpoint is
+        cursor-paginated, so this transparently walks every page)."""
+        base = self._page_params(page_size)
+        return paginate(lambda c: self._page_get(self._path(experiment_id), base, c), model=Evaluator)
+
+    def alist(self, experiment_id: str, *, page_size: Optional[int] = None) -> AsyncIterator[Evaluator]:
+        """Async sibling of ``list``."""
+        base = self._page_params(page_size)
+        return apaginate(lambda c: self._apage_get(self._path(experiment_id), base, c), model=Evaluator)
+
+    def list_page(
+        self, experiment_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of an experiment's attached evaluators."""
+        body = self._page_get(self._path(experiment_id), self._page_params(page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    async def alist_page(
+        self, experiment_id: str, *, cursor: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._path(experiment_id), self._page_params(page_size), cursor)
+        return CursorPage.from_body(body, model=Evaluator)
+
+    def attach(self, experiment_id: str, names: List[str]) -> List[Evaluator]:
+        """Attach evaluators to an experiment by NAME (POST; needs
+        ``experiment:write``). Config-only — future sessions inherit; existing
+        sessions are not re-scored. Idempotent (re-attaching is a no-op). If ANY
+        name is unknown for the experiment's agent the whole call fails
+        (``ValidationError``) and nothing is attached. Returns the experiment's
+        full current attached evaluator set."""
+        resp = self.http.post(self._path(experiment_id), {"evaluator_names": names})
+        return Evaluator.from_list(resp.get("evaluators", []))
+
+    async def aattach(self, experiment_id: str, names: List[str]) -> List[Evaluator]:
+        """Async sibling of ``attach``."""
+        resp = await self.http.apost(self._path(experiment_id), {"evaluator_names": names})
+        return Evaluator.from_list(resp.get("evaluators", []))
+
+    def detach(self, experiment_id: str, evaluator_id: str) -> None:
+        """Detach one evaluator (by its UUID) from an experiment (DELETE; needs
+        ``experiment:write``). Removes only the link — the evaluator definition and
+        any already-recorded metrics are untouched. An evaluator that isn't
+        attached (or an unknown id) → ``NotFoundError``."""
+        self.http.delete(f"{self._path(experiment_id)}/{evaluator_id}")
+
+    async def adetach(self, experiment_id: str, evaluator_id: str) -> None:
+        """Async sibling of ``detach``."""
+        await self.http.adelete(f"{self._path(experiment_id)}/{evaluator_id}")
+
+    # ---- internals ----
+
+    @staticmethod
+    def _path(experiment_id: str) -> str:
+        return f"sdk/v2/experiments/{experiment_id}/evaluators"
+
+    @staticmethod
+    def _page_params(page_size: Optional[int]) -> Dict[str, Any]:
+        return {"page_size": page_size} if page_size is not None else {}
+
+    def _page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params or None)
+
+    async def _apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params or None)

--- a/lucidicai/api/resources/mock_call.py
+++ b/lucidicai/api/resources/mock_call.py
@@ -32,13 +32,8 @@ Backend contract (`api/views/sdk_mock_call.py`, frozen):
 import logging
 from typing import Any, Dict, Optional
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import (
-    LucidicMockCallError,
-    error_class_for_code,
-)
+from ...core.errors import APIError, LucidicMockCallError
 
 logger = logging.getLogger("Lucidic")
 
@@ -49,54 +44,20 @@ def _truncate_id(id_str: Optional[str]) -> str:
     return f"{id_str[:8]}..." if len(id_str) > 8 else id_str
 
 
-def _exception_from_http_error(exc: httpx.HTTPStatusError) -> LucidicMockCallError:
-    """Translate a non-2xx response into the appropriate typed exception.
+def _as_mock_error(exc: APIError) -> LucidicMockCallError:
+    """Wrap a generic/untyped API error as a mock-call ``malformed_response``.
 
-    Backend envelope (LUC-584) is uniform: ``{"error": {"code": str,
-    "detail": str, ...code-specific keys...}}``. Look up the class by
-    `code` via ``error_class_for_code`` (returns the base class for
-    unknown codes — forward-compat with backend additions).
-
-    Falls back to ``LucidicMockCallError`` with a synthetic detail when
-    the body isn't parseable as the documented envelope (truncated
-    responses, proxy errors that don't pass the JSON through, etc.).
+    The central decoder (LUC-900) already produces the typed
+    ``LucidicMockCallError`` family for the ``{"error": {"code"}}`` envelope
+    (propagated untouched), and specific typed errors for recognized statuses
+    — ``InsufficientScopeError`` / ``AuthError`` / ``RateLimitError`` /
+    ``ValidationError`` etc. — which callers should see with their type and
+    fields intact, so those propagate too. Only a bare ``APIError`` (an
+    unparseable / proxy body, or an unmapped status) is wrapped here, so
+    ``sdk/tools/transport.py`` can still ``except LucidicMockCallError`` for the
+    genuinely-malformed case.
     """
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return LucidicMockCallError(
-            code="malformed_response",
-            detail=f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}",
-        )
-
-    err = body.get("error") if isinstance(body, dict) else None
-    if not isinstance(err, dict) or "code" not in err:
-        return LucidicMockCallError(
-            code="malformed_response",
-            detail=f"HTTP {exc.response.status_code}: {body!r}",
-        )
-
-    code = err["code"]
-    detail = err.get("detail", "")
-    extra = {k: v for k, v in err.items() if k not in ("code", "detail")}
-    cls = error_class_for_code(code)
-
-    # Each typed subclass that adds attributes does so via its own
-    # __init__ keyword params. Pass the extra dict through; classes that
-    # don't recognize a key still accept it via the base's **extra
-    # channel and stash it as an attribute.
-    #
-    # When `cls is LucidicMockCallError` (unknown code → forward-compat
-    # fallback), pass the actual code through so the exception carries
-    # the backend's wire value instead of the class-level default.
-    try:
-        if cls is LucidicMockCallError:
-            return cls(detail, code=code, **extra)
-        return cls(detail, **extra)
-    except TypeError:
-        # Defensive: if a subclass added a stricter __init__ in the
-        # future and rejects an unknown kwarg, fall back to the base.
-        return LucidicMockCallError(code=code, detail=detail, **extra)
+    return LucidicMockCallError(code="malformed_response", detail=str(exc))
 
 
 class MockCallResource:
@@ -150,8 +111,10 @@ class MockCallResource:
 
         try:
             return self.http.post("sdk/mock-call", body)
-        except httpx.HTTPStatusError as exc:
-            raise _exception_from_http_error(exc) from exc
+        except LucidicMockCallError:
+            raise
+        except APIError as exc:
+            raise _as_mock_error(exc) from exc
 
     async def acall(
         self,
@@ -177,8 +140,10 @@ class MockCallResource:
 
         try:
             return await self.http.apost("sdk/mock-call", body)
-        except httpx.HTTPStatusError as exc:
-            raise _exception_from_http_error(exc) from exc
+        except LucidicMockCallError:
+            raise
+        except APIError as exc:
+            raise _as_mock_error(exc) from exc
 
     # ==================== create() / acreate() — legacy LUC-483 API ====================
 

--- a/lucidicai/api/resources/projects.py
+++ b/lucidicai/api/resources/projects.py
@@ -1,0 +1,160 @@
+"""client.projects — project CRUD (LUC-913).
+
+A new namespace. Projects are org-level groupings agents can be filed under
+(``Agent.project``). Org-scoped: a bound key still reaches them all (agent
+binding is a no-op here). ``delete`` is low-risk — ``Agent.project`` is
+SET_NULL, so deleting a project un-projects its agents rather than destroying
+them.
+
+Reads and writes are data-bearing — they do NOT swallow in production; typed
+transport errors propagate. Every method has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.project import Project
+from ..pagination import apaginate, paginate
+
+_PROJECTS = "sdk/v2/projects"
+
+
+class ProjectsResource:
+    """Handle for the ``/sdk/v2/projects`` endpoints."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    # ==================== list ====================
+
+    def list(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> Iterator[Project]:
+        """Lazily iterate the org's projects, newest first. ``ordering`` accepts
+        ``id`` (± prefix). Handy for resolving a ``project_id`` by name."""
+        base = self._params(ordering, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=Project)
+
+    def alist(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> AsyncIterator[Project]:
+        """Async sibling of ``list``."""
+        base = self._params(ordering, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=Project)
+
+    def list_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of projects."""
+        return CursorPage.from_body(
+            self._page_get(self._params(ordering, page_size), cursor), model=Project
+        )
+
+    async def alist_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Project)
+
+    # ==================== get ====================
+
+    def get(self, project_id: str) -> Project:
+        """Read one project by id (raises ``NotFoundError`` if absent)."""
+        return Project.from_dict(self.http.get(f"{_PROJECTS}/{project_id}"))
+
+    async def aget(self, project_id: str) -> Project:
+        """Async sibling of ``get``."""
+        return Project.from_dict(await self.http.aget(f"{_PROJECTS}/{project_id}"))
+
+    # ==================== create ====================
+
+    def create(self, name: str, *, icon: str, description: Optional[str] = None) -> Project:
+        """Create a project in the key's org. ``name`` and ``icon`` are required
+        by the backend (``icon`` is a required keyword, matching the write
+        surface's keyword-only style); an over-length field → ``ValidationError``."""
+        return Project.from_dict(self.http.post(_PROJECTS, self._create_body(name, icon, description)))
+
+    async def acreate(self, name: str, *, icon: str, description: Optional[str] = None) -> Project:
+        """Async sibling of ``create``."""
+        body = self._create_body(name, icon, description)
+        return Project.from_dict(await self.http.apost(_PROJECTS, body))
+
+    # ==================== update ====================
+
+    def update(
+        self, project_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+    ) -> Project:
+        """Rename / re-describe / re-icon a project. Only the fields you pass
+        change; ``None`` leaves a field untouched."""
+        return Project.from_dict(
+            self.http.put(f"{_PROJECTS}/{project_id}", self._update_body(name, description, icon))
+        )
+
+    async def aupdate(
+        self, project_id: str, *, name: Optional[str] = None,
+        description: Optional[str] = None, icon: Optional[str] = None,
+    ) -> Project:
+        """Async sibling of ``update``."""
+        return Project.from_dict(
+            await self.http.aput(f"{_PROJECTS}/{project_id}", self._update_body(name, description, icon))
+        )
+
+    # ==================== delete ====================
+
+    def delete(self, project_id: str) -> None:
+        """Delete a project (needs ``project:delete``). Its agents survive,
+        un-projected (``Agent.project`` is SET_NULL). A missing project →
+        ``NotFoundError``."""
+        self.http.delete(f"{_PROJECTS}/{project_id}")
+
+    async def adelete(self, project_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_PROJECTS}/{project_id}")
+
+    # ==================== internals ====================
+
+    @staticmethod
+    def _params(ordering: Optional[str], page_size: Optional[int]) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params or None
+
+    def _page_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_PROJECTS, params or None)
+
+    async def _apage_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_PROJECTS, params or None)
+
+    @staticmethod
+    def _create_body(name: str, icon: str, description: Optional[str]) -> Dict[str, Any]:
+        # name + icon are required by the backend; description is optional.
+        body: Dict[str, Any] = {"name": name, "icon": icon}
+        if description is not None:
+            body["description"] = description
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], description: Optional[str], icon: Optional[str]
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if icon is not None:
+            body["icon"] = icon
+        return body

--- a/lucidicai/api/resources/prompt.py
+++ b/lucidicai/api/resources/prompt.py
@@ -2,9 +2,12 @@
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, TYPE_CHECKING
 
 from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.prompt import PromptInfo, PromptVersion
+from ..pagination import apaginate, paginate
 
 if TYPE_CHECKING:
     from ...core.config import SDKConfig
@@ -385,3 +388,117 @@ class PromptResource:
                 logger.error(f"[PromptResource] Failed to update prompt metadata: {e}")
                 return Prompt(raw_content="", content="", metadata={})
             raise
+
+    # ==================== v2 reads (LUC-909) ====================
+    #
+    # Prompt-ops discovery: list the agent's prompts, walk a prompt's full
+    # version history, read the agent's label set. Data-bearing reads — they do
+    # NOT swallow in production (they surface the typed transport error), unlike
+    # the get/update methods above. ``agent_id`` defaults to the configured
+    # agent. Each read has an async sibling.
+
+    def list(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[PromptInfo]:
+        """Lazily iterate the agent's prompts (by name). ``ordering`` accepts
+        ``name`` / ``id`` (± prefix)."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return paginate(lambda c: self._page_get("sdk/v2/prompts", base, c), model=PromptInfo)
+
+    def alist(
+        self, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[PromptInfo]:
+        """Async sibling of ``list``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        return apaginate(lambda c: self._apage_get("sdk/v2/prompts", base, c), model=PromptInfo)
+
+    def list_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of prompts (manual pagination control)."""
+        body = self._page_get("sdk/v2/prompts", self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=PromptInfo)
+
+    async def alist_page(
+        self, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get("sdk/v2/prompts", self._agent_params(agent_id, ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=PromptInfo)
+
+    def versions(
+        self, name: str, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> Iterator[PromptVersion]:
+        """Lazily iterate one prompt's full version history, newest first.
+        ``ordering`` accepts ``version_number`` / ``id`` (± prefix)."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        return paginate(lambda c: self._page_get("sdk/v2/prompts/versions", base, c), model=PromptVersion)
+
+    def aversions(
+        self, name: str, agent_id: Optional[str] = None, *,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> AsyncIterator[PromptVersion]:
+        """Async sibling of ``versions``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        return apaginate(lambda c: self._apage_get("sdk/v2/prompts/versions", base, c), model=PromptVersion)
+
+    def versions_page(
+        self, name: str, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of a prompt's version history."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        return CursorPage.from_body(self._page_get("sdk/v2/prompts/versions", base, cursor), model=PromptVersion)
+
+    async def aversions_page(
+        self, name: str, agent_id: Optional[str] = None, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``versions_page``."""
+        base = self._agent_params(agent_id, ordering, page_size)
+        base["prompt_name"] = name
+        body = await self._apage_get("sdk/v2/prompts/versions", base, cursor)
+        return CursorPage.from_body(body, model=PromptVersion)
+
+    def labels(self, agent_id: Optional[str] = None) -> List[str]:
+        """The agent's label names (shared across its prompts) — a small,
+        non-paginated read."""
+        resp = self.http.get("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        return resp.get("labels", [])
+
+    async def alabels(self, agent_id: Optional[str] = None) -> List[str]:
+        """Async sibling of ``labels``."""
+        resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        return resp.get("labels", [])
+
+    # ---- read internals ----
+
+    def _agent_params(
+        self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"agent_id": agent_id or self._config.agent_id}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params
+
+    def _page_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(path, params)
+
+    async def _apage_get(self, path: str, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(path, params)

--- a/lucidicai/api/resources/prompt.py
+++ b/lucidicai/api/resources/prompt.py
@@ -482,6 +482,171 @@ class PromptResource:
         resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent})
         return resp.get("labels", [])
 
+    # ==================== v2 writes (LUC-914) ====================
+    #
+    # create makes a brand-new prompt (+ its first version, via POST /sdk/v2/prompts,
+    # LUC-931); rename / set_labels / delete operate on EXISTING prompts. (``update()``
+    # above, the gen-3 PUT /sdk/prompts, adds a *version* to an existing prompt.)
+    # Data-bearing writes → no production swallow. Each has an async sibling.
+
+    def create(
+        self, name: str, prompt_content: str, *,
+        icon: Optional[str] = None, description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None, labels: Optional[List[str]] = None,
+        agent_id: Optional[str] = None,
+    ) -> Tuple[PromptInfo, Optional[PromptVersion]]:
+        """Create a brand-new prompt and its first version (POST /sdk/v2/prompts;
+        needs ``prompt:write``). ``name`` is unique per agent — a duplicate →
+        ``ConflictError`` (use ``update()`` to add a version to an existing prompt).
+        The first version auto-gets the ``latest`` + ``production`` labels; any
+        ``labels`` you pass are added on top. Returns ``(prompt, first_version)``
+        as typed models — ``first_version`` is ``None`` only if a future backend
+        omits the version subobject from the response."""
+        response = self.http.post(
+            "sdk/v2/prompts",
+            self._create_body(name, prompt_content, icon, description, metadata, labels, agent_id),
+        )
+        self._invalidate_cache(name)  # a same-name entry (deleted elsewhere, recreated) is now stale
+        return self._created(response)
+
+    async def acreate(
+        self, name: str, prompt_content: str, *,
+        icon: Optional[str] = None, description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None, labels: Optional[List[str]] = None,
+        agent_id: Optional[str] = None,
+    ) -> Tuple[PromptInfo, Optional[PromptVersion]]:
+        """Async sibling of ``create``."""
+        response = await self.http.apost(
+            "sdk/v2/prompts",
+            self._create_body(name, prompt_content, icon, description, metadata, labels, agent_id),
+        )
+        self._invalidate_cache(name)
+        return self._created(response)
+
+    def rename(
+        self, prompt_name: str, *, new_name: Optional[str] = None,
+        icon: Optional[str] = None, agent_id: Optional[str] = None,
+    ) -> PromptInfo:
+        """Rename and/or re-icon a prompt (PATCH /sdk/v2/prompts/detail). Pass
+        ``new_name`` and/or ``icon``. A name collision with another prompt →
+        ``ConflictError``. When the renamed prompt has shipped versions, the
+        result carries a ``warning`` (on ``.extra``): clients still fetching the
+        old name will 404 until updated."""
+        result = PromptInfo.from_dict(
+            self.http.patch("sdk/v2/prompts/detail", self._rename_body(prompt_name, new_name, icon, agent_id))
+        )
+        self._invalidate_cache(prompt_name)  # old (agent, name) fetches are now stale
+        return result
+
+    async def arename(
+        self, prompt_name: str, *, new_name: Optional[str] = None,
+        icon: Optional[str] = None, agent_id: Optional[str] = None,
+    ) -> PromptInfo:
+        """Async sibling of ``rename``."""
+        body = self._rename_body(prompt_name, new_name, icon, agent_id)
+        result = PromptInfo.from_dict(await self.http.apatch("sdk/v2/prompts/detail", body))
+        self._invalidate_cache(prompt_name)
+        return result
+
+    def set_labels(
+        self, prompt_name: str, version_number: int, labels: List[str], *,
+        agent_id: Optional[str] = None,
+    ) -> PromptVersion:
+        """Set which labels point at a specific version — promote / roll back
+        (PUT /sdk/v2/prompts/labels). This is a **replace**: ``labels`` becomes
+        that version's entire label set (any other label on it is removed), and
+        each label is **moved off** whatever version currently holds it — e.g.
+        ``set_labels("greeting", 5, ["production"])`` points ``production`` at
+        v5 and removes it from wherever it was. Not additive. ``"latest"`` is
+        auto-managed and can't be moved (→ ``ValidationError``); an unknown
+        ``version_number`` → ``NotFoundError``. Returns the updated version (a
+        promote onto a previously-unlabeled version carries a ``warning`` on
+        ``.extra``)."""
+        result = PromptVersion.from_dict(
+            self.http.put("sdk/v2/prompts/labels", self._label_body(prompt_name, version_number, labels, agent_id))
+        )
+        self._invalidate_cache(prompt_name)  # label pointers moved -> label fetches stale
+        return result
+
+    async def aset_labels(
+        self, prompt_name: str, version_number: int, labels: List[str], *,
+        agent_id: Optional[str] = None,
+    ) -> PromptVersion:
+        """Async sibling of ``set_labels``."""
+        body = self._label_body(prompt_name, version_number, labels, agent_id)
+        result = PromptVersion.from_dict(await self.http.aput("sdk/v2/prompts/labels", body))
+        self._invalidate_cache(prompt_name)
+        return result
+
+    def delete(self, prompt_name: str, *, agent_id: Optional[str] = None) -> None:
+        """Hard-delete a prompt and all its versions (DELETE /sdk/v2/prompts/detail;
+        needs ``prompt:delete``). A version bound to a checkpoint is protected →
+        ``ConflictError``."""
+        self.http.delete("sdk/v2/prompts/detail", self._name_params(prompt_name, agent_id))
+        self._invalidate_cache(prompt_name)
+
+    async def adelete(self, prompt_name: str, *, agent_id: Optional[str] = None) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete("sdk/v2/prompts/detail", self._name_params(prompt_name, agent_id))
+        self._invalidate_cache(prompt_name)
+
+    # ---- write internals ----
+
+    def _create_body(
+        self, name: str, prompt_content: str, icon: Optional[str],
+        description: Optional[str], metadata: Optional[Dict[str, Any]],
+        labels: Optional[List[str]], agent_id: Optional[str],
+    ) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.create")
+        body: Dict[str, Any] = {
+            "agent_id": agent, "name": name, "prompt_content": prompt_content,
+        }
+        # omit-None: let the backend apply its defaults (icon="compass",
+        # description="", metadata={}, labels=[]) rather than sending explicit nulls.
+        if icon is not None:
+            body["icon"] = icon
+        if description is not None:
+            body["description"] = description
+        if metadata is not None:
+            body["metadata"] = metadata
+        if labels is not None:
+            body["labels"] = labels
+        return body
+
+    @staticmethod
+    def _created(response: Dict[str, Any]) -> Tuple[PromptInfo, Optional[PromptVersion]]:
+        """Split the create response into the created ``PromptInfo`` and its first
+        ``PromptVersion``. The backend returns the prompt payload plus a ``version``
+        subobject; ``version`` is ``None`` only if a future backend omits it."""
+        info = PromptInfo.from_dict(response)
+        raw_version = response.get("version")
+        version = PromptVersion.from_dict(raw_version) if isinstance(raw_version, dict) else None
+        return info, version
+
+    def _rename_body(
+        self, prompt_name: str, new_name: Optional[str], icon: Optional[str], agent_id: Optional[str]
+    ) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.rename")
+        body: Dict[str, Any] = {"agent_id": agent, "prompt_name": prompt_name}
+        if new_name is not None:
+            body["name"] = new_name  # backend field is "name" (the new name)
+        if icon is not None:
+            body["icon"] = icon
+        return body
+
+    def _label_body(
+        self, prompt_name: str, version_number: int, labels: List[str], agent_id: Optional[str]
+    ) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.set_labels")
+        return {
+            "agent_id": agent, "prompt_name": prompt_name,
+            "version_number": version_number, "labels": labels,
+        }
+
+    def _name_params(self, prompt_name: str, agent_id: Optional[str]) -> Dict[str, Any]:
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.delete")
+        return {"agent_id": agent, "prompt_name": prompt_name}
+
     # ---- read internals ----
 
     def _agent_params(

--- a/lucidicai/api/resources/prompt.py
+++ b/lucidicai/api/resources/prompt.py
@@ -8,6 +8,7 @@ from ..client import HttpClient
 from ..models.base import CursorPage
 from ..models.prompt import PromptInfo, PromptVersion
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 if TYPE_CHECKING:
     from ...core.config import SDKConfig
@@ -471,12 +472,14 @@ class PromptResource:
     def labels(self, agent_id: Optional[str] = None) -> List[str]:
         """The agent's label names (shared across its prompts) — a small,
         non-paginated read."""
-        resp = self.http.get("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.labels")
+        resp = self.http.get("sdk/v2/prompts/labels", {"agent_id": agent})
         return resp.get("labels", [])
 
     async def alabels(self, agent_id: Optional[str] = None) -> List[str]:
         """Async sibling of ``labels``."""
-        resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent_id or self._config.agent_id})
+        agent = require_agent_id(agent_id or self._config.agent_id, "prompts.labels")
+        resp = await self.http.aget("sdk/v2/prompts/labels", {"agent_id": agent})
         return resp.get("labels", [])
 
     # ---- read internals ----
@@ -484,7 +487,9 @@ class PromptResource:
     def _agent_params(
         self, agent_id: Optional[str], ordering: Optional[str], page_size: Optional[int]
     ) -> Dict[str, Any]:
-        params: Dict[str, Any] = {"agent_id": agent_id or self._config.agent_id}
+        params: Dict[str, Any] = {
+            "agent_id": require_agent_id(agent_id or self._config.agent_id, "prompts.list"),
+        }
         if ordering is not None:
             params["ordering"] = ordering
         if page_size is not None:

--- a/lucidicai/api/resources/resources.py
+++ b/lucidicai/api/resources/resources.py
@@ -1,0 +1,213 @@
+"""client.resources — SQL-substrate Resource CRUD (LUC-917).
+
+A new namespace. Resources are the org-scoped definitions of external services the
+client mocks at runtime (SQL / API / CUSTOM), attached to Datasets and Tools — the
+SQL substrate backing tool-config mocking. Org-scoped: a bound key still reaches
+all of the org's resources (agent binding is a no-op here).
+
+Reads and writes are data-bearing — they do NOT swallow in production; typed
+transport errors propagate. Every method has an ``a``-prefixed async sibling.
+"""
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+
+from ..client import HttpClient
+from ..models.base import CursorPage
+from ..models.resource import Resource
+from ..pagination import apaginate, paginate
+
+_RESOURCES = "sdk/v2/resources"
+
+
+class ResourcesResource:
+    """Handle for the ``/sdk/v2/resources`` endpoints."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    # ==================== list ====================
+
+    def list(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> Iterator[Resource]:
+        """Lazily iterate the org's resources, newest first. ``ordering`` accepts
+        ``id`` (± prefix). Handy for resolving a ``resource_id`` by name."""
+        base = self._params(ordering, page_size)
+        return paginate(lambda c: self._page_get(base, c), model=Resource)
+
+    def alist(
+        self, *, ordering: Optional[str] = None, page_size: Optional[int] = None
+    ) -> AsyncIterator[Resource]:
+        """Async sibling of ``list``."""
+        base = self._params(ordering, page_size)
+        return apaginate(lambda c: self._apage_get(base, c), model=Resource)
+
+    def list_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Fetch a single page of resources."""
+        return CursorPage.from_body(
+            self._page_get(self._params(ordering, page_size), cursor), model=Resource
+        )
+
+    async def alist_page(
+        self, *, cursor: Optional[str] = None,
+        ordering: Optional[str] = None, page_size: Optional[int] = None,
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._params(ordering, page_size), cursor)
+        return CursorPage.from_body(body, model=Resource)
+
+    # ==================== get ====================
+
+    def get(self, resource_id: str) -> Resource:
+        """Read one resource by id (raises ``NotFoundError`` if absent/cross-org)."""
+        return Resource.from_dict(self.http.get(f"{_RESOURCES}/{resource_id}"))
+
+    async def aget(self, resource_id: str) -> Resource:
+        """Async sibling of ``get``."""
+        return Resource.from_dict(await self.http.aget(f"{_RESOURCES}/{resource_id}"))
+
+    # ==================== create ====================
+
+    def create(
+        self, *, type: str, tool_name: str, name: str,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        dialect: Optional[str] = None, description: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Create a resource in the key's org (POST /sdk/v2/resources; needs
+        ``resource:write``). ``type`` is ``"SQL"`` / ``"API"`` / ``"CUSTOM"``, and
+        ``dialect`` (e.g. ``"POSTGRES"``) is required when ``type == "SQL"``. Supply
+        the schema exactly one way — either a parsed ``spec`` dict or raw ``ddl``
+        (``CREATE TABLE`` SQL the backend parses into ``spec``); passing both or
+        neither → ``ValidationError``. ``name`` and ``tool_name`` are each unique
+        per org — a duplicate → ``ConflictError``. The org is taken from the API
+        key, never the body."""
+        return Resource.from_dict(self.http.post(
+            _RESOURCES,
+            self._create_body(type, tool_name, name, spec, ddl, dialect, description, hydration_config),
+        ))
+
+    async def acreate(
+        self, *, type: str, tool_name: str, name: str,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        dialect: Optional[str] = None, description: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Async sibling of ``create``."""
+        return Resource.from_dict(await self.http.apost(
+            _RESOURCES,
+            self._create_body(type, tool_name, name, spec, ddl, dialect, description, hydration_config),
+        ))
+
+    # ==================== update ====================
+
+    def update(
+        self, resource_id: str, *, name: Optional[str] = None,
+        tool_name: Optional[str] = None, description: Optional[str] = None,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Partially update a resource (PUT /sdk/v2/resources/{id}; needs
+        ``resource:write``). Send only the fields to change — ``name`` /
+        ``tool_name`` / ``description`` / ``hydration_config``, and the schema via a
+        new ``spec`` or ``ddl`` (re-parsed into ``spec``). ``type`` and ``dialect``
+        are immutable after creation and are intentionally not accepted here. A
+        rename / ``tool_name`` collision → ``ConflictError``."""
+        return Resource.from_dict(self.http.put(
+            f"{_RESOURCES}/{resource_id}",
+            self._update_body(name, tool_name, description, spec, ddl, hydration_config),
+        ))
+
+    async def aupdate(
+        self, resource_id: str, *, name: Optional[str] = None,
+        tool_name: Optional[str] = None, description: Optional[str] = None,
+        spec: Optional[Dict[str, Any]] = None, ddl: Optional[str] = None,
+        hydration_config: Optional[Dict[str, Any]] = None,
+    ) -> Resource:
+        """Async sibling of ``update``."""
+        return Resource.from_dict(await self.http.aput(
+            f"{_RESOURCES}/{resource_id}",
+            self._update_body(name, tool_name, description, spec, ddl, hydration_config),
+        ))
+
+    # ==================== delete ====================
+
+    def delete(self, resource_id: str) -> None:
+        """Delete a resource (DELETE /sdk/v2/resources/{id}; needs
+        ``resource:delete``). A resource still attached to any Dataset, Fixture, or
+        Tool is protected → ``ConflictError`` (detach it there first). A missing /
+        cross-org id → ``NotFoundError``."""
+        self.http.delete(f"{_RESOURCES}/{resource_id}")
+
+    async def adelete(self, resource_id: str) -> None:
+        """Async sibling of ``delete``."""
+        await self.http.adelete(f"{_RESOURCES}/{resource_id}")
+
+    # ==================== internals ====================
+
+    @staticmethod
+    def _params(ordering: Optional[str], page_size: Optional[int]) -> Optional[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if ordering is not None:
+            params["ordering"] = ordering
+        if page_size is not None:
+            params["page_size"] = page_size
+        return params or None
+
+    def _page_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get(_RESOURCES, params or None)
+
+    async def _apage_get(self, base: Optional[Dict[str, Any]], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base or {})
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget(_RESOURCES, params or None)
+
+    @staticmethod
+    def _create_body(
+        type_: str, tool_name: str, name: str, spec: Optional[Dict[str, Any]],
+        ddl: Optional[str], dialect: Optional[str], description: Optional[str],
+        hydration_config: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        # type/tool_name/name are always required; the backend enforces the
+        # spec/ddl XOR and the dialect-required-when-SQL rule, so we just forward
+        # what was provided (omit-None) and let it validate.
+        body: Dict[str, Any] = {"type": type_, "tool_name": tool_name, "name": name}
+        if spec is not None:
+            body["spec"] = spec
+        if ddl is not None:
+            body["ddl"] = ddl
+        if dialect is not None:
+            body["dialect"] = dialect
+        if description is not None:
+            body["description"] = description
+        if hydration_config is not None:
+            body["hydration_config"] = hydration_config
+        return body
+
+    @staticmethod
+    def _update_body(
+        name: Optional[str], tool_name: Optional[str], description: Optional[str],
+        spec: Optional[Dict[str, Any]], ddl: Optional[str],
+        hydration_config: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        # omit-None: PUT is a partial update — send only the fields being changed.
+        body: Dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if tool_name is not None:
+            body["tool_name"] = tool_name
+        if description is not None:
+            body["description"] = description
+        if spec is not None:
+            body["spec"] = spec
+        if ddl is not None:
+            body["ddl"] = ddl
+        if hydration_config is not None:
+            body["hydration_config"] = hydration_config
+        return body

--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -469,6 +469,45 @@ class SessionResource:
             await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}/events/{event_id}", params)
         )
 
+    def finish(self, session_ids: List[str]) -> int:
+        """Bulk-finish sessions by id (POST /sdk/v2/sessions/finish; needs
+        ``session:write``). Idempotent and best-effort — unknown, cross-org,
+        already-finished, non-UUID, or (for an agent-bound key) other-agent ids are
+        silently skipped, and the call still succeeds. Finishing marks each session
+        finished, recomputes its status, and — when it has evaluators — kicks off
+        async evaluation/summarization. Unlike the single-session gen-3 ``update``,
+        this only closes sessions; it does not set per-session success/eval/tags.
+        Returns the number of sessions matched and finished.
+
+        Data-bearing write — raises the typed transport error (does not swallow),
+        unlike the gen-3 ``create``/``end`` above."""
+        resp = self.http.post("sdk/v2/sessions/finish", self._finish_body(session_ids))
+        return self._finished_count(resp)
+
+    async def afinish(self, session_ids: List[str]) -> int:
+        """Async sibling of ``finish``."""
+        resp = await self.http.apost("sdk/v2/sessions/finish", self._finish_body(session_ids))
+        return self._finished_count(resp)
+
+    @staticmethod
+    def _finish_body(session_ids: List[str]) -> Dict[str, Any]:
+        # Guard the bare-string footgun: finish("<uuid>") would list()-split the
+        # string into single-char ids the backend silently drops (→ a misleading 0).
+        # The sibling get()/end()/event() take a bare str, so this mistake is easy;
+        # fail loudly instead, matching _filter_params' TypeError discipline.
+        if isinstance(session_ids, (str, bytes)):
+            raise TypeError(
+                "session_ids must be a list of session ids, not a single string — "
+                "wrap it in a list, e.g. finish([session_id])."
+            )
+        return {"session_ids": list(session_ids)}
+
+    @staticmethod
+    def _finished_count(resp: Dict[str, Any]) -> int:
+        # `or 0` (not a .get default) so a present-but-null count degrades to 0
+        # rather than raising int(None).
+        return int(resp.get("num_sessions_finished") or 0)
+
     def update(self, session_id: str, **updates) -> Dict[str, Any]:
         """Update an existing session.
 

--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -9,6 +9,7 @@ from ..client import HttpClient
 from ..models import session as session_models
 from ..models.base import CursorPage
 from ..pagination import apaginate, paginate
+from ...core.errors import require_agent_id
 
 if TYPE_CHECKING:
     from ...client import LucidicAI
@@ -102,6 +103,11 @@ class SessionResource:
                     auto_end=False,
                 )
             raise LucidicError("Client is not properly configured")
+
+        # LUC-926: a session must attach to an agent. Raise loudly (even in
+        # production) BEFORE the swallow below, rather than POST a null agent_id
+        # and silently drop this session + all its events.
+        require_agent_id(self._config.agent_id, "sessions.create")
 
         # Use client's auto_end by default
         if auto_end is None:
@@ -209,6 +215,9 @@ class SessionResource:
                     auto_end=False,
                 )
             raise LucidicError("Client is not properly configured")
+
+        # LUC-926: same guard as create() — raise before the swallow.
+        require_agent_id(self._config.agent_id, "sessions.create")
 
         if auto_end is None:
             auto_end = self._config.auto_end

--- a/lucidicai/api/resources/session.py
+++ b/lucidicai/api/resources/session.py
@@ -2,9 +2,13 @@
 import logging
 import threading
 import uuid
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, TYPE_CHECKING
+from urllib.parse import quote
 
 from ..client import HttpClient
+from ..models import session as session_models
+from ..models.base import CursorPage
+from ..pagination import apaginate, paginate
 
 if TYPE_CHECKING:
     from ...client import LucidicAI
@@ -403,16 +407,58 @@ class SessionResource:
         )
         return response
 
-    def get(self, session_id: str) -> Dict[str, Any]:
-        """Get a session by ID.
+    # ==================== v2 reads (LUC-907) ====================
+    #
+    # These reads are data-bearing, so — unlike the telemetry lifecycle methods
+    # above — they do NOT swallow errors in production: a failure raises the
+    # typed LucidicError the transport decoded. Each has an async sibling.
 
-        Args:
-            session_id: Session ID
+    def get(self, session_id: str) -> "session_models.SessionTrace":
+        """Read a session's detail + trace (LUC-817).
 
-        Returns:
-            Session data
+        Accepts the session UUID or the client-supplied ``custom_session_id``.
+        Returns a ``SessionTrace`` (session meta + flat ``occurred_at``-ordered
+        events); use ``.tree()`` to rebuild the parent/child tree.
         """
-        return self.http.get(f"sessions/{session_id}")
+        return session_models.SessionTrace.from_dict(
+            self.http.get(f"sdk/v2/sessions/{quote(session_id, safe='')}")
+        )
+
+    async def aget(self, session_id: str) -> "session_models.SessionTrace":
+        """Async sibling of ``get``."""
+        return session_models.SessionTrace.from_dict(
+            await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}")
+        )
+
+    def evaluator_results(self, session_id: str) -> "session_models.SessionEvaluatorResults":
+        """A session's eval scores: session-level ``evals`` + event-level
+        ``event_evals`` (accepts a UUID or ``custom_session_id``)."""
+        return session_models.SessionEvaluatorResults.from_dict(
+            self.http.get(f"sdk/v2/sessions/{quote(session_id, safe='')}/evaluator-results")
+        )
+
+    async def aevaluator_results(self, session_id: str) -> "session_models.SessionEvaluatorResults":
+        """Async sibling of ``evaluator_results``."""
+        return session_models.SessionEvaluatorResults.from_dict(
+            await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}/evaluator-results")
+        )
+
+    def event(self, session_id: str, event_id: str, *, raw: bool = False) -> "session_models.Event":
+        """Read one event of a session. ``raw=True`` returns the complete
+        payload — inline in ``.payload`` (<2 MB) or a short-lived presigned
+        ``.blob_url`` for an offloaded payload (fetch the bytes with
+        ``lucidicai.api.downloads.fetch_presigned``)."""
+        params = {"raw": "true"} if raw else None
+        return session_models.Event.from_dict(
+            self.http.get(f"sdk/v2/sessions/{quote(session_id, safe='')}/events/{event_id}", params)
+        )
+
+    async def aevent(self, session_id: str, event_id: str, *, raw: bool = False) -> "session_models.Event":
+        """Async sibling of ``event``."""
+        params = {"raw": "true"} if raw else None
+        return session_models.Event.from_dict(
+            await self.http.aget(f"sdk/v2/sessions/{quote(session_id, safe='')}/events/{event_id}", params)
+        )
 
     def update(self, session_id: str, **updates) -> Dict[str, Any]:
         """Update an existing session.
@@ -485,34 +531,133 @@ class SessionResource:
 
     def list(
         self,
-        agent_id: Optional[str] = None,
+        agent_id: str,
+        *,
         experiment_id: Optional[str] = None,
-        limit: int = 100,
-        offset: int = 0
-    ) -> Dict[str, Any]:
-        """List sessions with optional filters.
+        production: Optional[bool] = None,
+        cost: Optional[str] = None,
+        duration: Optional[str] = None,
+        num_events: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        status: Optional[str] = None,
+        eval_bool: Optional[Any] = None,
+        eval_number: Optional[Any] = None,
+        eval_string: Optional[Any] = None,
+        ordering: Optional[str] = None,
+        page_size: Optional[int] = None,
+    ) -> Iterator["session_models.Session"]:
+        """Lazily iterate an agent's sessions, following pages (LUC-816).
 
-        Args:
-            agent_id: Filter by agent ID
-            experiment_id: Filter by experiment ID
-            limit: Maximum number of sessions
-            offset: Pagination offset
+        Filters (all optional): ``experiment_id``; ``production`` (bool);
+        ``cost`` / ``duration`` / ``num_events`` as ``"min:max"`` range strings
+        (either side may be blank); ``tags`` (list, AND-matched); ``status``;
+        and the repeatable eval filters ``eval_bool`` (``"name:true"`` /
+        ``"name:false"``), ``eval_number`` (``"name:min:max"``), ``eval_string``
+        (``"name:value"``) — each takes a single string or a list of them.
+        ``ordering`` accepts ``start_time`` / ``id`` (± prefix); backend default
+        is newest-first.
 
-        Returns:
-            List of sessions and pagination info
+        Lazy generator: request errors surface on first iteration. Use
+        ``count()`` for a cheap total, ``list_page()`` for eager single-page.
         """
-        params: Dict[str, Any] = {
-            "limit": limit,
-            "offset": offset
-        }
+        base = self._filter_params(agent_id, {
+            "experiment_id": experiment_id, "production": production, "cost": cost,
+            "duration": duration, "num_events": num_events, "tags": tags,
+            "status": status, "eval_bool": eval_bool, "eval_number": eval_number,
+            "eval_string": eval_string, "ordering": ordering, "page_size": page_size,
+        })
+        return paginate(
+            lambda cursor: self._page_get(base, cursor), model=session_models.Session
+        )
 
-        if agent_id:
-            params["agent_id"] = agent_id
+    def alist(self, agent_id: str, **filters: Any) -> AsyncIterator["session_models.Session"]:
+        """Async sibling of ``list`` (same filter kwargs)."""
+        base = self._filter_params(agent_id, filters)
+        return apaginate(
+            lambda cursor: self._apage_get(base, cursor), model=session_models.Session
+        )
 
-        if experiment_id:
-            params["experiment_id"] = experiment_id
+    def list_page(
+        self, agent_id: str, *, cursor: Optional[str] = None, **filters: Any
+    ) -> CursorPage:
+        """Fetch a single page of sessions (manual pagination control)."""
+        return CursorPage.from_body(
+            self._page_get(self._filter_params(agent_id, filters), cursor),
+            model=session_models.Session,
+        )
 
-        return self.http.get("sessions", params)
+    async def alist_page(
+        self, agent_id: str, *, cursor: Optional[str] = None, **filters: Any
+    ) -> CursorPage:
+        """Async sibling of ``list_page``."""
+        body = await self._apage_get(self._filter_params(agent_id, filters), cursor)
+        return CursorPage.from_body(body, model=session_models.Session)
+
+    def count(self, agent_id: str, **filters: Any) -> int:
+        """Cheap total for the filtered set via HEAD (``X-Total-Count``), no
+        paging. Same filter kwargs as ``list``."""
+        headers = self.http.head("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return int(headers.get("X-Total-Count") or 0)
+
+    async def acount(self, agent_id: str, **filters: Any) -> int:
+        """Async sibling of ``count``."""
+        headers = await self.http.ahead("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return int(headers.get("X-Total-Count") or 0)
+
+    def tags(self, agent_id: str, **filters: Any) -> List[str]:
+        """The tag set for the filtered query via HEAD (``X-Tags``), no paging."""
+        headers = self.http.head("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return [t for t in headers.get("X-Tags", "").split(",") if t]
+
+    async def atags(self, agent_id: str, **filters: Any) -> List[str]:
+        """Async sibling of ``tags``."""
+        headers = await self.http.ahead("sdk/v2/sessions", self._filter_params(agent_id, filters))
+        return [t for t in headers.get("X-Tags", "").split(",") if t]
+
+    # ---- list internals ----
+
+    _FILTER_KEYS = frozenset({
+        "experiment_id", "production", "cost", "duration", "num_events", "tags",
+        "status", "eval_bool", "eval_number", "eval_string", "ordering", "page_size",
+    })
+
+    @classmethod
+    def _filter_params(cls, agent_id: str, f: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the /sdk/v2/sessions query params from the filter kwargs,
+        omitting unset ones. Shared by list / list_page / count / tags.
+
+        An unknown filter name raises TypeError: the ``**filters`` methods
+        (count/tags/list_page) would otherwise silently ignore a typo like
+        ``experiment=`` and return the *unfiltered* result — a wrong number
+        with no error."""
+        unknown = set(f) - cls._FILTER_KEYS
+        if unknown:
+            raise TypeError(f"unknown session filter(s): {sorted(unknown)}")
+        params: Dict[str, Any] = {"agent_id": agent_id}
+        for key in ("experiment_id", "status", "cost", "duration", "num_events",
+                    "ordering", "page_size", "eval_bool", "eval_number", "eval_string"):
+            value = f.get(key)
+            if value is not None:
+                params[key] = value
+        production = f.get("production")
+        if production is not None:
+            params["production"] = "true" if production else "false"
+        tags = f.get("tags")
+        if tags:
+            params["tags"] = ",".join(tags) if isinstance(tags, (list, tuple)) else tags
+        return params
+
+    def _page_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return self.http.get("sdk/v2/sessions", params)
+
+    async def _apage_get(self, base: Dict[str, Any], cursor: Optional[str]) -> Dict[str, Any]:
+        params = dict(base)
+        if cursor:
+            params["cursor"] = cursor
+        return await self.http.aget("sdk/v2/sessions", params)
 
     # ==================== Asynchronous HTTP Methods ====================
 
@@ -541,17 +686,6 @@ class SessionResource:
             f"session_id={_truncate_id(resp_session_id)}, response_keys={list(response.keys()) if response else 'None'}"
         )
         return response
-
-    async def aget(self, session_id: str) -> Dict[str, Any]:
-        """Get a session by ID (asynchronous).
-
-        Args:
-            session_id: Session ID
-
-        Returns:
-            Session data
-        """
-        return await self.http.aget(f"sessions/{session_id}")
 
     async def aupdate(self, session_id: str, **updates) -> Dict[str, Any]:
         """Update an existing session (asynchronous).
@@ -620,34 +754,3 @@ class SessionResource:
             updates["is_successful_reason"] = is_successful_reason
 
         return await self.aupdate(session_id, **updates)
-
-    async def alist(
-        self,
-        agent_id: Optional[str] = None,
-        experiment_id: Optional[str] = None,
-        limit: int = 100,
-        offset: int = 0
-    ) -> Dict[str, Any]:
-        """List sessions with optional filters (asynchronous).
-
-        Args:
-            agent_id: Filter by agent ID
-            experiment_id: Filter by experiment ID
-            limit: Maximum number of sessions
-            offset: Pagination offset
-
-        Returns:
-            List of sessions and pagination info
-        """
-        params: Dict[str, Any] = {
-            "limit": limit,
-            "offset": offset
-        }
-
-        if agent_id:
-            params["agent_id"] = agent_id
-
-        if experiment_id:
-            params["experiment_id"] = experiment_id
-
-        return await self.http.aget("sessions", params)

--- a/lucidicai/api/resources/session_init_fixtures.py
+++ b/lucidicai/api/resources/session_init_fixtures.py
@@ -23,10 +23,7 @@ Backend contract (``api/views/sdk_session_fixtures.py``):
 import logging
 from typing import Any, Dict
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import LucidicError
 
 logger = logging.getLogger("Lucidic")
 
@@ -44,37 +41,20 @@ class SessionInitFixturesResource:
         True → session is tool-backed and ready for mock_call; False →
         no-op (session has no DatasetItem or no Resources/tools).
 
-        Raises ``LucidicError`` on 4xx/5xx with the backend's error
-        string. The session_not_found path (404) is a real bug — the
-        session_id was wrong or already finished — but we surface it
-        as a plain ``LucidicError`` since the caller in
-        ``SessionResource.create()`` already swallows + warns.
+        Raises a typed ``LucidicError`` (e.g. ``NotFoundError`` on a wrong /
+        finished session_id, ``ServiceUnavailableError`` after the transport
+        exhausts its 503 retry budget) on non-2xx. The caller in
+        ``SessionResource.create()`` already swallows + warns, so these don't
+        surface to the user.
         """
         body = {"session_id": session_id}
         logger.debug(
             "[SessionInitFixturesResource] init session %s",
             session_id[:8] + "..." if len(session_id) > 8 else session_id,
         )
-        try:
-            return self.http.post("sdk/session-init-fixtures", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_init_error(exc)) from exc
+        return self.http.post("sdk/session-init-fixtures", body)
 
     async def ainit(self, session_id: str) -> Dict[str, Any]:
         """Async sibling of ``init``."""
         body = {"session_id": session_id}
-        try:
-            return await self.http.apost("sdk/session-init-fixtures", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_init_error(exc)) from exc
-
-
-def _format_init_error(exc: httpx.HTTPStatusError) -> str:
-    """Best-effort human-readable error from a non-2xx response."""
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
-    if isinstance(body, dict) and "error" in body:
-        return f"HTTP {exc.response.status_code}: {body['error']}"
-    return f"HTTP {exc.response.status_code}: {body!r}"
+        return await self.http.apost("sdk/session-init-fixtures", body)

--- a/lucidicai/api/resources/training_modules.py
+++ b/lucidicai/api/resources/training_modules.py
@@ -5,14 +5,16 @@ Thin wrappers over the backend inference-time Training Modules endpoints:
 - GET /sdk/training-modules/tools
 - POST /sdk/training-modules/inferences
 - GET /sdk/training-modules/inferences/{inference_run_id}
+
+Non-2xx responses raise a typed ``LucidicError`` from the central transport
+decoder (LUC-900) — e.g. ``NotFoundError``, ``ValidationError`` (with
+``.details``), or ``ServiceUnavailableError`` after the transport's 503 retry
+budget is exhausted. This module no longer hand-formats error strings.
 """
 import logging
 from typing import Any, Dict, Optional
 
-import httpx
-
 from ..client import HttpClient
-from ...core.errors import LucidicError
 
 logger = logging.getLogger("Lucidic")
 
@@ -41,13 +43,10 @@ class TrainingModulesAPIResource:
         ``prompt_name`` to scope to a single edit site server-side (LUC-801), and
         ``checkpoint_id`` to introspect a checkpoint without a live session.
         """
-        try:
-            return self.http.get(
-                "sdk/training-modules/tools",
-                _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return self.http.get(
+            "sdk/training-modules/tools",
+            _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
+        )
 
     async def alist_tools(
         self,
@@ -57,13 +56,10 @@ class TrainingModulesAPIResource:
         checkpoint_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Async sibling of ``list_tools``."""
-        try:
-            return await self.http.aget(
-                "sdk/training-modules/tools",
-                _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return await self.http.aget(
+            "sdk/training-modules/tools",
+            _tools_params(session_id=session_id, prompt_name=prompt_name, checkpoint_id=checkpoint_id),
+        )
 
     def submit_inference(
         self,
@@ -81,10 +77,7 @@ class TrainingModulesAPIResource:
         }
         if client_event_id is not None:
             body["client_event_id"] = client_event_id
-        try:
-            return self.http.post("sdk/training-modules/inferences", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return self.http.post("sdk/training-modules/inferences", body)
 
     async def asubmit_inference(
         self,
@@ -102,10 +95,7 @@ class TrainingModulesAPIResource:
         }
         if client_event_id is not None:
             body["client_event_id"] = client_event_id
-        try:
-            return await self.http.apost("sdk/training-modules/inferences", body)
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return await self.http.apost("sdk/training-modules/inferences", body)
 
     def get_inference(
         self,
@@ -115,13 +105,10 @@ class TrainingModulesAPIResource:
     ) -> Dict[str, Any]:
         """Fetch an existing Training Module inference run."""
         params = {"session_id": session_id} if session_id else None
-        try:
-            return self.http.get(
-                f"sdk/training-modules/inferences/{inference_run_id}",
-                params,
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return self.http.get(
+            f"sdk/training-modules/inferences/{inference_run_id}",
+            params,
+        )
 
     async def aget_inference(
         self,
@@ -131,13 +118,10 @@ class TrainingModulesAPIResource:
     ) -> Dict[str, Any]:
         """Async sibling of ``get_inference``."""
         params = {"session_id": session_id} if session_id else None
-        try:
-            return await self.http.aget(
-                f"sdk/training-modules/inferences/{inference_run_id}",
-                params,
-            )
-        except httpx.HTTPStatusError as exc:
-            raise LucidicError(_format_training_module_error(exc)) from exc
+        return await self.http.aget(
+            f"sdk/training-modules/inferences/{inference_run_id}",
+            params,
+        )
 
 
 def _tools_params(
@@ -159,18 +143,3 @@ def _tools_params(
     if prompt_name is not None:
         params["prompt_name"] = prompt_name
     return params
-
-
-def _format_training_module_error(exc: httpx.HTTPStatusError) -> str:
-    """Best-effort human-readable Training Modules error."""
-    try:
-        body = exc.response.json()
-    except ValueError:
-        return f"HTTP {exc.response.status_code}: {exc.response.text or 'no body'}"
-
-    if isinstance(body, dict):
-        if "error" in body:
-            return f"HTTP {exc.response.status_code}: {body['error']}"
-        if "errors" in body:
-            return f"HTTP {exc.response.status_code} validation: {body['errors']}"
-    return f"HTTP {exc.response.status_code}: {body!r}"

--- a/lucidicai/api/resources/usage.py
+++ b/lucidicai/api/resources/usage.py
@@ -1,0 +1,21 @@
+"""client.usage — org-aggregated usage / quota counters (LUC-911).
+
+A single-endpoint namespace. Data-bearing read — does NOT swallow in production.
+"""
+from ..client import HttpClient
+from ..models.usage import Usage
+
+
+class UsageResource:
+    """Handle for ``GET /sdk/v2/usage``."""
+
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    def get(self) -> Usage:
+        """Read the key's org aggregated usage counters (scope ``usage:read``)."""
+        return Usage.from_dict(self.http.get("sdk/v2/usage"))
+
+    async def aget(self) -> Usage:
+        """Async sibling of ``get``."""
+        return Usage.from_dict(await self.http.aget("sdk/v2/usage"))

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -37,7 +37,7 @@ from .api.resources.experiment import ExperimentResource
 from .api.resources.prompt import PromptResource
 from .api.resources.feature_flag import FeatureFlagResource
 from .api.resources.evals import EvalsResource
-from .api.resources.evosim import EvoSimResource
+from .api.resources.evosim import EvoSimsResource
 from .api.resources.mock_call import MockCallResource
 from .sdk.training_modules.resource import TrainingModulesResource
 from .sdk.tools.resource import ToolsResource
@@ -174,7 +174,7 @@ class LucidicAI:
             "prompts": PromptResource(self._http, self._config, self._production),
             "feature_flags": FeatureFlagResource(self._http, self._config.agent_id, self._production),
             "evals": EvalsResource(self._http, self._production),
-            "evosims": EvoSimResource(self._http, self._config.agent_id, self._production),
+            "evosims": EvoSimsResource(self._http, self._config.agent_id, self._production),
             "mock_calls": MockCallResource(self._http, self._production),
         }
 
@@ -417,8 +417,10 @@ class LucidicAI:
         return self._resources["evals"]
 
     @property
-    def evosims(self) -> EvoSimResource:
-        """Access EvoSim resource for agent optimization runs.
+    def evosims(self) -> EvoSimsResource:
+        """Access EvoSim run management (LUC-923): ``train`` kickoff, ``list`` /
+        ``get`` runs, ``cancel``, ``iteration_instances``, and ``wait_for`` a run to
+        a terminal status.
 
         Example:
             result = client.evosims.train("training_config.json")

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -25,6 +25,8 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 from .api.client import HttpClient
 from .api.resources.agents import AgentsResource
+from .api.resources.evaluator_results import EvaluatorResultsResource
+from .api.resources.evaluators import EvaluatorsResource
 from .api.resources.session import SessionResource
 from .api.resources.event import EventResource
 from .api.resources.dataset import DatasetResource
@@ -157,6 +159,8 @@ class LucidicAI:
         # Initialize API resources
         self._resources: Dict[str, Any] = {
             "agents": AgentsResource(self._http),
+            "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
+            "evaluator_results": EvaluatorResultsResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
             "datasets": DatasetResource(self._http, self._config.agent_id, self._production),
@@ -252,6 +256,26 @@ class LucidicAI:
         follow-up.)
         """
         return self._resources["agents"]
+
+    @property
+    def evaluators(self) -> EvaluatorsResource:
+        """Access evaluator reads (LUC-910): ``list()`` / ``get(id)``,
+        ``evals(id)`` (one evaluator's result distribution), and ``result(id)``
+        (a single evaluator result by id).
+
+        Distinct from ``client.evals`` (ad-hoc score ``emit``).
+        """
+        return self._resources["evaluators"]
+
+    @property
+    def evaluator_results(self) -> EvaluatorResultsResource:
+        """Read a single evaluator result by its id (LUC-910):
+        ``client.evaluator_results.get(eval_id)``.
+
+        Keyed by an ``EvalResult`` id — distinct from the evaluator-keyed reads
+        on ``client.evaluators``.
+        """
+        return self._resources["evaluator_results"]
 
     @property
     def tools(self) -> ToolsResource:

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -28,6 +28,7 @@ from .api.resources.agents import AgentsResource
 from .api.resources.evaluator_results import EvaluatorResultsResource
 from .api.resources.evaluators import EvaluatorsResource
 from .api.resources.session import SessionResource
+from .api.resources.usage import UsageResource
 from .api.resources.event import EventResource
 from .api.resources.dataset import DatasetResource
 from .api.resources.experiment import ExperimentResource
@@ -161,6 +162,7 @@ class LucidicAI:
             "agents": AgentsResource(self._http),
             "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
             "evaluator_results": EvaluatorResultsResource(self._http),
+            "usage": UsageResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
             "datasets": DatasetResource(self._http, self._config.agent_id, self._production),
@@ -276,6 +278,13 @@ class LucidicAI:
         on ``client.evaluators``.
         """
         return self._resources["evaluator_results"]
+
+    @property
+    def usage(self) -> UsageResource:
+        """Access org-aggregated usage counters (LUC-911):
+        ``client.usage.get()`` returns a read-only ``{stat_name: total}`` mapping.
+        """
+        return self._resources["usage"]
 
     @property
     def tools(self) -> ToolsResource:

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -28,6 +28,7 @@ from .api.resources.agents import AgentsResource
 from .api.resources.evaluator_results import EvaluatorResultsResource
 from .api.resources.evaluators import EvaluatorsResource
 from .api.resources.projects import ProjectsResource
+from .api.resources.resources import ResourcesResource
 from .api.resources.session import SessionResource
 from .api.resources.usage import UsageResource
 from .api.resources.event import EventResource
@@ -164,6 +165,7 @@ class LucidicAI:
             "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
             "evaluator_results": EvaluatorResultsResource(self._http),
             "projects": ProjectsResource(self._http),
+            "resources": ResourcesResource(self._http),
             "usage": UsageResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
@@ -288,6 +290,15 @@ class LucidicAI:
         (SET_NULL) rather than destroying them.
         """
         return self._resources["projects"]
+
+    @property
+    def resources(self) -> ResourcesResource:
+        """Access SQL-substrate Resource CRUD (LUC-917): ``list`` / ``create`` /
+        ``get`` / ``update`` / ``delete``. Org-scoped definitions of external
+        services the client mocks at runtime (SQL / API / CUSTOM), attached to
+        Datasets and Tools. ``delete`` is protected while the resource is in use.
+        """
+        return self._resources["resources"]
 
     @property
     def usage(self) -> UsageResource:

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -27,6 +27,7 @@ from .api.client import HttpClient
 from .api.resources.agents import AgentsResource
 from .api.resources.evaluator_results import EvaluatorResultsResource
 from .api.resources.evaluators import EvaluatorsResource
+from .api.resources.projects import ProjectsResource
 from .api.resources.session import SessionResource
 from .api.resources.usage import UsageResource
 from .api.resources.event import EventResource
@@ -162,6 +163,7 @@ class LucidicAI:
             "agents": AgentsResource(self._http),
             "evaluators": EvaluatorsResource(self._http, self._config.agent_id),
             "evaluator_results": EvaluatorResultsResource(self._http),
+            "projects": ProjectsResource(self._http),
             "usage": UsageResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
@@ -278,6 +280,14 @@ class LucidicAI:
         on ``client.evaluators``.
         """
         return self._resources["evaluator_results"]
+
+    @property
+    def projects(self) -> ProjectsResource:
+        """Access project CRUD (LUC-913): ``list`` / ``create`` / ``get`` /
+        ``update`` / ``delete``. Org-scoped; ``delete`` un-projects agents
+        (SET_NULL) rather than destroying them.
+        """
+        return self._resources["projects"]
 
     @property
     def usage(self) -> UsageResource:

--- a/lucidicai/client.py
+++ b/lucidicai/client.py
@@ -24,6 +24,7 @@ import uuid
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 from .api.client import HttpClient
+from .api.resources.agents import AgentsResource
 from .api.resources.session import SessionResource
 from .api.resources.event import EventResource
 from .api.resources.dataset import DatasetResource
@@ -155,6 +156,7 @@ class LucidicAI:
 
         # Initialize API resources
         self._resources: Dict[str, Any] = {
+            "agents": AgentsResource(self._http),
             "sessions": SessionResource(self._http, self, self._config, self._production),
             "events": EventResource(self._http, self._production),
             "datasets": DatasetResource(self._http, self._config.agent_id, self._production),
@@ -239,6 +241,17 @@ class LucidicAI:
     def is_valid(self) -> bool:
         """Check if the client is properly configured."""
         return self._valid
+
+    @property
+    def agents(self) -> AgentsResource:
+        """Access agent reads (LUC-906): ``list()`` / ``get(id)`` + ``tool_catalog(id)``.
+
+        Enumerate the org's agents (discover their ``agent_id`` s), read one
+        back, or inspect an agent's tool catalog. (A client still needs an
+        ``agent_id`` to construct today; a read-only bootstrap mode is a planned
+        follow-up.)
+        """
+        return self._resources["agents"]
 
     @property
     def tools(self) -> ToolsResource:

--- a/lucidicai/core/config.py
+++ b/lucidicai/core/config.py
@@ -223,10 +223,13 @@ class SDKConfig:
         
         if not self.api_key:
             errors.append("API key is required (LUCIDIC_API_KEY)")
-        
-        if not self.agent_id:
-            errors.append("Agent ID is required (LUCIDIC_AGENT_ID)")
-        
+
+        # agent_id is intentionally NOT required (LUC-926): a client may be
+        # constructed with just an api_key to run org-/id-scoped operations
+        # (agents/projects/usage, get-by-id). Agent-scoped operations (telemetry
+        # ingestion, prompt fetch, list-by-agent) guard with require_agent_id and
+        # raise AgentIdRequiredError when it's actually needed but absent.
+
         if self.blob_threshold < 1024:
             errors.append("Blob threshold must be at least 1024 bytes")
         

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -148,6 +148,39 @@ class FeatureFlagError(LucidicError):
         super().__init__(f"Failed to fetch feature flag: {message}")
 
 
+class AgentIdRequiredError(LucidicError):
+    """Raised when an operation needs an ``agent_id`` but the client was created
+    without one (LUC-926).
+
+    ``agent_id`` is optional at construction so org-/id-scoped work (agents,
+    projects, usage, and any get-by-id) can run without one. Operations that are
+    inherently agent-scoped — telemetry ingestion, prompt fetch, and the
+    list-by-agent reads — raise this instead. It is raised **even in production**
+    (not routed through the telemetry error-swallow): a missing agent_id is a
+    deterministic setup mistake, so silently no-op'ing would just lose data.
+    """
+
+    def __init__(self, operation: str):
+        super().__init__(
+            f"{operation} requires an agent_id, but this client was created "
+            f"without one. Provide it via LucidicAI(agent_id=...), the "
+            f"LUCIDIC_AGENT_ID env var, or (where the method accepts it) pass "
+            f"agent_id=... to the call."
+        )
+
+
+def require_agent_id(agent_id: Optional[str], operation: str) -> str:
+    """Return ``agent_id`` if present, else raise ``AgentIdRequiredError``.
+
+    The single guard for every agent-scoped operation. Call at the top of the
+    operation, before any HTTP request or error-swallowing, so the failure is
+    immediate and loud.
+    """
+    if not agent_id:
+        raise AgentIdRequiredError(operation)
+    return agent_id
+
+
 # ---------------------------------------------------------------------------
 # mock_call dispatch errors (LUC-607)
 # ---------------------------------------------------------------------------

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -78,10 +78,13 @@ class APIKeyVerificationError(AuthError):
 
 
 class InsufficientScopeError(LucidicAPIError):
-    """403 — the API key lacks the required capability scope.
+    """403 — the API key is not authorized for this action.
 
-    ``required_scope`` names the missing ``resource:verb`` when the backend
-    reports it, so the message can tell the user which preset/key to mint.
+    Usually a missing capability scope: ``required_scope`` names the missing
+    ``resource:verb`` when the backend reports it. When ``required_scope`` is
+    ``None`` the key HAS the scope but a narrower rule blocked the action (e.g.
+    an agent-bound key can't create new agents) — read the message rather than
+    assuming a scope is missing.
     """
     status_code = 403
 

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -8,10 +8,123 @@ class LucidicError(Exception):
     pass
 
 
-class APIKeyVerificationError(LucidicError):
-    """Exception for API key verification errors"""
-    def __init__(self, message):
-        super().__init__(f"Could not verify Lucidic API key: {message}")
+# ---------------------------------------------------------------------------
+# HTTP / API errors (LUC-900)
+# ---------------------------------------------------------------------------
+#
+# Every non-2xx response from the Lucidic API is decoded once, centrally, in
+# ``HttpClient._handle_response`` and raised as one of the typed exceptions
+# below (all subclasses of ``LucidicError``, so ``except LucidicError`` still
+# catches everything). The backend error envelope is one of:
+#
+#   {"error": "<message>"}                       -> message
+#   {"error": "Validation failed", "details": …} -> message + details
+#   {"errors": {<field>: [...]}}                 -> ValidationError(details=…)
+#   {"detail": "<message>"}                      -> message (DRF default)
+#   {"error": {"code": str, ...}}                -> mock-call family (below)
+#
+# ``exception_from_response`` does the decoding; ``_STATUS_TO_CLASS`` maps
+# status codes to the generic classes.
+
+
+class LucidicAPIError(LucidicError):
+    """Base for a typed non-2xx response from the Lucidic API.
+
+    Carries the HTTP ``status_code``, the decoded ``response_body`` (when the
+    body was JSON), the raw ``response_text``, and any field-level ``details``
+    so callers can inspect a failure without re-parsing the response.
+    """
+
+    # Subclasses pin their canonical status; the base leaves it None.
+    status_code: Optional[int] = None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        details: Any = None,
+        response_body: Any = None,
+        response_text: Optional[str] = None,
+    ):
+        if status_code is not None:
+            self.status_code = status_code
+        self.details = details
+        self.response_body = response_body
+        self.response_text = response_text
+        super().__init__(message)
+
+
+class ValidationError(LucidicAPIError):
+    """400 / 422 — invalid input. ``details`` carries field-level errors when
+    the backend returns ``{"errors": {...}}`` or ``{"details": {...}}``."""
+    status_code = 400
+
+
+class AuthError(LucidicAPIError):
+    """401 — missing or invalid API key."""
+    status_code = 401
+
+
+class APIKeyVerificationError(AuthError):
+    """Exception for API key verification errors.
+
+    Kept as a distinct type + message for the init/verify path and for
+    back-compat with callers that ``except APIKeyVerificationError``; it is now
+    an ``AuthError`` subclass so ``except AuthError`` catches it too.
+    """
+    def __init__(self, message, **kwargs: Any):
+        super().__init__(f"Could not verify Lucidic API key: {message}", **kwargs)
+
+
+class InsufficientScopeError(LucidicAPIError):
+    """403 — the API key lacks the required capability scope.
+
+    ``required_scope`` names the missing ``resource:verb`` when the backend
+    reports it, so the message can tell the user which preset/key to mint.
+    """
+    status_code = 403
+
+    def __init__(self, message: str, *, required_scope: Optional[str] = None, **kwargs: Any):
+        self.required_scope = required_scope
+        super().__init__(message, **kwargs)
+
+
+class NotFoundError(LucidicAPIError):
+    """404 — resource not found, **or** an agent-bound key that can't see it
+    (the backend returns 404 rather than 403 to avoid leaking existence)."""
+    status_code = 404
+
+
+class ConflictError(LucidicAPIError):
+    """409 — conflict, typically a duplicate (unique-constraint) violation."""
+    status_code = 409
+
+
+class RateLimitError(LucidicAPIError):
+    """429 — throttled. Raised only after the transport's retry budget is
+    exhausted; ``retry_after`` carries the server's hint when present."""
+    status_code = 429
+
+    def __init__(self, message: str, *, retry_after: Optional[float] = None, **kwargs: Any):
+        self.retry_after = retry_after
+        super().__init__(message, **kwargs)
+
+
+class ServiceUnavailableError(LucidicAPIError):
+    """503 — temporarily unavailable (Temporal / S3 degraded, or a workflow
+    couldn't start). Retryable; raised only after the transport's retry budget
+    is exhausted. ``retry_after`` carries the server's hint when present."""
+    status_code = 503
+
+    def __init__(self, message: str, *, retry_after: Optional[float] = None, **kwargs: Any):
+        self.retry_after = retry_after
+        super().__init__(message, **kwargs)
+
+
+class APIError(LucidicAPIError):
+    """Any other non-2xx (5xx, unmapped codes, or an unparseable/malformed
+    body). The catch-all so callers always get a typed ``LucidicAPIError``."""
 
 class LucidicNotInitializedError(LucidicError):
     """Exception for calling Lucidic functions before Lucidic Client is initialized (lai.init())"""
@@ -239,6 +352,98 @@ def error_class_for_code(code: str) -> Type[LucidicMockCallError]:
     generic `LucidicError`.
     """
     return _CODE_TO_CLASS.get(code, LucidicMockCallError)
+
+
+# ---------------------------------------------------------------------------
+# Central non-2xx decoding (LUC-900)
+# ---------------------------------------------------------------------------
+
+# Status -> generic typed exception. The mock-call ``{"error": {"code"}}``
+# family is matched by *shape*, not status, before this map is consulted.
+_STATUS_TO_CLASS: dict[int, Type[LucidicAPIError]] = {
+    400: ValidationError,
+    401: APIKeyVerificationError,  # back-compat: keep the verify-key type on 401
+    403: InsufficientScopeError,
+    404: NotFoundError,
+    409: ConflictError,
+    422: ValidationError,
+    429: RateLimitError,
+    503: ServiceUnavailableError,
+}
+
+
+def _mock_error_from_envelope(err: dict) -> LucidicMockCallError:
+    """Build the typed mock-call exception from a decoded
+    ``{"code": str, "detail": str, ...code-specific}`` error object.
+
+    Mirrors the forward-compat handling of the former
+    ``mock_call._exception_from_http_error``: unknown codes fall back to the
+    base ``LucidicMockCallError`` carrying the wire ``code``.
+    """
+    # Caller guarantees "code" is present (matched by shape before dispatch).
+    code = err["code"]
+    detail = err.get("detail", "")
+    extra = {k: v for k, v in err.items() if k not in ("code", "detail")}
+    cls = error_class_for_code(code)
+    try:
+        if cls is LucidicMockCallError:
+            return cls(detail, code=code, **extra)
+        return cls(detail, **extra)
+    except TypeError:
+        # Defensive: a subclass with a stricter __init__ rejecting an unknown
+        # kwarg still degrades to the base class.
+        return LucidicMockCallError(code=code, detail=detail, **extra)
+
+
+def exception_from_response(
+    status_code: int,
+    body: Any,
+    text: str = "",
+    *,
+    retry_after: Optional[float] = None,
+) -> LucidicError:
+    """Decode a non-2xx response into a typed exception.
+
+    Shapes handled, in priority order: the mock-call ``{"error": {"code"}}``
+    family, ``{"errors": {...}}`` validation dicts, ``{"error": "..."}`` (with
+    optional ``details``), DRF ``{"detail": "..."}``, then a text fallback.
+    Unknown/absent status codes yield ``APIError`` so callers always get a
+    typed ``LucidicAPIError``.
+    """
+    details: Any = None
+    message: Optional[str] = None
+
+    if isinstance(body, dict):
+        err = body.get("error")
+        # Mock-call family is keyed by shape (a nested dict with a "code"),
+        # which no generic endpoint returns — safe to match regardless of path.
+        if isinstance(err, dict) and "code" in err:
+            return _mock_error_from_envelope(err)
+        if isinstance(body.get("errors"), dict):
+            details = body["errors"]
+            message = "Validation failed"
+        elif isinstance(err, str):
+            message = err
+            if isinstance(body.get("details"), (dict, list)):
+                details = body["details"]
+        elif isinstance(body.get("detail"), str):
+            message = body["detail"]
+
+    if message is None:
+        message = text or f"HTTP {status_code}"
+
+    cls = _STATUS_TO_CLASS.get(status_code, APIError)
+    kwargs: dict = {
+        "status_code": status_code,
+        "details": details,
+        "response_body": body if isinstance(body, dict) else None,
+        "response_text": text,
+    }
+    if cls in (RateLimitError, ServiceUnavailableError):
+        kwargs["retry_after"] = retry_after
+    if cls is InsufficientScopeError and isinstance(body, dict):
+        kwargs["required_scope"] = body.get("required_scope")
+    return cls(message, **kwargs)
 
 
 def install_error_handler():

--- a/lucidicai/core/errors.py
+++ b/lucidicai/core/errors.py
@@ -8,6 +8,21 @@ class LucidicError(Exception):
     pass
 
 
+class WaitTimeout(LucidicError):
+    """Raised by the ``wait_for`` / ``await_for`` poll helpers (LUC-920) when a
+    trigger-then-poll workflow does not reach a terminal state before the deadline.
+
+    ``last_state`` is the most recently polled state (so a caller can still inspect
+    partial progress); ``timeout`` is the budget in seconds that elapsed.
+    """
+
+    def __init__(self, last_state: Any = None, timeout: Optional[float] = None):
+        self.last_state = last_state
+        self.timeout = timeout
+        detail = f" within {timeout:g}s" if timeout is not None else ""
+        super().__init__(f"Polling did not reach a terminal state{detail}.")
+
+
 # ---------------------------------------------------------------------------
 # HTTP / API errors (LUC-900)
 # ---------------------------------------------------------------------------

--- a/lucidicai/sdk/session.py
+++ b/lucidicai/sdk/session.py
@@ -75,7 +75,7 @@ def _ensure_http_and_resources_initialized(config: SDKConfig) -> None:
 def _build_session_params(
     session_id: Optional[str],
     session_name: Optional[str],
-    agent_id: str,
+    agent_id: Optional[str],
     task: Optional[str],
     tags: Optional[List],
     experiment_id: Optional[str],
@@ -84,10 +84,16 @@ def _build_session_params(
     production_monitoring: bool,
 ) -> tuple[str, dict]:
     """Build session parameters for API call.
-    
+
     Returns:
         Tuple of (real_session_id, session_params)
     """
+    # LUC-926: a session must attach to an agent. Raise loudly (even in
+    # production) if there's no agent_id, rather than POST a null one or let a
+    # swallow silently drop the session. Shared by create_session + acreate.
+    from ..core.errors import require_agent_id
+    require_agent_id(agent_id, "create_session")
+
     # Create or retrieve session
     if session_id:
         real_session_id = session_id
@@ -330,7 +336,12 @@ def emit_session(
         Session ID - returned immediately
     """
     from .init import _sdk_state
-    
+
+    # NOTE (LUC-926): emit_session is pre-existing-broken — the import above
+    # (`_sdk_state`) doesn't exist in sdk/init.py, so this fire-and-forget path
+    # raises ImportError on first use and is effectively dead (not in __all__).
+    # It is therefore NOT a silent-loss risk; no agent_id guard is added here.
+
     # Pre-generate session ID for instant return
     real_session_id = session_id or str(uuid.uuid4())
     

--- a/lucidicai/sdk/training_modules/resource.py
+++ b/lucidicai/sdk/training_modules/resource.py
@@ -4,15 +4,14 @@
 checkpoint-backed module tools. It hides backend inference-run bookkeeping
 on success and returns structured soft failures for agent-facing failures.
 """
-import asyncio
 import json
 import logging
-import time
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+from ...api.polling import await_for, wait_for
 from ...api.resources.training_modules import TrainingModulesAPIResource
-from ...core.errors import LucidicError
+from ...core.errors import LucidicError, WaitTimeout
 from ..context import current_session_id
 
 if TYPE_CHECKING:
@@ -22,6 +21,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger("Lucidic")
 
 ACTIVE_STATUSES = {"PENDING", "SUBMITTED", "RUNNING"}
+
+
+class _PollAbort(Exception):
+    """Carries a soft-failure result out of the poll closure (LUC-920 refactor).
+
+    The training-module mock-call contract never raises — a poll-time problem
+    (malformed response, transport error) degrades to a structured soft failure.
+    The generic ``wait_for`` loop can't produce those, so the poll closure raises
+    this to hand the already-built failure back for the caller to return."""
+
+    def __init__(self, failure: Dict[str, Any]):
+        self.failure = failure
+        super().__init__(failure.get("error", {}).get("code", "poll_abort"))
 
 
 class TrainingModulesResource:
@@ -355,37 +367,40 @@ class TrainingModulesResource:
         timeout_seconds: Optional[float],
         poll_interval_seconds: Optional[float],
     ) -> Any:
-        deadline = time.monotonic() + self._timeout(timeout_seconds)
-        interval = self._poll_interval(poll_interval_seconds)
+        box = {"run": run}
 
-        while run.get("status") in ACTIVE_STATUSES:
-            if time.monotonic() >= deadline:
-                return self._timeout_failure(run, timeout_seconds)
-            inference_run_id = run.get("inference_run_id")
+        def poll() -> Dict[str, Any]:
+            current = box["run"]
+            inference_run_id = current.get("inference_run_id")
             if not inference_run_id:
-                return self._soft_failure(
+                raise _PollAbort(self._soft_failure(
                     code="training_module_malformed_response",
                     message="Training Module inference response did not include inference_run_id.",
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
-            time.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
             try:
-                run = self._api.get_inference(
-                    inference_run_id=str(inference_run_id),
-                    session_id=session_id,
-                )
+                box["run"] = self._api.get_inference(
+                    inference_run_id=str(inference_run_id), session_id=session_id)
             except Exception as exc:
-                return self._soft_failure(
-                    code="training_module_poll_failed",
-                    message=str(exc),
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
+                raise _PollAbort(self._soft_failure(
+                    code="training_module_poll_failed", message=str(exc),
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
+            return box["run"]
 
-        return self._terminal_tool_result(run)
+        try:
+            final = wait_for(
+                poll,
+                is_terminal=lambda r: r.get("status") not in ACTIVE_STATUSES,
+                timeout=self._timeout(timeout_seconds),
+                interval=self._poll_interval(poll_interval_seconds),
+                initial=run,
+            )
+        except WaitTimeout as timed_out:
+            return self._timeout_failure(timed_out.last_state, timeout_seconds)
+        except _PollAbort as aborted:
+            return aborted.failure
+        return self._terminal_tool_result(final)
 
     async def _apoll_to_tool_result(
         self,
@@ -395,37 +410,40 @@ class TrainingModulesResource:
         timeout_seconds: Optional[float],
         poll_interval_seconds: Optional[float],
     ) -> Any:
-        deadline = time.monotonic() + self._timeout(timeout_seconds)
-        interval = self._poll_interval(poll_interval_seconds)
+        box = {"run": run}
 
-        while run.get("status") in ACTIVE_STATUSES:
-            if time.monotonic() >= deadline:
-                return self._timeout_failure(run, timeout_seconds)
-            inference_run_id = run.get("inference_run_id")
+        async def poll() -> Dict[str, Any]:
+            current = box["run"]
+            inference_run_id = current.get("inference_run_id")
             if not inference_run_id:
-                return self._soft_failure(
+                raise _PollAbort(self._soft_failure(
                     code="training_module_malformed_response",
                     message="Training Module inference response did not include inference_run_id.",
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
-            await asyncio.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
             try:
-                run = await self._api.aget_inference(
-                    inference_run_id=str(inference_run_id),
-                    session_id=session_id,
-                )
+                box["run"] = await self._api.aget_inference(
+                    inference_run_id=str(inference_run_id), session_id=session_id)
             except Exception as exc:
-                return self._soft_failure(
-                    code="training_module_poll_failed",
-                    message=str(exc),
-                    run=run,
-                    session_id=session_id,
-                    tool_name=run.get("tool_name"),
-                )
+                raise _PollAbort(self._soft_failure(
+                    code="training_module_poll_failed", message=str(exc),
+                    run=current, session_id=session_id, tool_name=current.get("tool_name"),
+                ))
+            return box["run"]
 
-        return self._terminal_tool_result(run)
+        try:
+            final = await await_for(
+                poll,
+                is_terminal=lambda r: r.get("status") not in ACTIVE_STATUSES,
+                timeout=self._timeout(timeout_seconds),
+                interval=self._poll_interval(poll_interval_seconds),
+                initial=run,
+            )
+        except WaitTimeout as timed_out:
+            return self._timeout_failure(timed_out.last_state, timeout_seconds)
+        except _PollAbort as aborted:
+            return aborted.failure
+        return self._terminal_tool_result(final)
 
     def _terminal_tool_result(self, run: Dict[str, Any]) -> Any:
         status = run.get("status")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="lucidicai",
-    version="3.7.2",
+    version="4.0.0",
     packages=find_packages(),
     install_requires=[
         "requests>=2.25.1",

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures for transport-layer tests (tests/api/).
+
+Build a hermetic ``HttpClient`` against a stub URL with configs constructed
+directly (never ``from_env`` — that honors ``LUCIDIC_DEBUG`` and would
+silently redirect to localhost). ``backoff_factor`` is tiny and retry sleeps
+are patched out in the retry tests, so nothing here actually waits.
+"""
+import pytest
+
+from lucidicai.api.client import HttpClient
+from lucidicai.core.config import NetworkConfig, SDKConfig
+
+BASE_URL = "https://stub.lucidic.test"
+
+
+@pytest.fixture
+def base_url() -> str:
+    return BASE_URL
+
+
+@pytest.fixture
+def http() -> HttpClient:
+    config = SDKConfig(
+        api_key="test-key",
+        agent_id="00000000-0000-0000-0000-000000000000",
+        network=NetworkConfig(base_url=BASE_URL, max_retries=3, backoff_factor=0.01),
+    )
+    return HttpClient(config=config)

--- a/tests/api/resources/test_agents.py
+++ b/tests/api/resources/test_agents.py
@@ -1,0 +1,159 @@
+"""LUC-906 — client.agents reads (list / get / tool_catalog).
+
+Uses the hermetic ``http`` fixture from tests/api/conftest.py (stub URL,
+retry sleeps irrelevant here). Backend mocked at the HTTP boundary via respx.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.agent import Agent, AgentToolCatalog, CatalogTool
+from lucidicai.api.resources.agents import AgentsResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_AGENTS = f"{_BASE}/sdk/v2/agents"
+
+
+@pytest.fixture
+def agents(http):
+    return AgentsResource(http)
+
+
+def _agent(i, **over):
+    d = {
+        "agent_id": f"a{i}",
+        "name": f"agent-{i}",
+        "icon": "compass",
+        "project_id": None,
+        "created_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+class TestGet:
+    @respx.mock
+    def test_returns_typed_agent(self, agents):
+        respx.get(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = agents.get("a1")
+        assert isinstance(a, Agent)
+        assert a.agent_id == "a1"
+        assert a.name == "agent-1"
+        assert a.icon == "compass"
+
+    @respx.mock
+    def test_404_raises_not_found(self, agents):
+        respx.get(f"{_AGENTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            agents.get("missing")
+
+    @respx.mock
+    def test_tolerates_unknown_fields(self, agents):
+        respx.get(f"{_AGENTS}/a1").mock(
+            return_value=httpx.Response(200, json=_agent(1, future_field="x")))
+        a = agents.get("a1")
+        assert a.extra == {"future_field": "x"}
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages(self, agents):
+        respx.get(_AGENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_agent(1), _agent(2)],
+                                      "next": f"{_AGENTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_agent(3)], "next": None, "previous": None}),
+        ])
+        got = list(agents.list())
+        assert [a.agent_id for a in got] == ["a1", "a2", "a3"]
+        assert all(isinstance(a, Agent) for a in got)
+
+    @respx.mock
+    def test_forwards_ordering_and_page_size(self, agents):
+        route = respx.get(_AGENTS).mock(
+            return_value=httpx.Response(200, json={"results": [_agent(1)], "next": None}))
+        list(agents.list(ordering="id", page_size=10))
+        sent = route.calls.last.request
+        assert sent.url.params["ordering"] == "id"
+        assert sent.url.params["page_size"] == "10"
+
+    @respx.mock
+    def test_list_page_returns_cursor_page(self, agents):
+        respx.get(_AGENTS).mock(return_value=httpx.Response(
+            200, json={"results": [_agent(1)], "next": f"{_AGENTS}?cursor=c9", "previous": None}))
+        page = agents.list_page()
+        assert len(page.results) == 1 and isinstance(page.results[0], Agent)
+        assert page.next_cursor == "c9" and page.has_next
+
+
+class TestToolCatalog:
+    @respx.mock
+    def test_typed_catalog_with_typed_tools(self, agents):
+        catalog = {
+            "agent_id": "a1",
+            "agent_name": "agent-1",
+            "tools": [{
+                "tool_id": "t1", "name": "query_sql", "tier": "SQL_TEMPLATE",
+                "call_count": 5, "last_called_at": "2026-07-22T00:00:00Z",
+                "has_drift": False,
+                "resources": [{"resource_id": "r1", "name": "db", "type": "SQL"}],
+            }],
+            "resources": [{"resource_id": "r1", "name": "db", "type": "SQL",
+                           "tool_names": ["query_sql"]}],
+        }
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(
+            return_value=httpx.Response(200, json=catalog))
+        result = agents.tool_catalog("a1")
+        assert isinstance(result, AgentToolCatalog)
+        assert result.agent_name == "agent-1"
+        assert len(result.tools) == 1
+        assert isinstance(result.tools[0], CatalogTool)
+        assert result.tools[0].call_count == 5
+        assert result.tools[0].name == "query_sql"
+        # The aux resource union stays as raw dicts.
+        assert result.resources[0]["resource_id"] == "r1"
+
+    @respx.mock
+    def test_empty_catalog(self, agents):
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(return_value=httpx.Response(
+            200, json={"agent_id": "a1", "agent_name": "n", "tools": [], "resources": []}))
+        result = agents.tool_catalog("a1")
+        assert result.tools == [] and result.resources == []
+
+    @respx.mock
+    def test_null_tools_and_resources_become_empty(self, agents):
+        # Backend `null` (not []) for the nested lists must not crash or leave
+        # None — the reference nested-conversion + central null-normalization
+        # both turn it into [].
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(return_value=httpx.Response(
+            200, json={"agent_id": "a1", "agent_name": "n", "tools": None, "resources": None}))
+        result = agents.tool_catalog("a1")
+        assert result.tools == [] and result.resources == []
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, agents):
+        respx.get(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = await agents.aget("a1")
+        assert a.agent_id == "a1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist_follows_pages(self, agents):
+        respx.get(_AGENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_agent(1)], "next": f"{_AGENTS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_agent(2)], "next": None}),
+        ])
+        got = [a.agent_id async for a in agents.alist()]
+        assert got == ["a1", "a2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_atool_catalog(self, agents):
+        respx.get(f"{_AGENTS}/a1/tool-catalog").mock(return_value=httpx.Response(
+            200, json={"agent_id": "a1", "agent_name": "n", "tools": [], "resources": []}))
+        c = await agents.atool_catalog("a1")
+        assert c.agent_id == "a1" and c.tools == []

--- a/tests/api/resources/test_agents.py
+++ b/tests/api/resources/test_agents.py
@@ -1,15 +1,17 @@
-"""LUC-906 — client.agents reads (list / get / tool_catalog).
+"""LUC-906 / LUC-912 — client.agents reads + writes.
 
 Uses the hermetic ``http`` fixture from tests/api/conftest.py (stub URL,
 retry sleeps irrelevant here). Backend mocked at the HTTP boundary via respx.
 """
+import json
+
 import httpx
 import pytest
 import respx
 
 from lucidicai.api.models.agent import Agent, AgentToolCatalog, CatalogTool
 from lucidicai.api.resources.agents import AgentsResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
 
 _BASE = "https://stub.lucidic.test"
 _AGENTS = f"{_BASE}/sdk/v2/agents"
@@ -157,3 +159,70 @@ class TestAsync:
             200, json={"agent_id": "a1", "agent_name": "n", "tools": [], "resources": []}))
         c = await agents.atool_catalog("a1")
         assert c.agent_id == "a1" and c.tools == []
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_omits_unset_optionals(self, agents):
+        route = respx.post(_AGENTS).mock(return_value=httpx.Response(201, json=_agent(1)))
+        a = agents.create("agent-1")
+        assert isinstance(a, Agent) and a.agent_id == "a1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "agent-1"
+        assert "icon" not in body            # omitted -> backend defaults ("compass")
+        assert "project_id" not in body
+
+    @respx.mock
+    def test_with_icon_and_project(self, agents):
+        route = respx.post(_AGENTS).mock(return_value=httpx.Response(201, json=_agent(1)))
+        agents.create("a", icon="rocket", project_id="p1")
+        body = json.loads(route.calls.last.request.read())
+        assert body["icon"] == "rocket" and body["project_id"] == "p1"
+
+    @respx.mock
+    def test_bound_key_403_is_insufficient_scope(self, agents):
+        respx.post(_AGENTS).mock(return_value=httpx.Response(
+            403, json={"error": "An agent-bound API key cannot create new agents."}))
+        with pytest.raises(InsufficientScopeError):
+            agents.create("x")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_sends_only_provided_fields(self, agents):
+        route = respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = agents.update("a1", name="renamed")
+        assert isinstance(a, Agent)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed"
+        assert "icon" not in body and "project_id" not in body
+
+    @respx.mock
+    def test_all_fields(self, agents):
+        route = respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        agents.update("a1", name="n", icon="i", project_id="p1")
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "n" and body["icon"] == "i" and body["project_id"] == "p1"
+
+    @respx.mock
+    def test_over_length_400_is_validation_error(self, agents):
+        respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(
+            400, json={"error": "A field exceeds its maximum length."}))
+        with pytest.raises(ValidationError):
+            agents.update("a1", name="x" * 999)
+
+
+class TestAsyncWrite:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, agents):
+        respx.post(_AGENTS).mock(return_value=httpx.Response(201, json=_agent(1)))
+        a = await agents.acreate("agent-1")
+        assert a.agent_id == "a1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, agents):
+        respx.put(f"{_AGENTS}/a1").mock(return_value=httpx.Response(200, json=_agent(1)))
+        a = await agents.aupdate("a1", icon="star")
+        assert a.agent_id == "a1"

--- a/tests/api/resources/test_datasets_v2.py
+++ b/tests/api/resources/test_datasets_v2.py
@@ -1,0 +1,236 @@
+"""LUC-918 — client.datasets v2: items + schemas (CRUD) + fixtures.create."""
+import json
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.dataset import DatasetItem, DatasetSchema, Fixture
+from lucidicai.api.resources.dataset import (
+    DatasetResource,
+    DatasetFixturesResource,
+    DatasetSchemasResource,
+)
+from lucidicai.core.errors import ConflictError, NotFoundError, ValidationError
+
+_BASE = "https://stub.lucidic.test"
+_SCHEMAS = f"{_BASE}/sdk/v2/datasets/schemas"
+_FIXTURES = f"{_BASE}/sdk/v2/fixtures"
+
+
+def _items_url(dataset_id):
+    return f"{_BASE}/sdk/v2/datasets/{dataset_id}/items"
+
+
+@pytest.fixture
+def datasets(http):
+    return DatasetResource(http, agent_id="a1", production=False)
+
+
+def _schema(i, **over):
+    d = {
+        "schema_id": f"s{i}", "name": f"schema-{i}", "description": "",
+        "fields": [{"key": "q", "type": "string"}],
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+def _item(i, **over):
+    d = {
+        "datasetitem_id": f"it{i}", "name": f"item-{i}", "description": "",
+        "tags": [], "input": {"q": "hi"}, "expected_output": "ok",
+        "metadata": {}, "flag_overrides": None, "created_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+def _fixture(**over):
+    d = {"fixture_id": "f1", "blob_key": "tenant=o/dataset=d/fixture=f1/data.duckdb",
+         "byte_size": 2048, "status": "COMPLETED"}
+    d.update(over)
+    return d
+
+
+class TestWiring:
+    def test_subnamespaces_resolve(self, datasets):
+        assert isinstance(datasets.schemas, DatasetSchemasResource)
+        assert isinstance(datasets.fixtures, DatasetFixturesResource)
+
+
+class TestItems:
+    @respx.mock
+    def test_follows_pages_typed(self, datasets):
+        url = _items_url("d1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_item(1), _item(2)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_item(3)], "next": None}),
+        ])
+        got = list(datasets.items("d1"))
+        assert [i.datasetitem_id for i in got] == ["it1", "it2", "it3"]
+        assert all(isinstance(i, DatasetItem) for i in got)
+        assert got[0].input == {"q": "hi"} and got[0].expected_output == "ok"
+
+    @respx.mock
+    def test_items_page_size(self, datasets):
+        route = respx.get(_items_url("d1")).mock(
+            return_value=httpx.Response(200, json={"results": [_item(1)], "next": None}))
+        page = datasets.items_page("d1", page_size=25)
+        assert isinstance(page.results[0], DatasetItem)
+        assert route.calls.last.request.url.params["page_size"] == "25"
+
+    @respx.mock
+    def test_items_404(self, datasets):
+        respx.get(_items_url("missing")).mock(
+            return_value=httpx.Response(404, json={"error": "Specified Dataset not found"}))
+        with pytest.raises(NotFoundError):
+            list(datasets.items("missing"))
+
+
+class TestSchemas:
+    @respx.mock
+    def test_list_typed_org_scoped(self, datasets):
+        route = respx.get(_SCHEMAS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_schema(1), _schema(2)], "next": f"{_SCHEMAS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_schema(3)], "next": None}),
+        ])
+        got = list(datasets.schemas.list(ordering="id"))
+        assert [s.schema_id for s in got] == ["s1", "s2", "s3"]
+        assert all(isinstance(s, DatasetSchema) for s in got)
+        p = route.calls[0].request.url.params
+        assert "agent_id" not in p and p["ordering"] == "id"
+
+    @respx.mock
+    def test_get(self, datasets):
+        respx.get(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(200, json=_schema(1)))
+        s = datasets.schemas.get("s1")
+        assert isinstance(s, DatasetSchema) and s.fields == [{"key": "q", "type": "string"}]
+
+    @respx.mock
+    def test_create(self, datasets):
+        route = respx.post(_SCHEMAS).mock(return_value=httpx.Response(201, json=_schema(1)))
+        fields = [{"key": "question", "type": "string"}]
+        s = datasets.schemas.create("qa-schema", fields=fields)
+        assert isinstance(s, DatasetSchema) and s.schema_id == "s1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "qa-schema" and body["fields"] == fields
+        assert "description" not in body  # omit-None
+
+    @respx.mock
+    def test_create_with_description(self, datasets):
+        route = respx.post(_SCHEMAS).mock(return_value=httpx.Response(201, json=_schema(1)))
+        datasets.schemas.create("s", fields=[{"key": "q", "type": "string"}], description="d")
+        assert json.loads(route.calls.last.request.read())["description"] == "d"
+
+    @respx.mock
+    def test_create_duplicate_409(self, datasets):
+        respx.post(_SCHEMAS).mock(return_value=httpx.Response(
+            409, json={"error": "A schema named 's' already exists for this org."}))
+        with pytest.raises(ConflictError):
+            datasets.schemas.create("s", fields=[{"key": "q", "type": "string"}])
+
+    @respx.mock
+    def test_create_bad_field_400(self, datasets):
+        respx.post(_SCHEMAS).mock(return_value=httpx.Response(
+            400, json={"error": "Validation failed", "details": {"fields": ["categorical needs options"]}}))
+        with pytest.raises(ValidationError):
+            datasets.schemas.create("s", fields=[{"key": "c", "type": "categorical"}])
+
+    @respx.mock
+    def test_update_partial(self, datasets):
+        route = respx.put(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(200, json=_schema(1)))
+        s = datasets.schemas.update("s1", name="renamed")
+        assert isinstance(s, DatasetSchema)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed" and "fields" not in body and "description" not in body
+
+    @respx.mock
+    def test_update_rename_collision_409(self, datasets):
+        respx.put(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(
+            409, json={"error": "A schema with this name already exists for this org."}))
+        with pytest.raises(ConflictError):
+            datasets.schemas.update("s1", name="taken")
+
+    @respx.mock
+    def test_delete_204(self, datasets):
+        route = respx.delete(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(204))
+        assert datasets.schemas.delete("s1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_404(self, datasets):
+        respx.delete(f"{_SCHEMAS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified DatasetSchema not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.schemas.delete("missing")
+
+
+class TestFixtures:
+    @respx.mock
+    def test_create(self, datasets):
+        route = respx.post(_FIXTURES).mock(return_value=httpx.Response(201, json=_fixture()))
+        tables = [{"name": "users", "rows": [{"id": 1, "name": "a"}]}]
+        f = datasets.fixtures.create(resource_id="r1", dataset_id="d1", tables=tables)
+        assert isinstance(f, Fixture) and f.fixture_id == "f1"
+        assert f.status == "COMPLETED" and f.byte_size == 2048
+        body = json.loads(route.calls.last.request.read())
+        assert body["resource_id"] == "r1" and body["dataset_id"] == "d1"
+        assert body["tables"] == tables
+
+    @respx.mock
+    def test_create_duplicate_409(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(
+            409, json={"error": "A fixture already exists for this dataset and resource."}))
+        with pytest.raises(ConflictError):
+            datasets.fixtures.create(resource_id="r1", dataset_id="d1", tables=[])
+
+    @respx.mock
+    def test_create_validation_400(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(
+            400, json={"error": "Fixture validation failed", "details": {"users": ["unknown column"]}}))
+        with pytest.raises(ValidationError):
+            datasets.fixtures.create(resource_id="r1", dataset_id="d1",
+                                     tables=[{"name": "users", "rows": [{"bad": 1}]}])
+
+    @respx.mock
+    def test_create_unknown_resource_404(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(
+            404, json={"error": "Specified Resource not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.fixtures.create(resource_id="missing", dataset_id="d1", tables=[])
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aitems(self, datasets):
+        url = _items_url("d1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_item(1)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_item(2)], "next": None}),
+        ])
+        got = [i.datasetitem_id async for i in datasets.aitems("d1")]
+        assert got == ["it1", "it2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aschema_create(self, datasets):
+        respx.post(_SCHEMAS).mock(return_value=httpx.Response(201, json=_schema(1)))
+        s = await datasets.schemas.acreate("s", fields=[{"key": "q", "type": "string"}])
+        assert s.schema_id == "s1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aschema_delete(self, datasets):
+        route = respx.delete(f"{_SCHEMAS}/s1").mock(return_value=httpx.Response(204))
+        assert await datasets.schemas.adelete("s1") is None
+        assert route.called
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afixture_create(self, datasets):
+        respx.post(_FIXTURES).mock(return_value=httpx.Response(201, json=_fixture()))
+        f = await datasets.fixtures.acreate(resource_id="r1", dataset_id="d1", tables=[])
+        assert f.fixture_id == "f1"

--- a/tests/api/resources/test_datasets_v2.py
+++ b/tests/api/resources/test_datasets_v2.py
@@ -5,17 +5,40 @@ import httpx
 import pytest
 import respx
 
-from lucidicai.api.models.dataset import DatasetItem, DatasetSchema, Fixture
+from lucidicai.api.models.dataset import (
+    DatasetGenerationRun,
+    DatasetItem,
+    DatasetSchema,
+    Fixture,
+)
 from lucidicai.api.resources.dataset import (
     DatasetResource,
     DatasetFixturesResource,
     DatasetSchemasResource,
 )
-from lucidicai.core.errors import ConflictError, NotFoundError, ValidationError
+from lucidicai.core.errors import (
+    ConflictError,
+    NotFoundError,
+    ServiceUnavailableError,
+    ValidationError,
+    WaitTimeout,
+)
 
 _BASE = "https://stub.lucidic.test"
 _SCHEMAS = f"{_BASE}/sdk/v2/datasets/schemas"
 _FIXTURES = f"{_BASE}/sdk/v2/fixtures"
+_GENERATE = f"{_BASE}/sdk/v2/datasets/generate"
+
+
+def _status_url(run_id):
+    return f"{_GENERATE}/{run_id}/status"
+
+
+def _gen_run(**over):
+    d = {"run_id": "run1", "dataset_id": "ds1", "status": "queued",
+         "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
 
 
 def _items_url(dataset_id):
@@ -234,3 +257,159 @@ class TestAsync:
         respx.post(_FIXTURES).mock(return_value=httpx.Response(201, json=_fixture()))
         f = await datasets.fixtures.acreate(resource_id="r1", dataset_id="d1", tables=[])
         assert f.fixture_id == "f1"
+
+
+# ==================== LUC-921 generation ====================
+
+
+class TestGenerationModel:
+    def test_terminal_and_succeeded_flags(self):
+        assert DatasetGenerationRun.from_dict(_gen_run(status="queued")).is_terminal is False
+        assert DatasetGenerationRun.from_dict(_gen_run(status="generating")).is_terminal is False
+        done = DatasetGenerationRun.from_dict(_gen_run(status="completed"))
+        assert done.is_terminal is True and done.succeeded is True
+        failed = DatasetGenerationRun.from_dict(_gen_run(status="failed", error_message="boom"))
+        assert failed.is_terminal is True and failed.succeeded is False
+        assert failed.error_message == "boom"
+
+
+class TestGenerate:
+    @respx.mock
+    def test_generate_required_fields_and_omit_none(self, datasets):
+        route = respx.post(_GENERATE).mock(return_value=httpx.Response(201, json=_gen_run()))
+        run = datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1",
+                                dataset_name="gen-1")
+        assert isinstance(run, DatasetGenerationRun)
+        assert run.run_id == "run1" and run.dataset_id == "ds1" and run.status == "queued"
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1" and body["experiment_id"] == "e1"
+        assert body["schema_id"] == "s1" and body["dataset_name"] == "gen-1"
+        # omit-None: unspecified optionals defer to the backend defaults
+        assert not any(k in body for k in
+                       ("dataset_description", "target_count", "combo_cap",
+                        "selected_dimension_ids", "resource_ids"))
+
+    @respx.mock
+    def test_generate_all_options(self, datasets):
+        route = respx.post(_GENERATE).mock(return_value=httpx.Response(201, json=_gen_run()))
+        datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1", dataset_name="g",
+                          dataset_description="d", target_count=100, combo_cap=20,
+                          selected_dimension_ids=["dim1"], resource_ids=["r1"])
+        body = json.loads(route.calls.last.request.read())
+        assert body["target_count"] == 100 and body["combo_cap"] == 20
+        assert body["selected_dimension_ids"] == ["dim1"] and body["resource_ids"] == ["r1"]
+        assert body["dataset_description"] == "d"
+
+    @respx.mock
+    def test_generate_503_service_unavailable(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1", dataset_name="g")
+
+    @respx.mock
+    def test_generate_no_taxonomy_400(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(
+            400, json={"error": "Experiment has no completed taxonomy run"}))
+        with pytest.raises(ValidationError):
+            datasets.generate(agent_id="a1", experiment_id="e1", schema_id="s1", dataset_name="g")
+
+    @respx.mock
+    def test_generate_unknown_agent_404(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(
+            404, json={"error": "Specified Agent not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.generate(agent_id="missing", experiment_id="e1", schema_id="s1", dataset_name="g")
+
+
+class TestGenerationStatus:
+    @respx.mock
+    def test_status_full_shape(self, datasets):
+        respx.get(_status_url("run1")).mock(return_value=httpx.Response(200, json=_gen_run(
+            status="generating", items_generated=12, total_target=50, dataset_name="g",
+            experiment_id="e1", schema_id="s1", config={"target_count": 50})))
+        run = datasets.generation_status("run1")
+        assert run.status == "generating" and run.items_generated == 12 and run.total_target == 50
+        assert run.is_terminal is False and run.config == {"target_count": 50}
+
+    @respx.mock
+    def test_status_404(self, datasets):
+        respx.get(_status_url("missing")).mock(return_value=httpx.Response(
+            404, json={"error": "Specified DatasetGenerationRun not found"}))
+        with pytest.raises(NotFoundError):
+            datasets.generation_status("missing")
+
+
+class TestRetryGeneration:
+    @respx.mock
+    def test_retry_returns_new_run(self, datasets):
+        route = respx.post(f"{_GENERATE}/run1/retry").mock(
+            return_value=httpx.Response(201, json=_gen_run(run_id="run2", dataset_id="ds2")))
+        run = datasets.retry_generation("run1")
+        assert run.run_id == "run2" and run.dataset_id == "ds2"
+        assert route.called
+
+    @respx.mock
+    def test_retry_non_failed_400(self, datasets):
+        respx.post(f"{_GENERATE}/run1/retry").mock(return_value=httpx.Response(
+            400, json={"error": "Only failed runs can be retried"}))
+        with pytest.raises(ValidationError):
+            datasets.retry_generation("run1")
+
+
+class TestWaitForGeneration:
+    @respx.mock
+    def test_polls_until_completed(self, datasets):
+        respx.get(_status_url("run1")).mock(side_effect=[
+            httpx.Response(200, json=_gen_run(status="queued")),
+            httpx.Response(200, json=_gen_run(status="generating", items_generated=5)),
+            httpx.Response(200, json=_gen_run(status="completed", items_generated=50)),
+        ])
+        run = datasets.wait_for_generation("run1", timeout=30, interval=0)
+        assert run.succeeded is True and run.status == "completed" and run.items_generated == 50
+
+    @respx.mock
+    def test_failed_run_is_returned_not_raised(self, datasets):
+        respx.get(_status_url("run1")).mock(side_effect=[
+            httpx.Response(200, json=_gen_run(status="generating")),
+            httpx.Response(200, json=_gen_run(status="failed", error_message="llm error")),
+        ])
+        run = datasets.wait_for_generation("run1", timeout=30, interval=0)
+        assert run.is_terminal is True and run.succeeded is False
+        assert run.error_message == "llm error"
+
+    @respx.mock
+    def test_timeout_raises_wait_timeout(self, datasets):
+        respx.get(_status_url("run1")).mock(
+            return_value=httpx.Response(200, json=_gen_run(status="generating")))
+        with pytest.raises(WaitTimeout) as exc:
+            datasets.wait_for_generation("run1", timeout=0, interval=0)
+        assert exc.value.last_state.status == "generating"
+
+
+class TestGenerationAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_agenerate(self, datasets):
+        respx.post(_GENERATE).mock(return_value=httpx.Response(201, json=_gen_run()))
+        run = await datasets.agenerate(agent_id="a1", experiment_id="e1", schema_id="s1",
+                                       dataset_name="g")
+        assert run.run_id == "run1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ageneration_status(self, datasets):
+        respx.get(_status_url("run1")).mock(return_value=httpx.Response(
+            200, json=_gen_run(status="completed")))
+        run = await datasets.ageneration_status("run1")
+        assert run.succeeded is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_await_for_generation(self, datasets):
+        respx.get(_status_url("run1")).mock(side_effect=[
+            httpx.Response(200, json=_gen_run(status="generating")),
+            httpx.Response(200, json=_gen_run(status="completed")),
+        ])
+        run = await datasets.await_for_generation("run1", timeout=30, interval=0)
+        assert run.succeeded is True

--- a/tests/api/resources/test_evaluator_results_v2.py
+++ b/tests/api/resources/test_evaluator_results_v2.py
@@ -1,0 +1,47 @@
+"""LUC-910 — client.evaluator_results.get (single evaluator result by id)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.session import EvalResult
+from lucidicai.api.resources.evaluator_results import EvaluatorResultsResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_EVAL_RESULTS = f"{_BASE}/sdk/v2/evaluator-results"
+
+
+@pytest.fixture
+def results(http):
+    return EvaluatorResultsResource(http)
+
+
+def _result(i, **over):
+    d = {"eval_id": f"r{i}", "evaluator_name": "eval-1", "result": True,
+         "result_type": "boolean", "is_pending": False}
+    d.update(over)
+    return d
+
+
+class TestGet:
+    @respx.mock
+    def test_single_result_typed(self, results):
+        respx.get(f"{_EVAL_RESULTS}/r1").mock(return_value=httpx.Response(
+            200, json=_result(1, result=0.9, result_type="number")))
+        r = results.get("r1")
+        assert isinstance(r, EvalResult)
+        assert r.eval_id == "r1" and r.result == 0.9
+
+    @respx.mock
+    def test_404_raises(self, results):
+        respx.get(f"{_EVAL_RESULTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            results.get("missing")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, results):
+        respx.get(f"{_EVAL_RESULTS}/r1").mock(return_value=httpx.Response(200, json=_result(1)))
+        r = await results.aget("r1")
+        assert r.eval_id == "r1"

--- a/tests/api/resources/test_evaluators_v2.py
+++ b/tests/api/resources/test_evaluators_v2.py
@@ -88,14 +88,13 @@ class TestEvalsDistribution:
 
 
 class TestAgentIdGuard:
-    @respx.mock
-    def test_list_omits_agent_id_when_none(self, http):
-        # No configured agent + none passed -> agent_id is omitted (not sent as
-        # an empty string), matching the sibling-resource convention.
-        route = respx.get(_EVALUATORS).mock(
-            return_value=httpx.Response(200, json={"results": [], "next": None}))
-        list(EvaluatorsResource(http, agent_id=None).list())
-        assert "agent_id" not in route.calls.last.request.url.params
+    def test_list_without_agent_id_raises(self, http):
+        # No configured agent + none passed -> a clear AgentIdRequiredError
+        # (raised eagerly at the .list() call, before any HTTP), not a backend
+        # 400 or an empty-string param (LUC-926).
+        from lucidicai.core.errors import AgentIdRequiredError
+        with pytest.raises(AgentIdRequiredError):
+            EvaluatorsResource(http, agent_id=None).list()
 
 
 class TestAsync:

--- a/tests/api/resources/test_evaluators_v2.py
+++ b/tests/api/resources/test_evaluators_v2.py
@@ -1,4 +1,7 @@
-"""LUC-910 — client.evaluators reads (list / get / evals / result)."""
+"""LUC-910 — client.evaluators reads (list / get / evals / result).
+LUC-916 — client.evaluators writes (create LLM / update / delete)."""
+import json
+
 import httpx
 import pytest
 import respx
@@ -6,7 +9,15 @@ import respx
 from lucidicai.api.models.evaluator import Evaluator
 from lucidicai.api.models.session import EvalResult
 from lucidicai.api.resources.evaluators import EvaluatorsResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import (
+    ConflictError,
+    InvalidOperationError,
+    NotFoundError,
+    ValidationError,
+)
+
+# A valid pass/fail criterion (boolean result_type).
+_CRIT = [{"name": "accurate", "pass_definition": "correct", "fail_definition": "wrong"}]
 
 _BASE = "https://stub.lucidic.test"
 _EVALUATORS = f"{_BASE}/sdk/v2/evaluators"
@@ -115,4 +126,158 @@ class TestAsync:
             200, json={"results": [_result(1)], "next": None}))
         got = [r.eval_id async for r in evaluators.aevals("e1")]
         assert got == ["r1"]
+
+
+# ==================== LUC-916 writes ====================
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_llm_boolean(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        e = evaluators.create("eval-1", criteria=_CRIT, result_type="boolean")
+        assert isinstance(e, Evaluator) and e.evaluator_id == "e1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1"  # defaulted from configured agent
+        assert body["name"] == "eval-1" and body["result_type"] == "boolean"
+        assert body["criteria"] == _CRIT and body["is_default"] is False
+        # omit-None: unspecified optionals aren't sent (backend defaults icon=compass)
+        assert "description" not in body and "icon" not in body
+        # the SDK never sends a type / rubric_json — the backend hardcodes LLM + builds the rubric
+        assert "type" not in body and "rubric_json" not in body
+
+    @respx.mock
+    def test_create_with_description_icon_default(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        evaluators.create("eval-1", criteria=_CRIT, result_type="boolean",
+                          description="d", icon="wave", is_default=True)
+        body = json.loads(route.calls.last.request.read())
+        assert body["description"] == "d" and body["icon"] == "wave" and body["is_default"] is True
+
+    @respx.mock
+    def test_create_rejects_code_type_before_http(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        # A LucidicError subclass (not a bare ValueError) so `except LucidicError` catches it.
+        with pytest.raises(InvalidOperationError):
+            evaluators.create("eval-1", criteria=_CRIT, result_type="boolean", type="code")
+        assert not route.called  # rejected client-side, no request made
+
+    @respx.mock
+    def test_create_rejects_non_string_type_cleanly(self, evaluators):
+        # A non-string type must raise the clear guard error, not an opaque AttributeError.
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        with pytest.raises(InvalidOperationError):
+            evaluators.create("eval-1", criteria=_CRIT, result_type="boolean", type=123)
+        assert not route.called
+
+    @respx.mock
+    def test_create_accepts_padded_llm(self, evaluators):
+        # Whitespace/case around a genuine "llm" is normalized, not rejected.
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        assert evaluators.create("eval-1", criteria=_CRIT, result_type="boolean",
+                                 type="  LLM  ").evaluator_id == "e1"
+
+    @respx.mock
+    def test_create_duplicate_409(self, evaluators):
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(
+            409, json={"error": "An evaluator named 'eval-1' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            evaluators.create("eval-1", criteria=_CRIT, result_type="boolean")
+
+    @respx.mock
+    def test_create_bad_criteria_400(self, evaluators):
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(
+            400, json={"error": "Validation failed", "details": {"criteria": ["missing pass_definition"]}}))
+        with pytest.raises(ValidationError):
+            evaluators.create("eval-1", criteria=[{"name": "x"}], result_type="boolean")
+
+    def test_create_without_agent_id_raises(self, http):
+        from lucidicai.core.errors import AgentIdRequiredError
+        res = EvaluatorsResource(http, agent_id=None)
+        with pytest.raises(AgentIdRequiredError):
+            res.create("eval-1", criteria=_CRIT, result_type="boolean")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_update_partial_name_only(self, evaluators):
+        route = respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(
+            200, json=_evaluator(1, name="renamed")))
+        e = evaluators.update("e1", name="renamed")
+        assert isinstance(e, Evaluator) and e.name == "renamed"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed"
+        # partial update — only the provided field is sent
+        assert all(k not in body for k in
+                   ("description", "icon", "is_default", "criteria", "result_type", "config"))
+
+    @respx.mock
+    def test_update_criteria_and_code_config(self, evaluators):
+        route = respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(200, json=_evaluator(1)))
+        evaluators.update("e1", criteria=_CRIT, is_default=True, config={"user_code": "return 1"})
+        body = json.loads(route.calls.last.request.read())
+        assert body["criteria"] == _CRIT and body["is_default"] is True
+        assert body["config"] == {"user_code": "return 1"}
+        assert "name" not in body
+
+    @respx.mock
+    def test_update_rename_collision_409(self, evaluators):
+        respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(
+            409, json={"error": "An evaluator named 'taken' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            evaluators.update("e1", name="taken")
+
+    @respx.mock
+    def test_update_with_no_fields_raises_before_http(self, evaluators):
+        # An all-None update would be an empty no-op write — surface the mistake.
+        route = respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(200, json=_evaluator(1)))
+        with pytest.raises(InvalidOperationError):
+            evaluators.update("e1")
+        assert not route.called
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_204(self, evaluators):
+        route = respx.delete(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(204))
+        assert evaluators.delete("e1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_404(self, evaluators):
+        respx.delete(f"{_EVALUATORS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified Evaluator not found"}))
+        with pytest.raises(NotFoundError):
+            evaluators.delete("missing")
+
+
+class TestWriteAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, evaluators):
+        respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        e = await evaluators.acreate("eval-1", criteria=_CRIT, result_type="boolean")
+        assert e.evaluator_id == "e1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate_rejects_code_case_insensitive(self, evaluators):
+        route = respx.post(_EVALUATORS).mock(return_value=httpx.Response(201, json=_evaluator(1)))
+        with pytest.raises(InvalidOperationError):
+            await evaluators.acreate("eval-1", criteria=_CRIT, result_type="boolean", type="CODE")
+        assert not route.called
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, evaluators):
+        respx.put(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(200, json=_evaluator(1)))
+        e = await evaluators.aupdate("e1", description="d")
+        assert e.evaluator_id == "e1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, evaluators):
+        route = respx.delete(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(204))
+        assert await evaluators.adelete("e1") is None
+        assert route.called
 

--- a/tests/api/resources/test_evaluators_v2.py
+++ b/tests/api/resources/test_evaluators_v2.py
@@ -1,0 +1,119 @@
+"""LUC-910 — client.evaluators reads (list / get / evals / result)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.evaluator import Evaluator
+from lucidicai.api.models.session import EvalResult
+from lucidicai.api.resources.evaluators import EvaluatorsResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_EVALUATORS = f"{_BASE}/sdk/v2/evaluators"
+
+
+@pytest.fixture
+def evaluators(http):
+    return EvaluatorsResource(http, agent_id="a1")
+
+
+def _evaluator(i, **over):
+    d = {
+        "evaluator_id": f"e{i}", "name": f"eval-{i}", "description": "", "icon": "star",
+        "type": "LLM", "result_type": "boolean", "is_default": False,
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+        "criteria": [],
+    }
+    d.update(over)
+    return d
+
+
+def _result(i, **over):
+    d = {"eval_id": f"r{i}", "evaluator_name": "eval-1", "result": True,
+         "result_type": "boolean", "is_pending": False}
+    d.update(over)
+    return d
+
+
+class TestListGet:
+    @respx.mock
+    def test_list_typed_and_defaults_agent(self, evaluators):
+        route = respx.get(_EVALUATORS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evaluator(1), _evaluator(2)],
+                                      "next": f"{_EVALUATORS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evaluator(3)], "next": None}),
+        ])
+        got = list(evaluators.list())
+        assert [e.evaluator_id for e in got] == ["e1", "e2", "e3"]
+        assert all(isinstance(e, Evaluator) for e in got)
+        assert route.calls[0].request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_get_detail(self, evaluators):
+        respx.get(f"{_EVALUATORS}/e1").mock(return_value=httpx.Response(
+            200, json=_evaluator(1, rubric_json={"q": "is it good?"}, config={"model": "gpt"})))
+        e = evaluators.get("e1")
+        assert isinstance(e, Evaluator)
+        assert e.rubric_json == {"q": "is it good?"}
+        assert e.config == {"model": "gpt"}
+
+    @respx.mock
+    def test_get_404(self, evaluators):
+        respx.get(f"{_EVALUATORS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            evaluators.get("missing")
+
+
+class TestEvalsDistribution:
+    @respx.mock
+    def test_evals_typed_and_no_agent_param(self, evaluators):
+        route = respx.get(f"{_EVALUATORS}/e1/evals").mock(side_effect=[
+            httpx.Response(200, json={"results": [_result(1), _result(2)],
+                                      "next": f"{_EVALUATORS}/e1/evals?cursor=c2"}),
+            httpx.Response(200, json={"results": [_result(3)], "next": None}),
+        ])
+        got = list(evaluators.evals("e1"))
+        assert [r.eval_id for r in got] == ["r1", "r2", "r3"]
+        assert all(isinstance(r, EvalResult) for r in got)
+        # path-keyed: no agent_id forwarded on the distribution read
+        assert "agent_id" not in route.calls[0].request.url.params
+
+    @respx.mock
+    def test_evals_page(self, evaluators):
+        respx.get(f"{_EVALUATORS}/e1/evals").mock(return_value=httpx.Response(
+            200, json={"results": [_result(1)], "next": None}))
+        page = evaluators.evals_page("e1")
+        assert isinstance(page.results[0], EvalResult)
+
+
+class TestAgentIdGuard:
+    @respx.mock
+    def test_list_omits_agent_id_when_none(self, http):
+        # No configured agent + none passed -> agent_id is omitted (not sent as
+        # an empty string), matching the sibling-resource convention.
+        route = respx.get(_EVALUATORS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(EvaluatorsResource(http, agent_id=None).list())
+        assert "agent_id" not in route.calls.last.request.url.params
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, evaluators):
+        respx.get(_EVALUATORS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evaluator(1)], "next": f"{_EVALUATORS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evaluator(2)], "next": None}),
+        ])
+        got = [e.evaluator_id async for e in evaluators.alist()]
+        assert got == ["e1", "e2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aevals(self, evaluators):
+        respx.get(f"{_EVALUATORS}/e1/evals").mock(return_value=httpx.Response(
+            200, json={"results": [_result(1)], "next": None}))
+        got = [r.eval_id async for r in evaluators.aevals("e1")]
+        assert got == ["r1"]
+

--- a/tests/api/resources/test_evosims.py
+++ b/tests/api/resources/test_evosims.py
@@ -1,0 +1,223 @@
+"""LUC-923 — client.evosims run management (list / get / cancel / iteration_instances
+/ wait_for). The gen-3 train() kickoff is covered elsewhere (agent-id guard test)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.evosim import EvoSim, EvoSimIteration, TrainingModuleInstance
+from lucidicai.api.resources.evosim import EvoSimsResource
+from lucidicai.core.errors import (
+    AgentIdRequiredError,
+    NotFoundError,
+    ServiceUnavailableError,
+    WaitTimeout,
+)
+
+_BASE = "https://stub.lucidic.test"
+_EVOSIMS = f"{_BASE}/sdk/evosims"
+
+
+@pytest.fixture
+def evosims(http):
+    return EvoSimsResource(http, agent_id="a1", production=False)
+
+
+def _evosim(i, **over):
+    d = {"evosim_id": f"es{i}", "agent_id": "a1", "experiment_id": "e1",
+         "name": f"run-{i}", "description": "", "max_iterations": 10,
+         "hard_stop_seconds_per_iteration": 1800, "max_session_concurrency": 10,
+         "webhook_url": None, "temporal_workflow_id": "wf1", "temporal_run_id": "trun1",
+         "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _iteration(**over):
+    d = {"evosimiteration_id": "it1", "evosim_id": "es1", "iteration": 1,
+         "status": "RUNNING", "failure_reason": None, "is_finished": False,
+         "hard_stop": None, "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _detail(status=None, **over):
+    d = {"evosim": _evosim(1), "iterations": [], "status": status,
+         "failure_reason": None, "checkpoint_id": None}
+    d.update(over)
+    return d
+
+
+def _tmi(i, **over):
+    d = {"tmi_id": f"tmi{i}", "module_key": "filesystem", "module_artifact_key": None,
+         "created_by": "u1", "status": "READY", "session_id": "s1",
+         "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+class TestModel:
+    def test_is_terminal_across_statuses(self):
+        for s in (None, "RUNNING"):
+            assert EvoSim.from_dict(_evosim(1, status=s)).is_terminal is False
+        for s in ("SUCCEEDED", "PARTIAL_SUCCESS", "FAILED", "CANCELED"):
+            assert EvoSim.from_dict(_evosim(1, status=s)).is_terminal is True
+
+    def test_iterations_typed(self):
+        run = EvoSim.from_dict(_evosim(1, iterations=[_iteration(), _iteration(evosimiteration_id="it2")]))
+        assert all(isinstance(it, EvoSimIteration) for it in run.iterations)
+        assert run.iterations[0].evosimiteration_id == "it1"
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed_and_defaults_agent(self, evosims):
+        route = respx.get(_EVOSIMS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evosim(1), _evosim(2)],
+                                      "next": f"{_EVOSIMS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evosim(3)], "next": None}),
+        ])
+        got = list(evosims.list())
+        assert [e.evosim_id for e in got] == ["es1", "es2", "es3"]
+        assert all(isinstance(e, EvoSim) for e in got)
+        assert route.calls[0].request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_explicit_agent_and_page_size(self, evosims):
+        route = respx.get(_EVOSIMS).mock(return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(evosims.list("a2", page_size=25))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a2" and p["page_size"] == "25"
+
+    def test_list_without_agent_id_raises(self, http):
+        res = EvoSimsResource(http, agent_id=None)
+        with pytest.raises(AgentIdRequiredError):
+            list(res.list())
+
+
+class TestGet:
+    @respx.mock
+    def test_get_flattens_detail_envelope(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(
+            status="SUCCEEDED", evosim=_evosim(1), iterations=[_iteration(status="SUCCEEDED")],
+            checkpoint_id="ck1", failure_reason=None)))
+        run = evosims.get("es1")
+        assert isinstance(run, EvoSim) and run.evosim_id == "es1"
+        assert run.status == "SUCCEEDED" and run.checkpoint_id == "ck1" and run.is_terminal is True
+        assert run.iterations[0].evosimiteration_id == "it1"
+
+    @respx.mock
+    def test_get_running_status_none_checkpoint(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(status="RUNNING")))
+        run = evosims.get("es1")
+        assert run.status == "RUNNING" and run.is_terminal is False and run.checkpoint_id is None
+
+    @respx.mock
+    def test_get_404(self, evosims):
+        respx.get(f"{_EVOSIMS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified EvoSim not found"}))
+        with pytest.raises(NotFoundError):
+            evosims.get("missing")
+
+
+class TestCancel:
+    @respx.mock
+    def test_cancel_returns_effective_status(self, evosims):
+        route = respx.post(f"{_EVOSIMS}/es1/cancel").mock(
+            return_value=httpx.Response(200, json={"evosim_id": "es1", "status": "CANCELED"}))
+        assert evosims.cancel("es1") == "CANCELED"
+        assert route.called
+
+    @respx.mock
+    def test_cancel_already_terminal_returns_its_status(self, evosims):
+        # idempotent — cancelling a finished run reports its real terminal status
+        respx.post(f"{_EVOSIMS}/es1/cancel").mock(
+            return_value=httpx.Response(200, json={"evosim_id": "es1", "status": "SUCCEEDED"}))
+        assert evosims.cancel("es1") == "SUCCEEDED"
+
+    @respx.mock
+    def test_cancel_503(self, evosims):
+        respx.post(f"{_EVOSIMS}/es1/cancel").mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            evosims.cancel("es1")
+
+
+class TestIterationInstances:
+    @respx.mock
+    def test_unwraps_typed_list(self, evosims):
+        respx.get(f"{_BASE}/sdk/evosim-iterations/it1/instances").mock(return_value=httpx.Response(
+            200, json={"evosim_iteration_id": "it1", "training_module_instances": [_tmi(1), _tmi(2)]}))
+        tmis = evosims.iteration_instances("it1")
+        assert [t.tmi_id for t in tmis] == ["tmi1", "tmi2"]
+        assert all(isinstance(t, TrainingModuleInstance) for t in tmis)
+        assert tmis[0].module_key == "filesystem" and tmis[0].status == "READY"
+
+    @respx.mock
+    def test_empty(self, evosims):
+        respx.get(f"{_BASE}/sdk/evosim-iterations/it1/instances").mock(
+            return_value=httpx.Response(200, json={"evosim_iteration_id": "it1", "training_module_instances": []}))
+        assert evosims.iteration_instances("it1") == []
+
+
+class TestWaitFor:
+    @respx.mock
+    def test_polls_past_none_and_running_to_terminal(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(side_effect=[
+            httpx.Response(200, json=_detail(status=None)),      # iteration not yet materialized
+            httpx.Response(200, json=_detail(status="RUNNING")),
+            httpx.Response(200, json=_detail(status="SUCCEEDED", checkpoint_id="ck1")),
+        ])
+        run = evosims.wait_for("es1", timeout=60, interval=0)
+        assert run.is_terminal is True and run.status == "SUCCEEDED" and run.checkpoint_id == "ck1"
+
+    @respx.mock
+    def test_canceled_is_terminal(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(side_effect=[
+            httpx.Response(200, json=_detail(status="RUNNING")),
+            httpx.Response(200, json=_detail(status="CANCELED")),
+        ])
+        run = evosims.wait_for("es1", timeout=60, interval=0)
+        assert run.status == "CANCELED" and run.is_terminal is True
+
+    @respx.mock
+    def test_timeout_raises(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(status="RUNNING")))
+        with pytest.raises(WaitTimeout) as exc:
+            evosims.wait_for("es1", timeout=0, interval=0)
+        assert exc.value.last_state.status == "RUNNING"
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, evosims):
+        respx.get(_EVOSIMS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_evosim(1)], "next": f"{_EVOSIMS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_evosim(2)], "next": None}),
+        ])
+        got = [e.evosim_id async for e in evosims.alist()]
+        assert got == ["es1", "es2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(return_value=httpx.Response(200, json=_detail(status="FAILED")))
+        run = await evosims.aget("es1")
+        assert run.status == "FAILED" and run.is_terminal is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acancel(self, evosims):
+        respx.post(f"{_EVOSIMS}/es1/cancel").mock(
+            return_value=httpx.Response(200, json={"evosim_id": "es1", "status": "CANCELED"}))
+        assert await evosims.acancel("es1") == "CANCELED"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_await_for(self, evosims):
+        respx.get(f"{_EVOSIMS}/es1").mock(side_effect=[
+            httpx.Response(200, json=_detail(status="RUNNING")),
+            httpx.Response(200, json=_detail(status="SUCCEEDED")),
+        ])
+        run = await evosims.await_for("es1", timeout=60, interval=0)
+        assert run.is_terminal is True

--- a/tests/api/resources/test_experiments_v2.py
+++ b/tests/api/resources/test_experiments_v2.py
@@ -1,0 +1,123 @@
+"""LUC-908 — client.experiments reads (list / count / get)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.experiment import Experiment
+from lucidicai.api.resources.experiment import ExperimentResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
+
+
+@pytest.fixture
+def experiments(http):
+    # Configured agent_id "a1" — list()/count() default to it.
+    return ExperimentResource(http, agent_id="a1", production=False)
+
+
+def _exp(i, **over):
+    d = {
+        "experiment_id": f"x{i}", "name": f"exp-{i}", "description": "",
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+        "num_sessions": 3, "tags": ["prod"], "eval_metrics": [],
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, experiments):
+        respx.get(_EXPERIMENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_exp(1), _exp(2)],
+                                      "next": f"{_EXPERIMENTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_exp(3)], "next": None}),
+        ])
+        got = list(experiments.list())
+        assert [e.experiment_id for e in got] == ["x1", "x2", "x3"]
+        assert all(isinstance(e, Experiment) for e in got)
+
+    @respx.mock
+    def test_defaults_configured_agent_id(self, experiments):
+        route = respx.get(_EXPERIMENTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(experiments.list())
+        assert route.calls.last.request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_explicit_agent_id_and_ordering(self, experiments):
+        route = respx.get(_EXPERIMENTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(experiments.list("a2", ordering="created_at", page_size=10))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a2"
+        assert p["ordering"] == "created_at"
+        assert p["page_size"] == "10"
+
+    @respx.mock
+    def test_list_page(self, experiments):
+        respx.get(_EXPERIMENTS).mock(return_value=httpx.Response(
+            200, json={"results": [_exp(1)], "next": f"{_EXPERIMENTS}?cursor=c9"}))
+        page = experiments.list_page()
+        assert isinstance(page.results[0], Experiment) and page.next_cursor == "c9"
+
+
+class TestCount:
+    @respx.mock
+    def test_count(self, experiments):
+        respx.head(_EXPERIMENTS).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "12"}))
+        assert experiments.count() == 12
+
+    @respx.mock
+    def test_count_missing_header_zero(self, experiments):
+        respx.head(_EXPERIMENTS).mock(return_value=httpx.Response(200))
+        assert experiments.count() == 0
+
+
+class TestGet:
+    @respx.mock
+    def test_detail_with_metrics(self, experiments):
+        detail = _exp(1, agent_id="a1", eval_metrics_by_tag={"prod": {}},
+                      time_data={"p50": 1.2}, event_failure_groups=[{"group": "timeout"}],
+                      analytics_session_count=3)
+        respx.get(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(200, json=detail))
+        e = experiments.get("x1")
+        assert isinstance(e, Experiment)
+        assert e.agent_id == "a1"
+        assert e.time_data == {"p50": 1.2}
+        assert e.event_failure_groups == [{"group": "timeout"}]
+
+    @respx.mock
+    def test_404_raises(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.get("missing")
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, experiments):
+        respx.get(_EXPERIMENTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_exp(1)], "next": f"{_EXPERIMENTS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_exp(2)], "next": None}),
+        ])
+        got = [e.experiment_id async for e in experiments.alist()]
+        assert got == ["x1", "x2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acount(self, experiments):
+        respx.head(_EXPERIMENTS).mock(return_value=httpx.Response(200, headers={"X-Total-Count": "5"}))
+        assert await experiments.acount() == 5
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(200, json=_exp(1)))
+        e = await experiments.aget("x1")
+        assert e.experiment_id == "x1"

--- a/tests/api/resources/test_experiments_v2.py
+++ b/tests/api/resources/test_experiments_v2.py
@@ -1,14 +1,22 @@
-"""LUC-908 — client.experiments reads (list / count / get)."""
+"""LUC-908 — client.experiments reads (list / count / get).
+LUC-915 — client.experiments writes (delete + evaluators attach/detach/list)."""
+import json
+
 import httpx
 import pytest
 import respx
 
+from lucidicai.api.models.evaluator import Evaluator
 from lucidicai.api.models.experiment import Experiment
 from lucidicai.api.resources.experiment import ExperimentResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
 
 _BASE = "https://stub.lucidic.test"
 _EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
+
+
+def _evals_url(xid):
+    return f"{_EXPERIMENTS}/{xid}/evaluators"
 
 
 @pytest.fixture
@@ -23,6 +31,13 @@ def _exp(i, **over):
         "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
         "num_sessions": 3, "tags": ["prod"], "eval_metrics": [],
     }
+    d.update(over)
+    return d
+
+
+def _ev(i, **over):
+    d = {"evaluator_id": f"e{i}", "name": f"eval-{i}", "type": "LLM",
+         "result_type": "boolean", "is_default": False}
     d.update(over)
     return d
 
@@ -121,3 +136,127 @@ class TestAsync:
         respx.get(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(200, json=_exp(1)))
         e = await experiments.aget("x1")
         assert e.experiment_id == "x1"
+
+
+# ==================== LUC-915 writes ====================
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_default_no_cascade(self, experiments):
+        # delete_sessions is a JSON BODY flag, default False (not a query param).
+        route = respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(204))
+        assert experiments.delete("x1") is None
+        assert json.loads(route.calls.last.request.read()) == {"delete_sessions": False}
+
+    @respx.mock
+    def test_delete_sessions_true_sends_body_flag(self, experiments):
+        route = respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(204))
+        experiments.delete("x1", delete_sessions=True)
+        assert json.loads(route.calls.last.request.read()) == {"delete_sessions": True}
+
+    @respx.mock
+    def test_delete_forbidden_403(self, experiments):
+        # experiment:delete is a full-key-only scope; an ingest key → 403.
+        respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(
+            403, json={"error": "This API key is not authorized for this action."}))
+        with pytest.raises(InsufficientScopeError):
+            experiments.delete("x1")
+
+    @respx.mock
+    def test_delete_missing_404(self, experiments):
+        respx.delete(f"{_EXPERIMENTS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified Experiment not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.delete("missing")
+
+
+class TestEvaluatorsList:
+    @respx.mock
+    def test_follows_pages_typed(self, experiments):
+        url = _evals_url("x1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_ev(1), _ev(2)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_ev(3)], "next": None}),
+        ])
+        got = list(experiments.evaluators.list("x1"))
+        assert [e.evaluator_id for e in got] == ["e1", "e2", "e3"]
+        assert all(isinstance(e, Evaluator) for e in got)
+
+    @respx.mock
+    def test_list_page_and_page_size(self, experiments):
+        route = respx.get(_evals_url("x1")).mock(return_value=httpx.Response(
+            200, json={"results": [_ev(1)], "next": None}))
+        page = experiments.evaluators.list_page("x1", page_size=50)
+        assert isinstance(page.results[0], Evaluator)
+        assert route.calls.last.request.url.params["page_size"] == "50"
+
+
+class TestEvaluatorsAttach:
+    @respx.mock
+    def test_attach_posts_names_returns_full_set(self, experiments):
+        route = respx.post(_evals_url("x1")).mock(return_value=httpx.Response(
+            200, json={"experiment_id": "x1", "evaluators": [_ev(1), _ev(2)]}))
+        got = experiments.evaluators.attach("x1", ["eval-1", "eval-2"])
+        assert [e.evaluator_id for e in got] == ["e1", "e2"]
+        assert all(isinstance(e, Evaluator) for e in got)
+        # backend field is evaluator_names (names, not ids); current_time is auto-injected.
+        assert json.loads(route.calls.last.request.read())["evaluator_names"] == ["eval-1", "eval-2"]
+
+    @respx.mock
+    def test_attach_unknown_name_400(self, experiments):
+        respx.post(_evals_url("x1")).mock(return_value=httpx.Response(
+            400, json={"error": "Validation failed",
+                       "details": {"evaluator_names": ["Unknown evaluators for this experiment's agent: ['nope']"]}}))
+        with pytest.raises(ValidationError):
+            experiments.evaluators.attach("x1", ["nope"])
+
+
+class TestEvaluatorsDetach:
+    @respx.mock
+    def test_detach_returns_none_204(self, experiments):
+        route = respx.delete(f"{_evals_url('x1')}/e1").mock(return_value=httpx.Response(204))
+        assert experiments.evaluators.detach("x1", "e1") is None
+        assert route.called
+
+    @respx.mock
+    def test_detach_not_attached_404(self, experiments):
+        respx.delete(f"{_evals_url('x1')}/e9").mock(return_value=httpx.Response(
+            404, json={"error": "Specified evaluator not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.evaluators.detach("x1", "e9")
+
+
+class TestWriteAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete_sends_body(self, experiments):
+        route = respx.delete(f"{_EXPERIMENTS}/x1").mock(return_value=httpx.Response(204))
+        assert await experiments.adelete("x1", delete_sessions=True) is None
+        assert json.loads(route.calls.last.request.read()) == {"delete_sessions": True}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aattach(self, experiments):
+        respx.post(_evals_url("x1")).mock(return_value=httpx.Response(
+            200, json={"experiment_id": "x1", "evaluators": [_ev(1)]}))
+        got = await experiments.evaluators.aattach("x1", ["eval-1"])
+        assert [e.evaluator_id for e in got] == ["e1"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adetach(self, experiments):
+        route = respx.delete(f"{_evals_url('x1')}/e1").mock(return_value=httpx.Response(204))
+        assert await experiments.evaluators.adetach("x1", "e1") is None
+        assert route.called
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, experiments):
+        url = _evals_url("x1")
+        respx.get(url).mock(side_effect=[
+            httpx.Response(200, json={"results": [_ev(1)], "next": f"{url}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_ev(2)], "next": None}),
+        ])
+        got = [e.evaluator_id async for e in experiments.evaluators.alist("x1")]
+        assert got == ["e1", "e2"]

--- a/tests/api/resources/test_experiments_v2.py
+++ b/tests/api/resources/test_experiments_v2.py
@@ -1,5 +1,6 @@
 """LUC-908 — client.experiments reads (list / count / get).
-LUC-915 — client.experiments writes (delete + evaluators attach/detach/list)."""
+LUC-915 — client.experiments writes (delete + evaluators attach/detach/list).
+LUC-922 — client.experiments taxonomy + failure-modes (async, trigger-then-poll)."""
 import json
 
 import httpx
@@ -7,9 +8,17 @@ import pytest
 import respx
 
 from lucidicai.api.models.evaluator import Evaluator
-from lucidicai.api.models.experiment import Experiment
-from lucidicai.api.resources.experiment import ExperimentResource
-from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
+from lucidicai.api.models.experiment import Experiment, FailureGroup
+from lucidicai.api.models.taxonomy import TaxonomyRun, TaxonomyStatus
+from lucidicai.api.resources.experiment import ExperimentResource, ExperimentTaxonomyResource
+from lucidicai.core.errors import (
+    ConflictError,
+    InsufficientScopeError,
+    NotFoundError,
+    ServiceUnavailableError,
+    ValidationError,
+    WaitTimeout,
+)
 
 _BASE = "https://stub.lucidic.test"
 _EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
@@ -17,6 +26,38 @@ _EXPERIMENTS = f"{_BASE}/sdk/v2/experiments"
 
 def _evals_url(xid):
     return f"{_EXPERIMENTS}/{xid}/evaluators"
+
+
+def _tax_url(xid):
+    return f"{_EXPERIMENTS}/{xid}/taxonomy"
+
+
+def _tax_run(**over):
+    d = {"run_id": "tr1", "version": 1, "status": "queued", "created_at": "2026-07-22T00:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _tax_status(**over):
+    d = {"ongoing": None, "latest_completed": None, "evaluating_session_count": 0}
+    d.update(over)
+    return d
+
+
+def _tax_completed(**over):
+    # The status endpoint's latest_completed carries NO status field (unlike a run) —
+    # {run_id, version, created_at, completed_at}. Keep the fixture faithful.
+    d = {"run_id": "tr1", "version": 1, "created_at": "2026-07-22T00:00:00Z",
+         "completed_at": "2026-07-22T01:00:00Z"}
+    d.update(over)
+    return d
+
+
+def _fgroup(i, **over):
+    d = {"id": f"fg{i}", "group_name": f"group-{i}", "group_description": "",
+         "icon": "warn", "events": [{"event_id": "e1", "session_id": "s1"}]}
+    d.update(over)
+    return d
 
 
 @pytest.fixture
@@ -260,3 +301,184 @@ class TestWriteAsync:
         ])
         got = [e.evaluator_id async for e in experiments.evaluators.alist("x1")]
         assert got == ["e1", "e2"]
+
+
+# ==================== LUC-922 taxonomy + failure-modes ====================
+
+
+class TestWiring:
+    def test_taxonomy_subnamespace_resolves(self, experiments):
+        assert isinstance(experiments.taxonomy, ExperimentTaxonomyResource)
+
+
+class TestTaxonomyModel:
+    def test_status_types_nested_runs_and_is_terminal(self):
+        # ongoing present -> not terminal, nested runs typed
+        st = TaxonomyStatus.from_dict(_tax_status(
+            ongoing=_tax_run(status="sampling"), latest_completed=_tax_completed(run_id="tr0", version=0)))
+        assert st.is_terminal is False
+        assert isinstance(st.ongoing, TaxonomyRun) and st.ongoing.status == "sampling"
+        assert isinstance(st.latest_completed, TaxonomyRun) and st.latest_completed.run_id == "tr0"
+
+    def test_status_no_ongoing_is_terminal(self):
+        st = TaxonomyStatus.from_dict(_tax_status(latest_completed=_tax_completed()))
+        assert st.is_terminal is True and st.ongoing is None
+        assert isinstance(st.latest_completed, TaxonomyRun)
+
+
+class TestTaxonomyGenerate:
+    @respx.mock
+    def test_generate_empty_body_and_typed(self, experiments):
+        route = respx.post(_tax_url("x1")).mock(return_value=httpx.Response(201, json=_tax_run()))
+        run = experiments.taxonomy.generate("x1")
+        assert isinstance(run, TaxonomyRun) and run.run_id == "tr1" and run.status == "queued"
+        body = json.loads(route.calls.last.request.read())
+        assert "seed_dimensions" not in body and "use_previous" not in body  # omit-None
+
+    @respx.mock
+    def test_generate_with_seeds_and_use_previous(self, experiments):
+        route = respx.post(_tax_url("x1")).mock(return_value=httpx.Response(201, json=_tax_run()))
+        seeds = [{"name": "tone", "description": "d"}]
+        experiments.taxonomy.generate("x1", seed_dimensions=seeds, use_previous=True)
+        body = json.loads(route.calls.last.request.read())
+        assert body["seed_dimensions"] == seeds and body["use_previous"] is True
+
+    @respx.mock
+    def test_generate_too_few_sessions_400(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(
+            400, json={"error": "Need at least 20 finished sessions, found 3"}))
+        with pytest.raises(ValidationError):
+            experiments.taxonomy.generate("x1")
+
+    @respx.mock
+    def test_generate_already_running_409(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(
+            409, json={"error": "A taxonomy run is already in progress", "ongoing_run_id": "tr9"}))
+        with pytest.raises(ConflictError):
+            experiments.taxonomy.generate("x1")
+
+    @respx.mock
+    def test_generate_503(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            experiments.taxonomy.generate("x1")
+
+
+class TestTaxonomyGetStatus:
+    @respx.mock
+    def test_get_completed_taxonomy(self, experiments):
+        respx.get(_tax_url("x1")).mock(return_value=httpx.Response(200, json=_tax_run(
+            status=None, completed_at="2026-07-22T01:00:00Z", taxonomy={"dimensions": []})))
+        run = experiments.taxonomy.get("x1")
+        assert run.taxonomy == {"dimensions": []} and run.completed_at is not None
+
+    @respx.mock
+    def test_get_404_until_completed(self, experiments):
+        respx.get(_tax_url("x1")).mock(return_value=httpx.Response(
+            404, json={"error": "Specified CompletedTaxonomyRun not found"}))
+        with pytest.raises(NotFoundError):
+            experiments.taxonomy.get("x1")
+
+    @respx.mock
+    def test_status_typed(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(return_value=httpx.Response(
+            200, json=_tax_status(ongoing=_tax_run(status="validating"), evaluating_session_count=4)))
+        st = experiments.taxonomy.status("x1")
+        assert isinstance(st, TaxonomyStatus) and st.evaluating_session_count == 4
+        assert st.ongoing.status == "validating" and st.is_terminal is False
+
+
+class TestTaxonomyWaitFor:
+    @respx.mock
+    def test_polls_until_no_ongoing(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(side_effect=[
+            httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="queued"))),
+            httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="validating"))),
+            httpx.Response(200, json=_tax_status(latest_completed=_tax_completed(run_id="tr1"))),
+        ])
+        st = experiments.taxonomy.wait_for("x1", timeout=30, interval=0)
+        assert st.is_terminal is True and st.ongoing is None
+        # latest_completed carries no status field from the backend — match on run_id
+        assert st.latest_completed.run_id == "tr1" and st.latest_completed.status is None
+
+    @respx.mock
+    def test_timeout_raises(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(
+            return_value=httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="sampling"))))
+        with pytest.raises(WaitTimeout) as exc:
+            experiments.taxonomy.wait_for("x1", timeout=0, interval=0)
+        assert exc.value.last_state.ongoing.status == "sampling"
+
+
+class TestFailureModes:
+    @respx.mock
+    def test_generate_failure_modes_returns_none(self, experiments):
+        route = respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(
+            return_value=httpx.Response(202, json={"experiment_id": "x1", "status": "started"}))
+        assert experiments.generate_failure_modes("x1") is None
+        assert route.called
+
+    @respx.mock
+    def test_generate_failure_modes_no_sessions_400(self, experiments):
+        respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(return_value=httpx.Response(
+            400, json={"error": "No sessions found in experiment"}))
+        with pytest.raises(ValidationError):
+            experiments.generate_failure_modes("x1")
+
+    @respx.mock
+    def test_generate_failure_modes_503(self, experiments):
+        respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(return_value=httpx.Response(
+            503, json={"error": "Workflow service is temporarily unavailable; please retry."}))
+        with pytest.raises(ServiceUnavailableError):
+            experiments.generate_failure_modes("x1")
+
+    @respx.mock
+    def test_failure_groups_unwraps_typed_list(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1/failure-groups").mock(return_value=httpx.Response(
+            200, json={"event_failure_groups": [_fgroup(1), _fgroup(2)]}))
+        groups = experiments.failure_groups("x1")
+        assert [g.id for g in groups] == ["fg1", "fg2"]
+        assert all(isinstance(g, FailureGroup) for g in groups)
+        assert groups[0].events == [{"event_id": "e1", "session_id": "s1"}]
+
+    @respx.mock
+    def test_failure_groups_empty(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1/failure-groups").mock(
+            return_value=httpx.Response(200, json={"event_failure_groups": []}))
+        assert experiments.failure_groups("x1") == []
+
+
+class TestTaxonomyFailureAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_agenerate(self, experiments):
+        respx.post(_tax_url("x1")).mock(return_value=httpx.Response(201, json=_tax_run()))
+        run = await experiments.taxonomy.agenerate("x1")
+        assert run.run_id == "tr1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_await_for(self, experiments):
+        respx.get(f"{_tax_url('x1')}/status").mock(side_effect=[
+            httpx.Response(200, json=_tax_status(ongoing=_tax_run(status="sampling"))),
+            httpx.Response(200, json=_tax_status(latest_completed=_tax_completed())),
+        ])
+        st = await experiments.taxonomy.await_for("x1", timeout=30, interval=0)
+        assert st.is_terminal is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afailure_groups(self, experiments):
+        respx.get(f"{_EXPERIMENTS}/x1/failure-groups").mock(return_value=httpx.Response(
+            200, json={"event_failure_groups": [_fgroup(1)]}))
+        groups = await experiments.afailure_groups("x1")
+        assert groups[0].id == "fg1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_agenerate_failure_modes(self, experiments):
+        route = respx.post(f"{_EXPERIMENTS}/x1/failure-modes").mock(
+            return_value=httpx.Response(202, json={"experiment_id": "x1", "status": "started"}))
+        assert await experiments.agenerate_failure_modes("x1") is None
+        assert route.called

--- a/tests/api/resources/test_mock_call.py
+++ b/tests/api/resources/test_mock_call.py
@@ -15,11 +15,13 @@ from lucidicai.api.client import HttpClient
 from lucidicai.api.resources.mock_call import MockCallResource
 from lucidicai.core.config import NetworkConfig, SDKConfig
 from lucidicai.core.errors import (
+    InsufficientScopeError,
     LucidicMockCallError,
     LucidicToolBlockedError,
     LucidicToolDriftError,
     LucidicUnknownToolError,
     LucidicUnsupportedSQLError,
+    RateLimitError,
 )
 
 
@@ -198,6 +200,27 @@ class TestCallErrors:
         with pytest.raises(LucidicMockCallError) as exc_info:
             resource.call(session_id="s", tool_name="t", kwargs={})
         assert exc_info.value.code == "malformed_response"
+
+
+class TestCallPropagatesTypedErrors:
+    """Well-typed non-mock errors (auth / scope / rate-limit) must propagate
+    with their type + fields intact — NOT be flattened to malformed_response.
+    Only a genuinely untyped/malformed body becomes a mock error."""
+
+    @respx.mock
+    def test_403_scope_propagates_with_fields(self, resource):
+        respx.post(_ENDPOINT).mock(return_value=httpx.Response(
+            403, json={"error": "missing scope", "required_scope": "tool:mock"}))
+        with pytest.raises(InsufficientScopeError) as ei:
+            resource.call(session_id="s", tool_name="t", kwargs={})
+        assert ei.value.required_scope == "tool:mock"
+
+    @respx.mock
+    def test_429_rate_limit_propagates(self, resource):
+        respx.post(_ENDPOINT).mock(return_value=httpx.Response(
+            429, json={"detail": "slow down"}))
+        with pytest.raises(RateLimitError):
+            resource.call(session_id="s", tool_name="t", kwargs={})
 
 
 # ---------- acall (async) ------------------------------------------------

--- a/tests/api/resources/test_projects_v2.py
+++ b/tests/api/resources/test_projects_v2.py
@@ -1,0 +1,147 @@
+"""LUC-913 — client.projects CRUD (list / create / get / update / delete)."""
+import json
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.project import Project
+from lucidicai.api.resources.projects import ProjectsResource
+from lucidicai.core.errors import NotFoundError, ValidationError
+
+_BASE = "https://stub.lucidic.test"
+_PROJECTS = f"{_BASE}/sdk/v2/projects"
+
+
+@pytest.fixture
+def projects(http):
+    return ProjectsResource(http)
+
+
+def _project(i, **over):
+    d = {"project_id": f"p{i}", "name": f"proj-{i}", "description": "", "icon": "folder"}
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, projects):
+        respx.get(_PROJECTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_project(1), _project(2)],
+                                      "next": f"{_PROJECTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_project(3)], "next": None}),
+        ])
+        got = list(projects.list())
+        assert [p.project_id for p in got] == ["p1", "p2", "p3"]
+        assert all(isinstance(p, Project) for p in got)
+
+    @respx.mock
+    def test_no_agent_id_param(self, projects):
+        # Projects are org-scoped: no agent_id is sent.
+        route = respx.get(_PROJECTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(projects.list(ordering="id"))
+        p = route.calls.last.request.url.params
+        assert "agent_id" not in p and p["ordering"] == "id"
+
+
+class TestGet:
+    @respx.mock
+    def test_get(self, projects):
+        respx.get(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        p = projects.get("p1")
+        assert isinstance(p, Project) and p.project_id == "p1" and p.icon == "folder"
+
+    @respx.mock
+    def test_404(self, projects):
+        respx.get(f"{_PROJECTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            projects.get("missing")
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_requires_name_and_icon(self, projects):
+        route = respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
+        p = projects.create("proj-1", icon="rocket")
+        assert isinstance(p, Project) and p.project_id == "p1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "proj-1" and body["icon"] == "rocket"
+        assert "description" not in body
+
+    @respx.mock
+    def test_create_with_description(self, projects):
+        route = respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
+        projects.create("proj-1", icon="rocket", description="my project")
+        body = json.loads(route.calls.last.request.read())
+        assert body["description"] == "my project"
+
+    @respx.mock
+    def test_create_over_length_400(self, projects):
+        respx.post(_PROJECTS).mock(return_value=httpx.Response(
+            400, json={"error": "A field exceeds its maximum length."}))
+        with pytest.raises(ValidationError):
+            projects.create("x" * 999, icon="i")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_only_provided_fields(self, projects):
+        route = respx.put(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        p = projects.update("p1", name="renamed")
+        assert isinstance(p, Project)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed"
+        assert "icon" not in body and "description" not in body
+
+    @respx.mock
+    def test_all_fields(self, projects):
+        route = respx.put(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        projects.update("p1", name="n", description="d", icon="i")
+        body = json.loads(route.calls.last.request.read())
+        assert body == {"name": "n", "description": "d", "icon": "i", **_current_time(body)}
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_returns_none_on_204(self, projects):
+        route = respx.delete(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(204))
+        assert projects.delete("p1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_404_raises(self, projects):
+        respx.delete(f"{_PROJECTS}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            projects.delete("missing")
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, projects):
+        respx.post(_PROJECTS).mock(return_value=httpx.Response(201, json=_project(1)))
+        p = await projects.acreate("proj-1", icon="rocket")
+        assert p.project_id == "p1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, projects):
+        respx.put(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(200, json=_project(1)))
+        p = await projects.aupdate("p1", icon="star")
+        assert p.project_id == "p1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, projects):
+        route = respx.delete(f"{_PROJECTS}/p1").mock(return_value=httpx.Response(204))
+        assert await projects.adelete("p1") is None
+        assert route.called
+
+
+def _current_time(body):
+    # PUT/POST bodies carry an auto-injected current_time; ignore it in equality.
+    return {"current_time": body["current_time"]} if "current_time" in body else {}

--- a/tests/api/resources/test_prompts_v2.py
+++ b/tests/api/resources/test_prompts_v2.py
@@ -1,0 +1,124 @@
+"""LUC-909 — client.prompts reads (list / versions / labels)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.prompt import PromptInfo, PromptVersion
+from lucidicai.api.resources.prompt import PromptResource
+from lucidicai.core.config import NetworkConfig, SDKConfig
+
+_BASE = "https://stub.lucidic.test"
+_PROMPTS = f"{_BASE}/sdk/v2/prompts"
+
+
+@pytest.fixture
+def prompts(http):
+    cfg = SDKConfig(api_key="test-key", agent_id="a1", network=NetworkConfig(base_url=_BASE))
+    return PromptResource(http, cfg, production=False)
+
+
+def _prompt(i):
+    return {"prompt_id": f"p{i}", "name": f"prompt-{i}", "icon": "doc", "preview": "Hello..."}
+
+
+def _version(n, **over):
+    d = {
+        "promptversion_id": f"v{n}", "prompt_version_number": n,
+        "prompt_content": f"content {n}", "description": "", "metadata": {},
+        "created_at": "2026-07-22T00:00:00Z", "labels": [],
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, prompts):
+        respx.get(_PROMPTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_prompt(1), _prompt(2)],
+                                      "next": f"{_PROMPTS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_prompt(3)], "next": None}),
+        ])
+        got = list(prompts.list())
+        assert [p.prompt_id for p in got] == ["p1", "p2", "p3"]
+        assert all(isinstance(p, PromptInfo) for p in got)
+
+    @respx.mock
+    def test_defaults_configured_agent_id(self, prompts):
+        route = respx.get(_PROMPTS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(prompts.list(ordering="name"))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a1"
+        assert p["ordering"] == "name"
+
+    @respx.mock
+    def test_list_page(self, prompts):
+        respx.get(_PROMPTS).mock(return_value=httpx.Response(
+            200, json={"results": [_prompt(1)], "next": f"{_PROMPTS}?cursor=c9"}))
+        page = prompts.list_page()
+        assert isinstance(page.results[0], PromptInfo) and page.next_cursor == "c9"
+
+
+class TestVersions:
+    @respx.mock
+    def test_sends_prompt_name_and_typed(self, prompts):
+        route = respx.get(f"{_PROMPTS}/versions").mock(side_effect=[
+            httpx.Response(200, json={"results": [_version(2, labels=["latest", "production"])],
+                                      "next": f"{_PROMPTS}/versions?cursor=c2"}),
+            httpx.Response(200, json={"results": [_version(1)], "next": None}),
+        ])
+        got = list(prompts.versions("greeting"))
+        assert route.calls[0].request.url.params["prompt_name"] == "greeting"
+        assert route.calls[0].request.url.params["agent_id"] == "a1"
+        assert [v.prompt_version_number for v in got] == [2, 1]
+        assert all(isinstance(v, PromptVersion) for v in got)
+        assert got[0].labels == ["latest", "production"]
+
+    @respx.mock
+    def test_versions_page(self, prompts):
+        respx.get(f"{_PROMPTS}/versions").mock(return_value=httpx.Response(
+            200, json={"results": [_version(1)], "next": None}))
+        page = prompts.versions_page("greeting")
+        assert isinstance(page.results[0], PromptVersion)
+
+
+class TestLabels:
+    @respx.mock
+    def test_labels_unwrapped(self, prompts):
+        route = respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(
+            200, json={"labels": ["latest", "production", "staging"]}))
+        assert prompts.labels() == ["latest", "production", "staging"]
+        assert route.calls.last.request.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_labels_empty(self, prompts):
+        respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(200, json={"labels": []}))
+        assert prompts.labels() == []
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, prompts):
+        respx.get(_PROMPTS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_prompt(1)], "next": f"{_PROMPTS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_prompt(2)], "next": None}),
+        ])
+        got = [p.prompt_id async for p in prompts.alist()]
+        assert got == ["p1", "p2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aversions(self, prompts):
+        respx.get(f"{_PROMPTS}/versions").mock(return_value=httpx.Response(
+            200, json={"results": [_version(1)], "next": None}))
+        got = [v.prompt_version_number async for v in prompts.aversions("greeting")]
+        assert got == [1]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alabels(self, prompts):
+        respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(
+            200, json={"labels": ["latest"]}))
+        assert await prompts.alabels() == ["latest"]

--- a/tests/api/resources/test_prompts_v2.py
+++ b/tests/api/resources/test_prompts_v2.py
@@ -1,4 +1,6 @@
-"""LUC-909 — client.prompts reads (list / versions / labels)."""
+"""LUC-909 / LUC-914 — client.prompts reads + writes."""
+import json
+
 import httpx
 import pytest
 import respx
@@ -6,9 +8,17 @@ import respx
 from lucidicai.api.models.prompt import PromptInfo, PromptVersion
 from lucidicai.api.resources.prompt import PromptResource
 from lucidicai.core.config import NetworkConfig, SDKConfig
+from lucidicai.core.errors import (
+    AgentIdRequiredError,
+    ConflictError,
+    InsufficientScopeError,
+    ValidationError,
+)
 
 _BASE = "https://stub.lucidic.test"
 _PROMPTS = f"{_BASE}/sdk/v2/prompts"
+_DETAIL = f"{_PROMPTS}/detail"
+_LABELS = f"{_PROMPTS}/labels"
 
 
 @pytest.fixture
@@ -122,3 +132,221 @@ class TestAsync:
         respx.get(f"{_PROMPTS}/labels").mock(return_value=httpx.Response(
             200, json={"labels": ["latest"]}))
         assert await prompts.alabels() == ["latest"]
+
+
+def _ct(body):
+    # PATCH/PUT bodies carry an auto-injected current_time; ignore in equality.
+    return {"current_time": body["current_time"]} if "current_time" in body else {}
+
+
+class TestCreate:
+    """LUC-914 follow-up (unblocked by backend LUC-931): POST /sdk/v2/prompts —
+    create a brand-new prompt + its first version."""
+
+    @respx.mock
+    def test_create_prompt_and_typed_first_version(self, prompts):
+        route = respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            201, json={**_prompt(1), "version": _version(1, labels=["latest", "production"])}))
+        info, v = prompts.create("prompt-1", "content 1")
+        assert isinstance(info, PromptInfo) and info.prompt_id == "p1" and info.name == "prompt-1"
+        assert isinstance(v, PromptVersion) and v.prompt_version_number == 1
+        assert set(v.labels) == {"latest", "production"}
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1"  # defaulted from config
+        assert body["name"] == "prompt-1" and body["prompt_content"] == "content 1"
+        # omit-None: unspecified optionals are NOT sent (backend applies its defaults)
+        assert not any(k in body for k in ("icon", "description", "metadata", "labels"))
+
+    @respx.mock
+    def test_create_all_fields_sent(self, prompts):
+        route = respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        prompts.create("prompt-1", "c", icon="star", description="d",
+                       metadata={"k": "v"}, labels=["staging"])
+        body = json.loads(route.calls.last.request.read())
+        assert body["icon"] == "star" and body["description"] == "d"
+        assert body["metadata"] == {"k": "v"} and body["labels"] == ["staging"]
+
+    @respx.mock
+    def test_create_explicit_agent_id_overrides_config(self, prompts):
+        route = respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        prompts.create("prompt-1", "c", agent_id="a2")
+        assert json.loads(route.calls.last.request.read())["agent_id"] == "a2"
+
+    @respx.mock
+    def test_create_without_version_subobject(self, prompts):
+        # Forward-compat: a response missing the version subobject yields (PromptInfo, None).
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        info, v = prompts.create("prompt-1", "c")
+        assert isinstance(info, PromptInfo) and v is None
+
+    @respx.mock
+    def test_create_duplicate_name_409(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            409, json={"error": "A prompt named 'prompt-1' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            prompts.create("prompt-1", "c")
+
+    @respx.mock
+    def test_create_missing_content_400(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            400, json={"error": "This field may not be blank."}))
+        with pytest.raises(ValidationError):
+            prompts.create("prompt-1", "")
+
+    @respx.mock
+    def test_create_without_write_scope_403(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            403, json={"error": "requires prompt:write"}))
+        with pytest.raises(InsufficientScopeError):
+            prompts.create("prompt-1", "c")
+
+    @respx.mock
+    def test_create_invalidates_stale_same_name_cache(self, prompts):
+        # A name deleted elsewhere then recreated must not keep serving old cached content.
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(201, json=_prompt(1)))
+        prompts._cache[("prompt-1", "production", None, None)] = {"content": "old", "timestamp": 0}
+        prompts.create("prompt-1", "c")
+        assert not any(k[0] == "prompt-1" for k in prompts._cache)
+
+    def test_create_without_agent_id_raises(self, http):
+        # No HTTP call: the guard fires client-side before the request.
+        res = PromptResource(http, SDKConfig(
+            api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE)))
+        with pytest.raises(AgentIdRequiredError):
+            res.create("prompt-1", "c")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, prompts):
+        respx.post(_PROMPTS).mock(return_value=httpx.Response(
+            201, json={**_prompt(1), "version": _version(1)}))
+        info, v = await prompts.acreate("prompt-1", "c")
+        assert isinstance(info, PromptInfo) and isinstance(v, PromptVersion)
+
+
+class TestRename:
+    @respx.mock
+    def test_rename_and_reicon(self, prompts):
+        route = respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        p = prompts.rename("greeting", new_name="salutation", icon="wave")
+        assert isinstance(p, PromptInfo)
+        body = json.loads(route.calls.last.request.read())
+        assert body["agent_id"] == "a1" and body["prompt_name"] == "greeting"
+        assert body["name"] == "salutation" and body["icon"] == "wave"
+
+    @respx.mock
+    def test_rename_only_provided(self, prompts):
+        route = respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        prompts.rename("greeting", icon="wave")
+        body = json.loads(route.calls.last.request.read())
+        assert "name" not in body and body["icon"] == "wave"
+
+    @respx.mock
+    def test_warning_on_extra(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(
+            200, json=dict(_prompt(1), warning="clients fetching the old name will 404")))
+        p = prompts.rename("greeting", new_name="salutation")
+        assert "404" in p.extra["warning"]
+
+    @respx.mock
+    def test_collision_409(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(
+            409, json={"error": "A prompt named 'x' already exists for this agent."}))
+        with pytest.raises(ConflictError):
+            prompts.rename("greeting", new_name="x")
+
+
+class TestSetLabels:
+    @respx.mock
+    def test_promote(self, prompts):
+        route = respx.put(_LABELS).mock(return_value=httpx.Response(
+            200, json=_version(3, labels=["production"])))
+        v = prompts.set_labels("greeting", 3, ["production"])
+        assert isinstance(v, PromptVersion) and v.labels == ["production"]
+        body = json.loads(route.calls.last.request.read())
+        assert body == {"agent_id": "a1", "prompt_name": "greeting",
+                        "version_number": 3, "labels": ["production"], **_ct(body)}
+
+    @respx.mock
+    def test_warning_on_extra(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(
+            200, json=dict(_version(3), warning="version 3 previously had no labels")))
+        v = prompts.set_labels("greeting", 3, ["production"])
+        assert "no labels" in v.extra["warning"]
+
+    @respx.mock
+    def test_move_latest_400(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(
+            400, json={"error": "'latest' is auto-managed"}))
+        with pytest.raises(ValidationError):
+            prompts.set_labels("greeting", 3, ["latest"])
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_204_sends_query(self, prompts):
+        route = respx.delete(_DETAIL).mock(return_value=httpx.Response(204))
+        assert prompts.delete("greeting") is None
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a1" and p["prompt_name"] == "greeting"
+
+    @respx.mock
+    def test_checkpoint_bound_409(self, prompts):
+        respx.delete(_DETAIL).mock(return_value=httpx.Response(
+            409, json={"error": "This prompt has a version bound to a checkpoint and cannot be deleted."}))
+        with pytest.raises(ConflictError):
+            prompts.delete("greeting")
+
+
+class TestAsyncWrite:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_arename(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        p = await prompts.arename("greeting", new_name="salutation")
+        assert isinstance(p, PromptInfo)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aset_labels(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(200, json=_version(3)))
+        v = await prompts.aset_labels("greeting", 3, ["production"])
+        assert v.prompt_version_number == 3
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, prompts):
+        route = respx.delete(_DETAIL).mock(return_value=httpx.Response(204))
+        assert await prompts.adelete("greeting") is None
+        assert route.called
+
+
+class TestCacheInvalidation:
+    """The writes must clear the local get() cache (keyed by prompt_name) —
+    like update()/update_metadata() do — else a promoted/renamed/deleted prompt
+    keeps serving stale cached content."""
+
+    @staticmethod
+    def _seed(prompts):
+        prompts._cache[("greeting", "production", None, None)] = {"content": "old", "timestamp": 0}
+
+    @respx.mock
+    def test_rename_invalidates(self, prompts):
+        respx.patch(_DETAIL).mock(return_value=httpx.Response(200, json=_prompt(1)))
+        self._seed(prompts)
+        prompts.rename("greeting", new_name="salutation")
+        assert not any(k[0] == "greeting" for k in prompts._cache)
+
+    @respx.mock
+    def test_set_labels_invalidates(self, prompts):
+        respx.put(_LABELS).mock(return_value=httpx.Response(200, json=_version(3)))
+        self._seed(prompts)
+        prompts.set_labels("greeting", 3, ["production"])
+        assert not any(k[0] == "greeting" for k in prompts._cache)
+
+    @respx.mock
+    def test_delete_invalidates(self, prompts):
+        respx.delete(_DETAIL).mock(return_value=httpx.Response(204))
+        self._seed(prompts)
+        prompts.delete("greeting")
+        assert not any(k[0] == "greeting" for k in prompts._cache)

--- a/tests/api/resources/test_resources_v2.py
+++ b/tests/api/resources/test_resources_v2.py
@@ -1,0 +1,199 @@
+"""LUC-917 — client.resources CRUD (SQL-substrate resources; new namespace)."""
+import json
+
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.resource import Resource
+from lucidicai.api.resources.resources import ResourcesResource
+from lucidicai.core.errors import ConflictError, NotFoundError, ValidationError
+
+_BASE = "https://stub.lucidic.test"
+_RESOURCES = f"{_BASE}/sdk/v2/resources"
+
+
+@pytest.fixture
+def resources(http):
+    return ResourcesResource(http)
+
+
+def _resource(i, **over):
+    d = {
+        "resource_id": f"res{i}", "type": "SQL", "dialect": "POSTGRES",
+        "tool_name": f"tool_{i}", "name": f"resource-{i}", "description": "",
+        "spec": {"tables": []}, "handler_type": "SQL",
+        "hydration_config": {"default_rows_per_table": 100},
+        "created_at": "2026-07-22T00:00:00Z", "updated_at": "2026-07-22T00:00:00Z",
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, resources):
+        respx.get(_RESOURCES).mock(side_effect=[
+            httpx.Response(200, json={"results": [_resource(1), _resource(2)],
+                                      "next": f"{_RESOURCES}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_resource(3)], "next": None}),
+        ])
+        got = list(resources.list())
+        assert [r.resource_id for r in got] == ["res1", "res2", "res3"]
+        assert all(isinstance(r, Resource) for r in got)
+
+    @respx.mock
+    def test_org_scoped_no_agent_id_param(self, resources):
+        # Resources are org-scoped: no agent_id is sent (scoped by the key's org).
+        route = respx.get(_RESOURCES).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(resources.list(ordering="id", page_size=10))
+        p = route.calls.last.request.url.params
+        assert "agent_id" not in p and p["ordering"] == "id" and p["page_size"] == "10"
+
+    @respx.mock
+    def test_list_page(self, resources):
+        respx.get(_RESOURCES).mock(return_value=httpx.Response(
+            200, json={"results": [_resource(1)], "next": f"{_RESOURCES}?cursor=c9"}))
+        page = resources.list_page()
+        assert isinstance(page.results[0], Resource) and page.next_cursor == "c9"
+
+
+class TestGet:
+    @respx.mock
+    def test_get_typed(self, resources):
+        respx.get(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        r = resources.get("res1")
+        assert isinstance(r, Resource) and r.resource_id == "res1"
+        assert r.type == "SQL" and r.spec == {"tables": []}
+        assert r.handler_type == "SQL" and r.hydration_config == {"default_rows_per_table": 100}
+
+    @respx.mock
+    def test_get_404(self, resources):
+        respx.get(f"{_RESOURCES}/missing").mock(
+            return_value=httpx.Response(404, json={"error": "Specified Resource not found"}))
+        with pytest.raises(NotFoundError):
+            resources.get("missing")
+
+
+class TestCreate:
+    @respx.mock
+    def test_create_with_spec(self, resources):
+        route = respx.post(_RESOURCES).mock(return_value=httpx.Response(201, json=_resource(1)))
+        spec = {"tables": [{"name": "users", "columns": []}]}
+        r = resources.create(type="SQL", tool_name="query_db", name="prod-db",
+                             dialect="POSTGRES", spec=spec)
+        assert isinstance(r, Resource) and r.resource_id == "res1"
+        body = json.loads(route.calls.last.request.read())
+        assert body["type"] == "SQL" and body["tool_name"] == "query_db"
+        assert body["name"] == "prod-db" and body["dialect"] == "POSTGRES"
+        assert body["spec"] == spec and "ddl" not in body
+        # the org is taken from the key server-side — never sent from the client
+        assert "org" not in body and "org_id" not in body
+
+    @respx.mock
+    def test_create_with_ddl_and_optionals(self, resources):
+        route = respx.post(_RESOURCES).mock(return_value=httpx.Response(201, json=_resource(1)))
+        resources.create(type="SQL", tool_name="query_db", name="db2", dialect="POSTGRES",
+                        ddl="CREATE TABLE users (id INT);", description="d",
+                        hydration_config={"default_rows_per_table": 50})
+        body = json.loads(route.calls.last.request.read())
+        assert body["ddl"] == "CREATE TABLE users (id INT);" and "spec" not in body
+        assert body["description"] == "d"
+        assert body["hydration_config"] == {"default_rows_per_table": 50}
+
+    @respx.mock
+    def test_create_duplicate_409(self, resources):
+        respx.post(_RESOURCES).mock(return_value=httpx.Response(
+            409, json={"error": "A resource named 'db2' already exists for this org."}))
+        with pytest.raises(ConflictError):
+            resources.create(type="SQL", tool_name="t", name="db2", dialect="POSTGRES", spec={})
+
+    @respx.mock
+    def test_create_xor_violation_400(self, resources):
+        # Neither spec nor ddl — the SDK forwards and lets the backend enforce the XOR.
+        respx.post(_RESOURCES).mock(return_value=httpx.Response(
+            400, json={"error": "exactly one of ddl or spec is required on create"}))
+        with pytest.raises(ValidationError):
+            resources.create(type="SQL", tool_name="t", name="db3", dialect="POSTGRES")
+
+
+class TestUpdate:
+    @respx.mock
+    def test_update_partial(self, resources):
+        route = respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        r = resources.update("res1", name="renamed", hydration_config={"max_result_rows": 5000})
+        assert isinstance(r, Resource)
+        body = json.loads(route.calls.last.request.read())
+        assert body["name"] == "renamed" and body["hydration_config"] == {"max_result_rows": 5000}
+        # type/dialect are immutable and intentionally absent from the update surface
+        assert "type" not in body and "dialect" not in body
+        assert all(k not in body for k in ("tool_name", "description", "spec", "ddl"))
+
+    @respx.mock
+    def test_update_ddl_reparse(self, resources):
+        route = respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        resources.update("res1", ddl="CREATE TABLE t (id INT);")
+        assert json.loads(route.calls.last.request.read())["ddl"] == "CREATE TABLE t (id INT);"
+
+    @respx.mock
+    def test_update_rename_collision_409(self, resources):
+        respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(
+            409, json={"error": "A resource named 'taken' already exists for this org."}))
+        with pytest.raises(ConflictError):
+            resources.update("res1", name="taken")
+
+
+class TestDelete:
+    @respx.mock
+    def test_delete_204(self, resources):
+        route = respx.delete(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(204))
+        assert resources.delete("res1") is None
+        assert route.called
+
+    @respx.mock
+    def test_delete_in_use_409(self, resources):
+        respx.delete(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(
+            409, json={"error": "detach it from those Datasets first", "dataset_ids": ["d1"]}))
+        with pytest.raises(ConflictError):
+            resources.delete("res1")
+
+    @respx.mock
+    def test_delete_404(self, resources):
+        respx.delete(f"{_RESOURCES}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "Specified Resource not found"}))
+        with pytest.raises(NotFoundError):
+            resources.delete("missing")
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, resources):
+        respx.get(_RESOURCES).mock(side_effect=[
+            httpx.Response(200, json={"results": [_resource(1)], "next": f"{_RESOURCES}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_resource(2)], "next": None}),
+        ])
+        got = [r.resource_id async for r in resources.alist()]
+        assert got == ["res1", "res2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acreate(self, resources):
+        respx.post(_RESOURCES).mock(return_value=httpx.Response(201, json=_resource(1)))
+        r = await resources.acreate(type="SQL", tool_name="t", name="n", dialect="POSTGRES", spec={})
+        assert r.resource_id == "res1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aupdate(self, resources):
+        respx.put(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(200, json=_resource(1)))
+        r = await resources.aupdate("res1", description="d")
+        assert r.resource_id == "res1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_adelete(self, resources):
+        route = respx.delete(f"{_RESOURCES}/res1").mock(return_value=httpx.Response(204))
+        assert await resources.adelete("res1") is None
+        assert route.called

--- a/tests/api/resources/test_sessions_v2.py
+++ b/tests/api/resources/test_sessions_v2.py
@@ -1,5 +1,8 @@
 """LUC-907 — client.sessions v2 reads (list/count/tags, detail+trace,
-evaluator-results, event raw)."""
+evaluator-results, event raw).
+LUC-919 — client.sessions bulk finish."""
+import json
+
 import httpx
 import pytest
 import respx
@@ -13,7 +16,7 @@ from lucidicai.api.models.session import (
     SessionTrace,
 )
 from lucidicai.api.resources.session import SessionResource
-from lucidicai.core.errors import NotFoundError
+from lucidicai.core.errors import InsufficientScopeError, NotFoundError, ValidationError
 
 _BASE = "https://stub.lucidic.test"
 _SESSIONS = f"{_BASE}/sdk/v2/sessions"
@@ -264,3 +267,79 @@ class TestAsync:
             200, json={"event_id": "e1"}))
         ev = await sessions.aevent("s1", "e1")
         assert ev.event_id == "e1"
+
+
+class TestBulkFinish:
+    _FINISH = f"{_SESSIONS}/finish"
+
+    @respx.mock
+    def test_finish_returns_count_and_sends_ids(self, sessions):
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 2}))
+        n = sessions.finish(["s1", "s2", "s3"])
+        assert n == 2
+        body = json.loads(route.calls.last.request.read())
+        assert body["session_ids"] == ["s1", "s2", "s3"]
+        # bulk finish is ownership-scoped server-side — the client sends no agent_id
+        assert "agent_id" not in body
+
+    @respx.mock
+    def test_finish_empty_list_is_zero(self, sessions):
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 0}))
+        assert sessions.finish([]) == 0
+        assert json.loads(route.calls.last.request.read())["session_ids"] == []
+
+    @respx.mock
+    def test_finish_missing_count_defaults_zero(self, sessions):
+        respx.post(self._FINISH).mock(return_value=httpx.Response(200, json={}))
+        assert sessions.finish(["s1"]) == 0
+
+    @respx.mock
+    def test_finish_null_count_degrades_to_zero(self, sessions):
+        # a present-but-null count must not raise int(None)
+        respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": None}))
+        assert sessions.finish(["s1"]) == 0
+
+    @respx.mock
+    def test_finish_bare_string_raises_before_http(self, sessions):
+        # finish("s1") would char-split into single-char ids the backend drops -> a
+        # silent 0. Guard it loudly instead, with no request made.
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 0}))
+        with pytest.raises(TypeError):
+            sessions.finish("s1")
+        assert not route.called
+
+    @respx.mock
+    def test_finish_accepts_any_iterable(self, sessions):
+        # a generator/tuple is materialized into a list before sending
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 1}))
+        sessions.finish((sid for sid in ["s9"]))
+        assert json.loads(route.calls.last.request.read())["session_ids"] == ["s9"]
+
+    @respx.mock
+    def test_finish_not_a_list_400(self, sessions):
+        respx.post(self._FINISH).mock(return_value=httpx.Response(
+            400, json={"error": "session_ids must be a list of session ids"}))
+        # the SDK always sends a list, but a backend 400 surfaces as ValidationError
+        with pytest.raises(ValidationError):
+            sessions.finish(["s1"])
+
+    @respx.mock
+    def test_finish_forbidden_without_write_403(self, sessions):
+        respx.post(self._FINISH).mock(return_value=httpx.Response(
+            403, json={"error": "This API key is not authorized for this action."}))
+        with pytest.raises(InsufficientScopeError):
+            sessions.finish(["s1"])
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afinish(self, sessions):
+        route = respx.post(self._FINISH).mock(
+            return_value=httpx.Response(200, json={"num_sessions_finished": 5}))
+        n = await sessions.afinish(["s1", "s2"])
+        assert n == 5
+        assert json.loads(route.calls.last.request.read())["session_ids"] == ["s1", "s2"]

--- a/tests/api/resources/test_sessions_v2.py
+++ b/tests/api/resources/test_sessions_v2.py
@@ -1,0 +1,266 @@
+"""LUC-907 — client.sessions v2 reads (list/count/tags, detail+trace,
+evaluator-results, event raw)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.session import (
+    EvalResult,
+    Event,
+    EventEval,
+    Session,
+    SessionEvaluatorResults,
+    SessionTrace,
+)
+from lucidicai.api.resources.session import SessionResource
+from lucidicai.core.errors import NotFoundError
+
+_BASE = "https://stub.lucidic.test"
+_SESSIONS = f"{_BASE}/sdk/v2/sessions"
+
+
+@pytest.fixture
+def sessions(http):
+    # v2 reads only use self.http; client/config/production are irrelevant here.
+    return SessionResource(http, client=None, config=None, production=False)
+
+
+def _session(i, **over):
+    d = {
+        "session_id": f"s{i}", "custom_session_id": None, "name": f"run-{i}",
+        "start_time": "2026-07-22T00:00:00Z", "duration": 1.5, "is_finished": True,
+        "production_monitoring": False, "task": None, "cost": 0.01, "tags": ["prod"],
+        "eval_previews": [], "num_events": 3, "status": "finished", "datasetitem_id": None,
+    }
+    d.update(over)
+    return d
+
+
+class TestList:
+    @respx.mock
+    def test_follows_pages_typed(self, sessions):
+        respx.get(_SESSIONS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_session(1), _session(2)],
+                                      "next": f"{_SESSIONS}?cursor=c2", "previous": None}),
+            httpx.Response(200, json={"results": [_session(3)], "next": None}),
+        ])
+        got = list(sessions.list("a1"))
+        assert [s.session_id for s in got] == ["s1", "s2", "s3"]
+        assert all(isinstance(s, Session) for s in got)
+
+    @respx.mock
+    def test_filters_are_normalized(self, sessions):
+        route = respx.get(_SESSIONS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(sessions.list(
+            "a1", experiment_id="e1", production=True, cost="0:10", duration=":5",
+            num_events="1:", tags=["prod", "canary"], status="finished",
+            eval_bool="quality:true", ordering="-start_time", page_size=25,
+        ))
+        p = route.calls.last.request.url.params
+        assert p["agent_id"] == "a1"
+        assert p["experiment_id"] == "e1"
+        assert p["production"] == "true"       # bool -> "true"
+        assert p["cost"] == "0:10"
+        assert p["duration"] == ":5"
+        assert p["num_events"] == "1:"
+        assert p["tags"] == "prod,canary"      # list -> comma
+        assert p["status"] == "finished"
+        assert p["eval_bool"] == "quality:true"
+        assert p["ordering"] == "-start_time"
+        assert p["page_size"] == "25"
+
+    @respx.mock
+    def test_production_false_serialized(self, sessions):
+        route = respx.get(_SESSIONS).mock(
+            return_value=httpx.Response(200, json={"results": [], "next": None}))
+        list(sessions.list("a1", production=False))
+        assert route.calls.last.request.url.params["production"] == "false"
+
+    @respx.mock
+    def test_list_page(self, sessions):
+        respx.get(_SESSIONS).mock(return_value=httpx.Response(
+            200, json={"results": [_session(1)], "next": f"{_SESSIONS}?cursor=c9"}))
+        page = sessions.list_page("a1")
+        assert isinstance(page.results[0], Session) and page.next_cursor == "c9"
+
+
+class TestCountTags:
+    @respx.mock
+    def test_count(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "42"}))
+        assert sessions.count("a1", production=True) == 42
+
+    @respx.mock
+    def test_tags(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(
+            200, headers={"X-Tags": "prod,canary"}))
+        assert sessions.tags("a1") == ["prod", "canary"]
+
+    @respx.mock
+    def test_tags_empty(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(200, headers={"X-Tags": ""}))
+        assert sessions.tags("a1") == []
+
+
+class TestGetTrace:
+    @respx.mock
+    def test_detail_and_tree(self, sessions):
+        body = {
+            "session": _session(1),
+            "events": [
+                {"event_id": "e1", "parent_event_id": None, "occurred_at": "1", "type": "llm"},
+                {"event_id": "e2", "parent_event_id": "e1", "occurred_at": "2", "type": "tool"},
+                {"event_id": "e3", "parent_event_id": "e1", "occurred_at": "3", "type": "tool"},
+            ],
+            "num_events": 3,
+        }
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(200, json=body))
+        trace = sessions.get("s1")
+        assert isinstance(trace, SessionTrace)
+        assert isinstance(trace.session, Session) and trace.session.session_id == "s1"
+        assert trace.num_events == 3
+        assert all(isinstance(e, Event) for e in trace.events)
+        roots = trace.tree()
+        assert [r.event_id for r in roots] == ["e1"]
+        assert [c.event_id for c in roots[0].children] == ["e2", "e3"]
+
+    @respx.mock
+    def test_accepts_custom_session_id(self, sessions):
+        respx.get(f"{_SESSIONS}/my-custom-id").mock(return_value=httpx.Response(
+            200, json={"session": _session(1), "events": [], "num_events": 0}))
+        trace = sessions.get("my-custom-id")
+        assert trace.events == []
+
+    @respx.mock
+    def test_404_raises(self, sessions):
+        respx.get(f"{_SESSIONS}/missing").mock(return_value=httpx.Response(
+            404, json={"error": "not found"}))
+        with pytest.raises(NotFoundError):
+            sessions.get("missing")
+
+    @respx.mock
+    def test_orphan_event_surfaces_as_root(self, sessions):
+        # e2's parent e1 is absent from the returned set (purged/truncated) —
+        # it must surface as a root, not silently vanish from tree().
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(200, json={
+            "session": _session(1),
+            "events": [{"event_id": "e2", "parent_event_id": "e1", "occurred_at": "1"}],
+            "num_events": 1,
+        }))
+        roots = sessions.get("s1").tree()
+        assert [r.event_id for r in roots] == ["e2"]
+
+    @respx.mock
+    def test_self_cycle_event_is_root(self, sessions):
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(200, json={
+            "session": _session(1),
+            "events": [{"event_id": "e1", "parent_event_id": "e1", "occurred_at": "1"}],
+        }))
+        roots = sessions.get("s1").tree()
+        assert [r.event_id for r in roots] == ["e1"]
+        assert roots[0].children == []  # not its own child
+
+    @respx.mock
+    def test_custom_session_id_path_encoded(self, sessions):
+        # A client-supplied custom_session_id with URL-significant chars must be
+        # percent-encoded so it doesn't break routing (false NotFound otherwise).
+        route = respx.route(method="GET").mock(return_value=httpx.Response(
+            200, json={"session": _session(1), "events": [], "num_events": 0}))
+        sessions.get("a/b c")
+        raw = route.calls.last.request.url.raw_path.decode()
+        assert "/sessions/a/b" not in raw   # the raw '/' did not leak
+        assert "a%2Fb" in raw
+
+
+class TestFilterValidation:
+    def test_unknown_filter_raises(self, sessions):
+        # A typo in a **filters method must fail loudly, not silently return the
+        # unfiltered count/tags.
+        with pytest.raises(TypeError):
+            sessions.count("a1", experiment="e1")  # should be experiment_id
+
+
+class TestEvaluatorResults:
+    @respx.mock
+    def test_typed_results(self, sessions):
+        body = {
+            "evals": [{"eval_id": "ev1", "evaluator_name": "quality", "result": 0.9,
+                       "result_type": "number", "is_pending": False}],
+            "event_evals": [{"eval_id": "ee1", "event_id": "e1", "criteria_name": "grounded",
+                             "result": True}],
+        }
+        respx.get(f"{_SESSIONS}/s1/evaluator-results").mock(
+            return_value=httpx.Response(200, json=body))
+        res = sessions.evaluator_results("s1")
+        assert isinstance(res, SessionEvaluatorResults)
+        assert isinstance(res.evals[0], EvalResult) and res.evals[0].evaluator_name == "quality"
+        assert isinstance(res.event_evals[0], EventEval) and res.event_evals[0].event_id == "e1"
+
+    @respx.mock
+    def test_empty_results(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/evaluator-results").mock(return_value=httpx.Response(
+            200, json={"evals": [], "event_evals": []}))
+        res = sessions.evaluator_results("s1")
+        assert res.evals == [] and res.event_evals == []
+
+
+class TestEvent:
+    @respx.mock
+    def test_non_raw_returns_typed_event(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1", "type": "llm", "has_blob": True,
+                       "payload": {"preview": "..."}}))
+        ev = sessions.event("s1", "e1")
+        assert isinstance(ev, Event) and ev.event_id == "e1" and ev.has_blob is True
+
+    @respx.mock
+    def test_raw_true_sends_param_and_returns_blob_url(self, sessions):
+        route = respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1", "type": "llm", "has_blob": True,
+                       "blob_url": "https://s3/presigned?sig=x"}))
+        ev = sessions.event("s1", "e1", raw=True)
+        assert route.calls.last.request.url.params["raw"] == "true"
+        assert ev.blob_url == "https://s3/presigned?sig=x"
+
+    @respx.mock
+    def test_raw_true_inline_payload(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1", "payload": {"full": [1, 2, 3]}}))
+        ev = sessions.event("s1", "e1", raw=True)
+        assert ev.payload == {"full": [1, 2, 3]}
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, sessions):
+        respx.get(f"{_SESSIONS}/s1").mock(return_value=httpx.Response(
+            200, json={"session": _session(1), "events": [], "num_events": 0}))
+        trace = await sessions.aget("s1")
+        assert trace.session.session_id == "s1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alist(self, sessions):
+        respx.get(_SESSIONS).mock(side_effect=[
+            httpx.Response(200, json={"results": [_session(1)], "next": f"{_SESSIONS}?cursor=c2"}),
+            httpx.Response(200, json={"results": [_session(2)], "next": None}),
+        ])
+        got = [s.session_id async for s in sessions.alist("a1")]
+        assert got == ["s1", "s2"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_acount(self, sessions):
+        respx.head(_SESSIONS).mock(return_value=httpx.Response(200, headers={"X-Total-Count": "7"}))
+        assert await sessions.acount("a1") == 7
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aevent(self, sessions):
+        respx.get(f"{_SESSIONS}/s1/events/e1").mock(return_value=httpx.Response(
+            200, json={"event_id": "e1"}))
+        ev = await sessions.aevent("s1", "e1")
+        assert ev.event_id == "e1"

--- a/tests/api/resources/test_usage_v2.py
+++ b/tests/api/resources/test_usage_v2.py
@@ -1,0 +1,54 @@
+"""LUC-911 — client.usage.get (org-aggregated usage counters)."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.models.usage import Usage
+from lucidicai.api.resources.usage import UsageResource
+from lucidicai.core.errors import InsufficientScopeError
+
+_BASE = "https://stub.lucidic.test"
+_USAGE = f"{_BASE}/sdk/v2/usage"
+
+
+@pytest.fixture
+def usage(http):
+    return UsageResource(http)
+
+
+class TestGet:
+    @respx.mock
+    def test_returns_mapping(self, usage):
+        respx.get(_USAGE).mock(return_value=httpx.Response(
+            200, json={"num_sessions": 120, "num_events": 4500, "cost": 3.14}))
+        u = usage.get()
+        assert isinstance(u, Usage)
+        assert u["num_sessions"] == 120
+        assert u.get("cost") == 3.14
+        assert u.get("missing", 0) == 0
+        assert "num_events" in u
+        assert set(u.keys()) == {"num_sessions", "num_events", "cost"}
+        assert dict(u.items()) == u.to_dict()
+        assert len(u) == 3
+
+    @respx.mock
+    def test_empty_map(self, usage):
+        # org-less key -> {} (backend defensive path)
+        respx.get(_USAGE).mock(return_value=httpx.Response(200, json={}))
+        u = usage.get()
+        assert u.to_dict() == {} and len(u) == 0
+
+    @respx.mock
+    def test_missing_scope_raises(self, usage):
+        # Data-bearing read: surfaces the typed error, doesn't swallow.
+        respx.get(_USAGE).mock(return_value=httpx.Response(
+            403, json={"error": "missing scope", "required_scope": "usage:read"}))
+        with pytest.raises(InsufficientScopeError):
+            usage.get()
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_aget(self, usage):
+        respx.get(_USAGE).mock(return_value=httpx.Response(200, json={"num_sessions": 7}))
+        u = await usage.aget()
+        assert u["num_sessions"] == 7

--- a/tests/api/test_agent_id_guard.py
+++ b/tests/api/test_agent_id_guard.py
@@ -7,7 +7,7 @@ production — when it's actually needed but absent.
 import pytest
 
 from lucidicai.api.resources.evaluators import EvaluatorsResource
-from lucidicai.api.resources.evosim import EvoSimResource
+from lucidicai.api.resources.evosim import EvoSimsResource
 from lucidicai.api.resources.experiment import ExperimentResource
 from lucidicai.api.resources.prompt import PromptResource
 from lucidicai.api.resources.session import SessionResource
@@ -58,7 +58,7 @@ class TestIngestionGuard:
 
     def test_evosim_train_raises_even_in_production(self, http):
         # Guard is before the try/except swallow, so production doesn't eat it.
-        res = EvoSimResource(http, agent_id=None, production=True)
+        res = EvoSimsResource(http, agent_id=None, production=True)
         with pytest.raises(AgentIdRequiredError):
             res.train("does-not-matter.json")  # raises before reading the file
 

--- a/tests/api/test_agent_id_guard.py
+++ b/tests/api/test_agent_id_guard.py
@@ -1,0 +1,109 @@
+"""LUC-926 — agent_id optional at construction + AgentIdRequiredError guard.
+
+agent_id is no longer required to build a client (org-/id-scoped work runs
+without one); agent-scoped operations raise a clear, typed error — even in
+production — when it's actually needed but absent.
+"""
+import pytest
+
+from lucidicai.api.resources.evaluators import EvaluatorsResource
+from lucidicai.api.resources.evosim import EvoSimResource
+from lucidicai.api.resources.experiment import ExperimentResource
+from lucidicai.api.resources.prompt import PromptResource
+from lucidicai.api.resources.session import SessionResource
+from lucidicai.core.config import NetworkConfig, SDKConfig
+from lucidicai.core.errors import AgentIdRequiredError, require_agent_id
+from lucidicai.sdk.session import _build_session_params
+
+_BASE = "https://stub.lucidic.test"
+
+
+class _FakeClient:
+    """Minimal stand-in: the write guard fires before any real client use."""
+    is_valid = True
+
+
+class TestValidateRelaxed:
+    def test_no_agent_id_is_valid(self):
+        # api_key alone is a valid config now (LUC-926).
+        assert SDKConfig(api_key="k", agent_id=None).validate() == []
+
+    def test_api_key_still_required(self):
+        errors = SDKConfig(api_key=None, agent_id=None).validate()
+        assert any("API key" in e for e in errors)
+
+
+class TestHelper:
+    def test_returns_when_present(self):
+        assert require_agent_id("a1", "op") == "a1"
+
+    def test_raises_when_absent(self):
+        with pytest.raises(AgentIdRequiredError) as ei:
+            require_agent_id(None, "create_session")
+        assert "create_session" in str(ei.value)
+        assert "agent_id" in str(ei.value)
+
+
+class TestIngestionGuard:
+    def test_build_session_params_requires_agent(self):
+        # Telemetry chokepoint: a session must attach to an agent. This helper
+        # has no production branch, so it raises unconditionally.
+        with pytest.raises(AgentIdRequiredError):
+            _build_session_params(None, "run", None, None, None, None, None, None, False)
+
+    def test_build_session_params_ok_with_agent(self):
+        real_id, params = _build_session_params(
+            None, "run", "a1", None, None, None, None, None, False)
+        assert params["agent_id"] == "a1"
+
+    def test_evosim_train_raises_even_in_production(self, http):
+        # Guard is before the try/except swallow, so production doesn't eat it.
+        res = EvoSimResource(http, agent_id=None, production=True)
+        with pytest.raises(AgentIdRequiredError):
+            res.train("does-not-matter.json")  # raises before reading the file
+
+
+class TestListReadGuards:
+    def test_experiments_list_raises(self, http):
+        with pytest.raises(AgentIdRequiredError):
+            ExperimentResource(http, agent_id=None).list()
+
+    def test_evaluators_list_raises(self, http):
+        with pytest.raises(AgentIdRequiredError):
+            EvaluatorsResource(http, agent_id=None).list()
+
+    def test_prompts_list_raises(self, http):
+        cfg = SDKConfig(api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE))
+        with pytest.raises(AgentIdRequiredError):
+            PromptResource(http, cfg).list()
+
+    def test_prompts_labels_raises(self, http):
+        cfg = SDKConfig(api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE))
+        with pytest.raises(AgentIdRequiredError):
+            PromptResource(http, cfg).labels()
+
+    def test_explicit_agent_id_bypasses_guard(self, http):
+        # Passing agent_id explicitly is fine even with no configured agent —
+        # the resolver never reaches the guard (no HTTP asserted; just no raise).
+        import respx
+        import httpx
+        with respx.mock:
+            respx.get(f"{_BASE}/sdk/v2/experiments").mock(
+                return_value=httpx.Response(200, json={"results": [], "next": None}))
+            assert list(ExperimentResource(http, agent_id=None).list("a2")) == []
+
+
+class TestWriteGuards:
+    """The write chokepoints (the live public telemetry / provisioning paths)
+    must raise BEFORE their production error-swallow, not silently no-op."""
+
+    def test_session_create_raises_even_in_production(self, http):
+        cfg = SDKConfig(api_key="k", agent_id=None, network=NetworkConfig(base_url=_BASE))
+        res = SessionResource(http, client=_FakeClient(), config=cfg, production=True)
+        with pytest.raises(AgentIdRequiredError):
+            res.create(session_name="x")
+
+    def test_experiment_create_raises_even_in_production(self, http):
+        res = ExperimentResource(http, agent_id=None, production=True)
+        with pytest.raises(AgentIdRequiredError):
+            res.create("my-exp")

--- a/tests/api/test_downloads.py
+++ b/tests/api/test_downloads.py
@@ -1,0 +1,35 @@
+"""LUC-904 — presigned-URL GET fetch-through."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.api.downloads import afetch_presigned, fetch_presigned
+
+_PRESIGNED = "https://s3.example.com/bucket/key?X-Amz-Signature=deadbeef"
+
+
+class TestFetchPresigned:
+    @respx.mock
+    def test_returns_bytes(self):
+        respx.get(_PRESIGNED).mock(return_value=httpx.Response(200, content=b"blob-bytes"))
+        assert fetch_presigned(_PRESIGNED) == b"blob-bytes"
+
+    @respx.mock
+    def test_no_auth_header_sent(self):
+        # Presigned download bypasses the authed HttpClient — S3 needs no
+        # Lucidic Authorization header.
+        route = respx.get(_PRESIGNED).mock(return_value=httpx.Response(200, content=b"x"))
+        fetch_presigned(_PRESIGNED)
+        assert "Authorization" not in route.calls.last.request.headers
+
+    @respx.mock
+    def test_expired_url_raises(self):
+        respx.get(_PRESIGNED).mock(return_value=httpx.Response(403, text="expired"))
+        with pytest.raises(httpx.HTTPStatusError):
+            fetch_presigned(_PRESIGNED)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_afetch_returns_bytes(self):
+        respx.get(_PRESIGNED).mock(return_value=httpx.Response(200, content=b"async-blob"))
+        assert await afetch_presigned(_PRESIGNED) == b"async-blob"

--- a/tests/api/test_head.py
+++ b/tests/api/test_head.py
@@ -1,0 +1,48 @@
+"""LUC-903 — HEAD count/tags helpers."""
+import httpx
+import pytest
+import respx
+
+from lucidicai.core.errors import NotFoundError
+
+_URL = "https://stub.lucidic.test/sdk/v2/sessions"
+
+
+class TestHead:
+    @respx.mock
+    def test_returns_headers(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "42", "X-Tags": "prod,canary"}))
+        headers = http.head("sdk/v2/sessions")
+        assert headers["X-Total-Count"] == "42"
+        assert headers["X-Tags"] == "prod,canary"
+
+    @respx.mock
+    def test_case_insensitive(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "7"}))
+        headers = http.head("sdk/v2/sessions")
+        assert headers["x-total-count"] == "7"
+
+    @respx.mock
+    def test_forwards_filter_params(self, http):
+        route = respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "3"}))
+        http.head("sdk/v2/sessions", {"production": "true", "agent_id": "a1"})
+        sent = route.calls.last.request
+        assert sent.url.params["production"] == "true"
+        assert sent.url.params["agent_id"] == "a1"
+
+    @respx.mock
+    def test_error_raises_typed(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(404))
+        with pytest.raises(NotFoundError):
+            http.head("sdk/v2/sessions")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_ahead_returns_headers(self, http):
+        respx.head(_URL).mock(return_value=httpx.Response(
+            200, headers={"X-Total-Count": "9"}))
+        headers = await http.ahead("sdk/v2/sessions")
+        assert headers["X-Total-Count"] == "9"

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,6 +1,6 @@
 """LUC-905 — typed response-model base."""
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -12,6 +12,13 @@ class _Agent(APIModel):
     agent_id: str
     name: Optional[str] = None
     tags: Optional[List[str]] = None
+
+
+@dataclass
+class _WithLists(APIModel):
+    id: str
+    tags: List[str] = field(default_factory=list)
+    meta: Dict[str, Any] = field(default_factory=dict)
 
 
 class TestFromDict:
@@ -42,6 +49,30 @@ class TestFromDict:
     def test_extra_defaults_empty(self):
         a = _Agent.from_dict({"agent_id": "a1"})
         assert a.extra == {}
+
+
+class TestNullNormalization:
+    """A backend `null` for a field with a default must not stick as None —
+    it should fall back to the default (e.g. [] / {}), so downstream
+    iteration stays safe. This is the reference behavior every model relies on."""
+
+    def test_null_list_becomes_empty(self):
+        m = _WithLists.from_dict({"id": "1", "tags": None, "meta": None})
+        assert m.tags == []
+        assert m.meta == {}
+
+    def test_absent_list_uses_default(self):
+        m = _WithLists.from_dict({"id": "1"})
+        assert m.tags == [] and m.meta == {}
+
+    def test_present_list_preserved(self):
+        m = _WithLists.from_dict({"id": "1", "tags": ["a", "b"]})
+        assert m.tags == ["a", "b"]
+
+    def test_null_optional_stays_none(self):
+        # An Optional[...] = None field: null is the correct value, unchanged.
+        a = _Agent.from_dict({"agent_id": "a1", "name": None})
+        assert a.name is None
 
 
 class TestFromList:

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,0 +1,59 @@
+"""LUC-905 — typed response-model base."""
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytest
+
+from lucidicai.api.models.base import APIModel
+
+
+@dataclass
+class _Agent(APIModel):
+    agent_id: str
+    name: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+
+class TestFromDict:
+    def test_maps_known_fields(self):
+        a = _Agent.from_dict({"agent_id": "a1", "name": "bot", "tags": ["x"]})
+        assert a.agent_id == "a1"
+        assert a.name == "bot"
+        assert a.tags == ["x"]
+
+    def test_unknown_fields_go_to_extra(self):
+        a = _Agent.from_dict({"agent_id": "a1", "created_at": "2026", "future_flag": True})
+        assert a.extra == {"created_at": "2026", "future_flag": True}
+        # ...and don't blow up construction (forward-compat).
+        assert a.agent_id == "a1"
+
+    def test_missing_optional_uses_default(self):
+        a = _Agent.from_dict({"agent_id": "a1"})
+        assert a.name is None and a.tags is None
+
+    def test_missing_required_raises(self):
+        with pytest.raises(TypeError):
+            _Agent.from_dict({"name": "no-id"})
+
+    def test_non_dict_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            _Agent.from_dict(["not", "a", "dict"])
+
+    def test_extra_defaults_empty(self):
+        a = _Agent.from_dict({"agent_id": "a1"})
+        assert a.extra == {}
+
+
+class TestFromList:
+    def test_builds_list(self):
+        items = _Agent.from_list([{"agent_id": "1"}, {"agent_id": "2", "name": "b"}])
+        assert [i.agent_id for i in items] == ["1", "2"]
+        assert items[1].name == "b"
+
+
+class TestToDict:
+    def test_excludes_extra(self):
+        a = _Agent.from_dict({"agent_id": "a1", "name": "bot", "unknown": 9})
+        d = a.to_dict()
+        assert d == {"agent_id": "a1", "name": "bot", "tags": None}
+        assert "unknown" not in d

--- a/tests/api/test_pagination.py
+++ b/tests/api/test_pagination.py
@@ -1,0 +1,102 @@
+"""LUC-902 — cursor-pagination lazy iterator."""
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from lucidicai.api.models.base import APIModel, CursorPage, _extract_cursor
+from lucidicai.api.pagination import apaginate, paginate
+
+
+@dataclass
+class _Item(APIModel):
+    id: str
+    name: Optional[str] = None
+
+
+def _page(results, next_cursor):
+    nxt = f"https://stub.lucidic.test/things?cursor={next_cursor}" if next_cursor else None
+    return {"results": results, "next": nxt, "previous": None}
+
+
+class TestExtractCursor:
+    def test_pulls_cursor_param(self):
+        assert _extract_cursor("https://x/things?cursor=abc123&page_size=50") == "abc123"
+
+    def test_none_when_no_next(self):
+        assert _extract_cursor(None) is None
+
+    def test_none_when_no_cursor_param(self):
+        assert _extract_cursor("https://x/things?page_size=50") is None
+
+
+class TestPaginate:
+    def test_follows_next_across_pages(self):
+        pages = {
+            None: _page([{"id": "1"}, {"id": "2"}], "c1"),
+            "c1": _page([{"id": "3"}], "c2"),
+            "c2": _page([{"id": "4"}], None),
+        }
+        seen_cursors = []
+
+        def fetch(cursor):
+            seen_cursors.append(cursor)
+            return pages[cursor]
+
+        ids = [item.id for item in paginate(fetch, model=_Item)]
+        assert ids == ["1", "2", "3", "4"]
+        assert seen_cursors == [None, "c1", "c2"]
+
+    def test_single_page_stops(self):
+        calls = []
+
+        def fetch(cursor):
+            calls.append(cursor)
+            return _page([{"id": "only"}], None)
+
+        items = list(paginate(fetch, model=_Item))
+        assert len(items) == 1 and items[0].id == "only"
+        assert calls == [None]  # no second request
+
+    def test_raw_dicts_when_no_model(self):
+        def fetch(cursor):
+            return _page([{"id": "1"}], None)
+
+        items = list(paginate(fetch))
+        assert items == [{"id": "1"}]
+
+    def test_empty_results(self):
+        def fetch(cursor):
+            return {"results": [], "next": None}
+
+        assert list(paginate(fetch, model=_Item)) == []
+
+
+class TestCursorPage:
+    def test_from_body_typed(self):
+        page = CursorPage.from_body(_page([{"id": "1"}], "next-cur"), model=_Item)
+        assert isinstance(page.results[0], _Item)
+        assert page.next_cursor == "next-cur"
+        assert page.previous_cursor is None
+        assert page.has_next is True
+
+    def test_from_body_last_page(self):
+        page = CursorPage.from_body(_page([{"id": "1"}], None), model=_Item)
+        assert page.has_next is False
+
+
+class TestAsyncPaginate:
+    @pytest.mark.asyncio
+    async def test_apaginate_follows_next(self):
+        pages = {
+            None: _page([{"id": "1"}], "c1"),
+            "c1": _page([{"id": "2"}], None),
+        }
+
+        async def fetch(cursor):
+            return pages[cursor]
+
+        got = []
+        async for item in apaginate(fetch, model=_Item):
+            got.append(item.id)
+        assert got == ["1", "2"]

--- a/tests/api/test_polling.py
+++ b/tests/api/test_polling.py
@@ -1,0 +1,108 @@
+"""LUC-920 — the generic wait_for / await_for poll primitive."""
+import pytest
+
+from lucidicai.api.polling import await_for, wait_for
+from lucidicai.core.errors import LucidicError, WaitTimeout
+
+
+def _terminal(state):
+    return state == "done"
+
+
+class TestWaitForSync:
+    def test_returns_initial_without_polling_when_already_terminal(self):
+        def poll():
+            raise AssertionError("poll must not run when initial is terminal")
+        assert wait_for(poll, is_terminal=_terminal, timeout=5, interval=0,
+                        initial="done") == "done"
+
+    def test_polls_until_terminal(self):
+        states = iter(["running", "running", "done"])
+        calls = {"n": 0}
+
+        def poll():
+            calls["n"] += 1
+            return next(states)
+
+        # no initial -> poll() supplies the first state too
+        assert wait_for(poll, is_terminal=_terminal, timeout=5, interval=0) == "done"
+        assert calls["n"] == 3
+
+    def test_initial_supplied_skips_first_poll(self):
+        states = iter(["done"])
+        calls = {"n": 0}
+
+        def poll():
+            calls["n"] += 1
+            return next(states)
+
+        # initial is non-terminal, so exactly one poll is needed to reach "done"
+        assert wait_for(poll, is_terminal=_terminal, timeout=5, interval=0,
+                        initial="running") == "done"
+        assert calls["n"] == 1
+
+    def test_timeout_raises_with_last_state_and_budget(self):
+        def poll():
+            return "running"  # never terminal
+
+        with pytest.raises(WaitTimeout) as exc:
+            wait_for(poll, is_terminal=_terminal, timeout=0, interval=0, initial="running")
+        assert exc.value.last_state == "running"
+        assert exc.value.timeout == 0
+        assert isinstance(exc.value, LucidicError)  # catchable as a LucidicError
+
+    def test_timeout_last_state_is_most_recent_poll(self):
+        # no initial: the first poll runs, then the deadline (0) trips
+        def poll():
+            return "step-1"
+
+        with pytest.raises(WaitTimeout) as exc:
+            wait_for(poll, is_terminal=_terminal, timeout=0, interval=0)
+        assert exc.value.last_state == "step-1"
+
+    def test_negative_timeout_clamps_reported_budget_to_zero(self):
+        # a misused negative timeout raises immediately AND reports a sane budget
+        # (not "within -5s") — the deadline is clamped, so is the WaitTimeout.
+        def poll():
+            return "running"
+        with pytest.raises(WaitTimeout) as exc:
+            wait_for(poll, is_terminal=_terminal, timeout=-5, interval=0, initial="running")
+        assert exc.value.timeout == 0
+        assert "-5" not in str(exc.value)
+
+    def test_falsy_initial_state_is_honored_not_treated_as_unset(self):
+        # initial=None must NOT trigger a first poll (None != the _UNSET sentinel)
+        def poll():
+            raise AssertionError("poll must not run for a terminal None initial")
+        assert wait_for(poll, is_terminal=lambda s: s is None, timeout=5, interval=0,
+                        initial=None) is None
+
+
+class TestAwaitForAsync:
+    @pytest.mark.asyncio
+    async def test_returns_initial_when_terminal(self):
+        async def poll():
+            raise AssertionError("poll must not run when initial is terminal")
+        assert await await_for(poll, is_terminal=_terminal, timeout=5, interval=0,
+                               initial="done") == "done"
+
+    @pytest.mark.asyncio
+    async def test_polls_until_terminal(self):
+        states = iter(["running", "done"])
+        calls = {"n": 0}
+
+        async def poll():
+            calls["n"] += 1
+            return next(states)
+
+        assert await await_for(poll, is_terminal=_terminal, timeout=5, interval=0) == "done"
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises(self):
+        async def poll():
+            return "running"
+
+        with pytest.raises(WaitTimeout) as exc:
+            await await_for(poll, is_terminal=_terminal, timeout=0, interval=0, initial="running")
+        assert exc.value.last_state == "running"

--- a/tests/api/test_transport_errors.py
+++ b/tests/api/test_transport_errors.py
@@ -1,0 +1,145 @@
+"""LUC-900 — central error-envelope decode + typed exception hierarchy.
+
+Backend is mocked via respx at the HTTP boundary so we exercise the real
+``HttpClient._handle_response`` → ``exception_from_response`` path and assert
+each envelope/status maps to the right typed ``LucidicError`` subclass.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.core.errors import (
+    APIError,
+    APIKeyVerificationError,
+    AuthError,
+    ConflictError,
+    exception_from_response,
+    InsufficientScopeError,
+    LucidicError,
+    LucidicUnknownToolError,
+    NotFoundError,
+    RateLimitError,
+    ServiceUnavailableError,
+    ValidationError,
+)
+
+_URL = "https://stub.lucidic.test/agents"
+
+
+def _mock(status, json=None, text=None, headers=None):
+    if json is not None:
+        return httpx.Response(status, json=json, headers=headers or {})
+    return httpx.Response(status, text=text or "", headers=headers or {})
+
+
+class TestTypedDecode:
+    @respx.mock
+    def test_400_error_string_is_validation_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(400, {"error": "bad input"}))
+        with pytest.raises(ValidationError) as ei:
+            http.get("agents")
+        assert str(ei.value) == "bad input"
+        assert ei.value.status_code == 400
+
+    @respx.mock
+    def test_400_validation_envelope_carries_details(self, http):
+        respx.get(_URL).mock(return_value=_mock(
+            400, {"error": "Validation failed", "details": {"name": ["required"]}}))
+        with pytest.raises(ValidationError) as ei:
+            http.get("agents")
+        assert ei.value.details == {"name": ["required"]}
+
+    @respx.mock
+    def test_422_errors_dict_is_validation_error_with_details(self, http):
+        respx.get(_URL).mock(return_value=_mock(
+            422, {"errors": {"tools": ["bad source_hash"]}}))
+        with pytest.raises(ValidationError) as ei:
+            http.get("agents")
+        assert ei.value.details == {"tools": ["bad source_hash"]}
+
+    @respx.mock
+    def test_401_is_api_key_verification_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(401, {"detail": "no key"}))
+        with pytest.raises(APIKeyVerificationError) as ei:
+            http.get("agents")
+        # Still an AuthError so `except AuthError` works.
+        assert isinstance(ei.value, AuthError)
+
+    @respx.mock
+    def test_403_is_insufficient_scope_and_names_scope(self, http):
+        respx.get(_URL).mock(return_value=_mock(
+            403, {"error": "missing scope", "required_scope": "agent:read"}))
+        with pytest.raises(InsufficientScopeError) as ei:
+            http.get("agents")
+        assert ei.value.required_scope == "agent:read"
+
+    @respx.mock
+    def test_404_is_not_found(self, http):
+        respx.get(_URL).mock(return_value=_mock(404, {"error": "gone"}))
+        with pytest.raises(NotFoundError):
+            http.get("agents")
+
+    @respx.mock
+    def test_409_is_conflict(self, http):
+        respx.get(_URL).mock(return_value=_mock(409, {"error": "duplicate"}))
+        with pytest.raises(ConflictError):
+            http.get("agents")
+
+    @respx.mock
+    def test_500_json_is_generic_api_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(500, {"detail": "boom"}))
+        with pytest.raises(APIError) as ei:
+            http.get("agents")
+        assert ei.value.status_code == 500
+        assert str(ei.value) == "boom"
+
+    @respx.mock
+    def test_non_json_body_is_api_error_with_text(self, http):
+        respx.get(_URL).mock(return_value=_mock(500, text="<html>500</html>"))
+        with pytest.raises(APIError) as ei:
+            http.get("agents")
+        assert ei.value.response_text == "<html>500</html>"
+
+    @respx.mock
+    def test_mock_call_code_family_still_produced_centrally(self, http):
+        # A `{"error": {"code"}}` body maps to the mock-call typed family even
+        # from a generic endpoint — the family is keyed by shape, not path.
+        respx.get(_URL).mock(return_value=_mock(
+            404, {"error": {"code": "unknown_tool", "detail": "no tool"}}))
+        with pytest.raises(LucidicUnknownToolError):
+            http.get("agents")
+
+    @respx.mock
+    def test_every_typed_error_is_a_lucidic_error(self, http):
+        respx.get(_URL).mock(return_value=_mock(404, {"error": "x"}))
+        with pytest.raises(LucidicError):
+            http.get("agents")
+
+
+class TestDecoderUnit:
+    """Direct unit coverage of exception_from_response for the statuses the
+    transport retries (429/503), which the HttpClient path would retry first."""
+
+    def test_429_maps_to_rate_limit(self):
+        exc = exception_from_response(429, {"error": "slow down"}, retry_after=1.5)
+        assert isinstance(exc, RateLimitError)
+        assert exc.retry_after == 1.5
+
+    def test_503_maps_to_service_unavailable(self):
+        exc = exception_from_response(503, {"error": "degraded"}, retry_after=2.0)
+        assert isinstance(exc, ServiceUnavailableError)
+        assert exc.retry_after == 2.0
+
+    def test_unmapped_status_is_api_error(self):
+        exc = exception_from_response(418, {"error": "teapot"})
+        assert type(exc) is APIError
+        assert exc.status_code == 418
+
+
+class TestAsyncDecode:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_path_raises_typed(self, http):
+        respx.get(_URL).mock(return_value=_mock(404, {"error": "gone"}))
+        with pytest.raises(NotFoundError):
+            await http.aget("agents")

--- a/tests/api/test_transport_retry.py
+++ b/tests/api/test_transport_retry.py
@@ -1,0 +1,137 @@
+"""LUC-901 — 429/503 retry + backoff + Retry-After.
+
+Retry sleeps are patched out (and recorded) so the tests assert the retry
+count and computed delays without actually waiting.
+"""
+import httpx
+import pytest
+import respx
+
+from lucidicai.core.errors import NotFoundError, ServiceUnavailableError
+
+
+@pytest.fixture
+def sleeps(monkeypatch):
+    """Record + skip sync retry sleeps."""
+    recorded = []
+    monkeypatch.setattr("lucidicai.api.client.time.sleep", lambda s: recorded.append(s))
+    return recorded
+
+
+@pytest.fixture
+def asleeps(monkeypatch):
+    """Record + skip async retry sleeps."""
+    recorded = []
+
+    async def _fake(s):
+        recorded.append(s)
+
+    monkeypatch.setattr("lucidicai.api.client.asyncio.sleep", _fake)
+    return recorded
+
+
+_URL = "https://stub.lucidic.test/agents"
+
+
+class TestRetry:
+    @respx.mock
+    def test_503_then_success_is_retried(self, http, sleeps):
+        route = respx.get(_URL).mock(side_effect=[
+            httpx.Response(503, json={"error": "degraded"}),
+            httpx.Response(200, json={"ok": True}),
+        ])
+        assert http.get("agents") == {"ok": True}
+        assert route.call_count == 2
+        # First backoff = backoff_factor * 2**0 = 0.01.
+        assert sleeps == [pytest.approx(0.01)]
+
+    @respx.mock
+    def test_exponential_backoff_across_two_retries(self, http, sleeps):
+        route = respx.get(_URL).mock(side_effect=[
+            httpx.Response(503),
+            httpx.Response(503),
+            httpx.Response(200, json={"ok": 1}),
+        ])
+        http.get("agents")
+        assert route.call_count == 3
+        assert sleeps == [pytest.approx(0.01), pytest.approx(0.02)]
+
+    @respx.mock
+    def test_retry_after_header_overrides_backoff(self, http, sleeps):
+        respx.get(_URL).mock(side_effect=[
+            httpx.Response(429, headers={"Retry-After": "2"}),
+            httpx.Response(200, json={"ok": 1}),
+        ])
+        http.get("agents")
+        assert sleeps == [pytest.approx(2.0)]
+
+    @respx.mock
+    def test_exhausts_retries_then_raises_typed(self, http, sleeps):
+        # max_retries=3 -> 1 initial + 3 retries = 4 attempts, all 503.
+        route = respx.get(_URL).mock(return_value=httpx.Response(503, json={"error": "down"}))
+        with pytest.raises(ServiceUnavailableError):
+            http.get("agents")
+        assert route.call_count == 4
+        assert len(sleeps) == 3
+
+    @respx.mock
+    def test_non_retryable_status_not_retried(self, http, sleeps):
+        route = respx.get(_URL).mock(return_value=httpx.Response(404, json={"error": "x"}))
+        with pytest.raises(NotFoundError):
+            http.get("agents")
+        assert route.call_count == 1
+        assert sleeps == []
+
+    @respx.mock
+    def test_post_not_retried_may_have_committed(self, http, sleeps):
+        # A POST may have committed a write before the 503 (e.g. the EvoSim
+        # kickoff commits the run row, then 503s), so it must NOT be retried —
+        # retrying would duplicate. Fails fast, like pre-C0.
+        route = respx.post("https://stub.lucidic.test/sdk/thing").mock(
+            return_value=httpx.Response(503, json={"error": "down"}))
+        with pytest.raises(ServiceUnavailableError):
+            http.post("sdk/thing", {"a": 1})
+        assert route.call_count == 1
+        assert sleeps == []
+
+    @respx.mock
+    def test_put_is_retried(self, http, sleeps):
+        # PUT is idempotent -> safe to replay.
+        route = respx.put("https://stub.lucidic.test/sdk/thing").mock(side_effect=[
+            httpx.Response(503),
+            httpx.Response(200, json={"ok": True}),
+        ])
+        assert http.put("sdk/thing", {"a": 1})["ok"] is True
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_retry_after_is_capped(self, http, sleeps):
+        # A huge / proxy-injected Retry-After is clamped so it can't pin the
+        # caller thread for minutes (_MAX_RETRY_DELAY_SECONDS = 30).
+        respx.get(_URL).mock(side_effect=[
+            httpx.Response(503, headers={"Retry-After": "3600"}),
+            httpx.Response(200, json={"ok": 1}),
+        ])
+        http.get("agents")
+        assert sleeps == [pytest.approx(30.0)]
+
+
+class TestAsyncRetry:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_503_then_success(self, http, asleeps):
+        route = respx.get(_URL).mock(side_effect=[
+            httpx.Response(503),
+            httpx.Response(200, json={"ok": True}),
+        ])
+        assert await http.aget("agents") == {"ok": True}
+        assert route.call_count == 2
+        assert asleeps == [pytest.approx(0.01)]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_exhausts_and_raises(self, http, asleeps):
+        route = respx.get(_URL).mock(return_value=httpx.Response(503))
+        with pytest.raises(ServiceUnavailableError):
+            await http.aget("agents")
+        assert route.call_count == 4

--- a/tests/sdk/test_training_modules_poll.py
+++ b/tests/sdk/test_training_modules_poll.py
@@ -1,0 +1,107 @@
+"""Characterization tests for TrainingModulesResource's inference poll loop.
+
+These pin the observable behavior of ``_poll_to_tool_result`` /
+``_apoll_to_tool_result`` (terminal mapping, SDK timeout, malformed-response and
+poll-error soft failures, poll progression) so the LUC-920 refactor onto the
+generic ``wait_for`` primitive provably changes no behavior.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from lucidicai.sdk.training_modules.resource import TrainingModulesResource
+
+
+@pytest.fixture
+def tm():
+    # A MagicMock client is enough — we drive _api directly per test.
+    resource = TrainingModulesResource(client=MagicMock())
+    resource._api = MagicMock()
+    return resource
+
+
+def _run(status, **over):
+    d = {"status": status, "inference_run_id": "ir1", "tool_name": "t", "session_id": "sess"}
+    d.update(over)
+    return d
+
+
+def _poll(tm, run, *, timeout=5.0, interval=0.001):
+    return tm._poll_to_tool_result(
+        run, session_id="sess", timeout_seconds=timeout, poll_interval_seconds=interval)
+
+
+class TestTerminalMapping:
+    def test_initial_succeeded_unwraps_return_value(self, tm):
+        out = _poll(tm, _run("SUCCEEDED", result={"return_value": 42}))
+        assert out == 42
+        tm._api.get_inference.assert_not_called()  # already terminal, no poll
+
+    def test_succeeded_without_return_value_returns_result(self, tm):
+        out = _poll(tm, _run("SUCCEEDED", result={"other": "x"}))
+        assert out == {"other": "x"}
+
+    def test_failed_is_soft_failure(self, tm):
+        out = _poll(tm, _run("FAILED", error={"code": "x", "message": "bad"}))
+        assert out["error"]["message"] == "bad"
+
+    def test_timed_out_maps_to_code(self, tm):
+        out = _poll(tm, _run("TIMED_OUT"))
+        assert out["error"]["code"] == "training_module_inference_timed_out"
+
+    def test_cancelled_maps_to_code(self, tm):
+        out = _poll(tm, _run("CANCELLED"))
+        assert out["error"]["code"] == "training_module_inference_cancelled"
+
+    def test_unknown_terminal_status_maps_to_code(self, tm):
+        out = _poll(tm, _run("WEIRD"))
+        assert out["error"]["code"] == "training_module_inference_unknown_status"
+
+
+class TestPollProgression:
+    def test_polls_running_until_succeeded(self, tm):
+        tm._api.get_inference.side_effect = [
+            _run("RUNNING"), _run("SUCCEEDED", result={"return_value": "ok"})]
+        out = _poll(tm, _run("RUNNING"))
+        assert out == "ok"
+        assert tm._api.get_inference.call_count == 2
+
+    def test_poll_passes_inference_run_id_and_session(self, tm):
+        tm._api.get_inference.side_effect = [_run("SUCCEEDED", result={"return_value": 1})]
+        _poll(tm, _run("RUNNING", inference_run_id="ir-42"))
+        tm._api.get_inference.assert_called_once_with(inference_run_id="ir-42", session_id="sess")
+
+
+class TestFailurePaths:
+    def test_sdk_timeout_before_first_poll(self, tm):
+        out = _poll(tm, _run("RUNNING"), timeout=0)
+        assert out["error"]["code"] == "training_module_sdk_timeout"
+        tm._api.get_inference.assert_not_called()
+
+    def test_missing_inference_run_id_is_malformed(self, tm):
+        out = _poll(tm, _run("RUNNING", inference_run_id=None))
+        assert out["error"]["code"] == "training_module_malformed_response"
+        tm._api.get_inference.assert_not_called()  # never fetches without an id
+
+    def test_poll_exception_is_soft_failure(self, tm):
+        tm._api.get_inference.side_effect = RuntimeError("boom")
+        out = _poll(tm, _run("RUNNING"))
+        assert out["error"]["code"] == "training_module_poll_failed"
+        assert "boom" in out["error"]["message"]
+
+
+class TestAsyncParity:
+    @pytest.mark.asyncio
+    async def test_apoll_running_until_succeeded(self, tm):
+        async def _aget(*, inference_run_id, session_id):
+            return _run("SUCCEEDED", result={"return_value": "async-ok"})
+        tm._api.aget_inference = _aget
+        out = await tm._apoll_to_tool_result(
+            _run("RUNNING"), session_id="sess", timeout_seconds=5.0, poll_interval_seconds=0.001)
+        assert out == "async-ok"
+
+    @pytest.mark.asyncio
+    async def test_apoll_sdk_timeout(self, tm):
+        out = await tm._apoll_to_tool_result(
+            _run("RUNNING"), session_id="sess", timeout_seconds=0, poll_interval_seconds=0.001)
+        assert out["error"]["code"] == "training_module_sdk_timeout"


### PR DESCRIPTION
Ships the **SDK-First Parity — Python Client** project: `client.*` is now a full programmatic alternative to the dashboard, spanning reads, writes/lifecycle, async workflows, and EvoSim/training-module management. Additive — the gen-3 methods are preserved — but the scope of the new surface warrants the **4.0.0** major bump.

**Note:** merge the version-bump PR #97 into this branch first so this PR ships as 4.0.0 (it's currently 3.7.2 until #97 lands).

## What's new (by namespace)
- **Transport (C0):** typed `LucidicError` hierarchy + central decoder, idempotent-gated 429/503 retry, cursor pagination + lazy iterators, typed `APIModel` base, `require_agent_id` guard (agent_id optional at construction), presigned downloads.
- **Reads (C1):** `client.agents` / `sessions` (v2 list/detail/trace/events) / `experiments` / `prompts` / `evaluators` + `evaluator_results` / `usage`.
- **Writes & lifecycle (C2):** agents, projects, prompts (incl. `create` — with the backend endpoint LUC-931), experiments (delete + `evaluators` sub-namespace), evaluators (LLM create/update/delete), `resources` (SQL-substrate CRUD), datasets v2 (items / `schemas` / `fixtures`), sessions bulk-finish.
- **Async workflows (C3):** a generic `wait_for` / `await_for` poll primitive (`WaitTimeout`), dataset **generation** (`generate` / `status` / `retry` / `wait_for`), and experiment **taxonomy** + **failure-modes**.
- **EvoSim & training modules (C4):** `client.evosims` run management — `list` / `get` / `cancel` / `iteration_instances` / `wait_for` (and the `EvoSimResource` → `EvoSimsResource` rename).

Every method has a sync + `a`-prefixed async sibling; data-bearing reads/writes surface typed transport errors (no production swallow), while the grandfathered telemetry paths keep their swallow behavior.

## Milestone sub-PRs merged into this branch
- **C0 transport:** #76
- **C1 reads:** #77 agents · #78 sessions · #79 experiments · #80 prompts · #81 evaluators + results · #82 usage
- **agent_id optional (LUC-926):** #83
- **C2 writes:** #84 agents · #85 projects · #86 prompts (+create) · #87 experiments · #88 evaluators · #89 resources · #90 datasets v2 · #91 sessions bulk-finish
- **C3 async:** #92 wait_for helper · #93 dataset generation · #94 taxonomy/failure-modes
- **C4 evosims:** #95
- **Docs/release:** #96 delete-retry caveat · #97 version bump (4.0.0)

## Quality
Each ticket shipped as its own PR, verified with a two-lens adversarial workflow — a code-skeptic pass plus a backend-contract-conformance check against the merged `sdk-first-platform-parity` backend (fresh ref each time). ~558 hermetic tests pass.