### PR TITLE
LUC-941: fix EventBuilder strict path dropping parent-linking + client_event_id

### DIFF
--- a/lucidicai/sdk/event_builder.py
+++ b/lucidicai/sdk/event_builder.py
@@ -62,9 +62,17 @@ class EventBuilder:
         Returns:
             Normalized event request dictionary
         """
-        # check if already in strict format
+        # check if already in strict format (caller supplied a `payload` dict)
         if cls._is_strict_format(params):
-            return params
+            # Still translate the identity/base fields to the wire names the backend
+            # reads (event_id -> client_event_id, parent_event_id -> client_parent_event_id,
+            # + session_id/occurred_at/duration/tags/metadata), then attach the caller's
+            # payload verbatim. Without this the strict path drops parent-linking and
+            # idempotency dedup (LUC-941).
+            base = cls._extract_base_params(params)
+            base['type'] = params.get('type', 'generic')
+            base['payload'] = params['payload']
+            return base
         
         # normalize field names
         normalized = cls._normalize_fields(params)

--- a/tests/test_event_builder.py
+++ b/tests/test_event_builder.py
@@ -1,0 +1,71 @@
+"""EventBuilder.build strict-format regression (LUC-941).
+
+A caller-supplied `payload` dict (strict format) must still map the identity fields to
+the backend wire names (client_event_id / client_parent_event_id). Previously the strict
+path returned params verbatim, so event_id/parent_event_id never became client_*,
+dropping parent-linking and idempotency dedup.
+"""
+from lucidicai.sdk.event_builder import EventBuilder
+
+
+def _public_params(**over):
+    p = {
+        "type": "generic",
+        "event_id": "ev-1",
+        "parent_event_id": "ev-parent",
+        "session_id": "sess-1",
+        "occurred_at": "2026-01-01T00:00:00+00:00",
+        "payload": {"details": "hi"},
+    }
+    p.update(over)
+    return p
+
+
+def test_strict_format_maps_identity_fields_to_wire_names():
+    out = EventBuilder.build(_public_params())
+    # the whole point: event_id/parent_event_id -> client_* (what the backend reads)
+    assert out["client_event_id"] == "ev-1"
+    assert out["client_parent_event_id"] == "ev-parent"
+    # the raw public names must not leak through untranslated
+    assert "event_id" not in out
+    assert "parent_event_id" not in out
+    # payload passed through verbatim; base fields preserved
+    assert out["payload"] == {"details": "hi"}
+    assert out["type"] == "generic"
+    assert out["session_id"] == "sess-1"
+    assert out["occurred_at"] == "2026-01-01T00:00:00+00:00"
+
+
+def test_strict_and_non_strict_produce_the_same_identity_mapping():
+    # The divergence between the two paths WAS the bug — they must now agree.
+    strict = EventBuilder.build(_public_params(payload={"details": "hi"}))
+    non_strict = EventBuilder.build({
+        "type": "generic", "event_id": "ev-1", "parent_event_id": "ev-parent",
+        "session_id": "sess-1", "occurred_at": "2026-01-01T00:00:00+00:00", "details": "hi",
+    })
+    for k in ("client_event_id", "client_parent_event_id", "session_id", "type"):
+        assert strict[k] == non_strict[k]
+
+
+def test_strict_format_without_parent_is_fine():
+    out = EventBuilder.build(_public_params(parent_event_id=None))
+    assert out["client_event_id"] == "ev-1"
+    assert out.get("client_parent_event_id") is None  # no-parent, mapped as None
+
+
+def test_strict_format_empty_payload_still_maps_ids():
+    # payload={} is the exact LUC-941 / SE-E4 trigger — still strict (isinstance({}, dict)),
+    # ids still mapped.
+    out = EventBuilder.build(_public_params(payload={}))
+    assert out["client_event_id"] == "ev-1"
+    assert out["client_parent_event_id"] == "ev-parent"
+    assert out["payload"] == {}
+
+
+def test_strict_format_passes_through_duration_tags_metadata():
+    # these base fields must survive the strict path (most likely to silently regress
+    # if _extract_base_params is edited later).
+    out = EventBuilder.build(_public_params(duration=1.5, tags=["a"], metadata={"k": "v"}))
+    assert out["duration"] == 1.5
+    assert out["tags"] == ["a"]
+    assert out["metadata"] == {"k": "v"}


### PR DESCRIPTION
## Bug
`EventBuilder.build`'s strict-format branch (triggered whenever the caller passes a `payload` dict) did `return params` verbatim. But `events.create()`/`acreate()` always build params in the **public** shape (`event_id`/`parent_event_id`), while the backend reads only the **wire** names (`client_event_id`/`client_parent_event_id`, and uses `client_event_id` as the Redis idempotency key). The non-strict path maps these via `_extract_base_params`; the strict path skipped it. So a `payload={...}` caller got:
- a **flat trace** (parent link silently dropped), and
- **no idempotency dedup** (retries duplicated the event).

## Fix
The strict branch now runs the same `_extract_base_params` identity translation as the non-strict path (`event_id` → `client_event_id`, `parent_event_id` → `client_parent_event_id`, plus `session_id`/`occurred_at`/`duration`/`tags`/`metadata`), while keeping the caller's `payload` verbatim — mirroring `_build_generic_event`'s base+type+payload shape.

Note: the strict path now emits only the normalized field set; any extra top-level *sibling* of `payload` is dropped, but the backend ingest view never read those (they were forwarded-and-ignored before), so there's no persisted-data change.

## Verification
- `tests/test_event_builder.py` — 5 unit tests (id mapping, strict==non-strict identity parity, `payload={}` trigger, no-parent, duration/tags/metadata pass-through).
- The SDK-First Parity E2E `SE-E4` (out-of-order parent backfill) now uses the strict `payload={}` path and nests correctly against the live backend (it was a permanently flat trace before).

Files changed:
- `lucidicai/sdk/event_builder.py` — translate identity fields in the strict-format branch.
- `tests/test_event_builder.py` — new unit tests.